### PR TITLE
WIP: add gas fraction phase diagrams and VR plots

### DIFF
--- a/colibre/auto_plotter/dust_mass_function.yml
+++ b/colibre/auto_plotter/dust_mass_function.yml
@@ -3,7 +3,7 @@ dust_mass_function:
   legend_loc: "lower left"
   number_of_bins: 30
   x:
-    quantity: "derived_quantities.total_dust_masses"
+    quantity: "derived_quantities.total_dust_masses_100_kpc"
     units: Solar_Mass
     start: 1e4
     end: 1e10

--- a/colibre/auto_plotter/dust_mass_function.yml
+++ b/colibre/auto_plotter/dust_mass_function.yml
@@ -1,5 +1,5 @@
 dust_mass_function:
-  type: "adaptivemassfunction"
+  type: "massfunction"
   legend_loc: "lower left"
   number_of_bins: 30
   x:
@@ -12,7 +12,9 @@ dust_mass_function:
     start: 1e-6
     end: 0.316 # (1e-0.5)
   metadata:
+    section: Dust Mass Functions
     title: Dust Mass Function
+    caption: 100 kpc aperture Galaxy HI Mass Function, showing all galaxies with a fixed bin-width of 0.2 dex.
   observational_data:
     - filename: GalaxyDustMassFunction/Pozzi2020_z000p100.hdf5
     - filename: GalaxyDustMassFunction/Pozzi2020_z001p800.hdf5

--- a/colibre/auto_plotter/dust_mass_function.yml
+++ b/colibre/auto_plotter/dust_mass_function.yml
@@ -1,0 +1,19 @@
+dust_mass_function:
+  type: "adaptivemassfunction"
+  legend_loc: "lower left"
+  number_of_bins: 30
+  x:
+    quantity: "derived_quantities.total_dust_masses"
+    units: Solar_Mass
+    start: 1e4
+    end: 1e10
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 0.316 # (1e-0.5)
+  metadata:
+    title: Dust Mass Function
+  observational_data:
+    - filename: GalaxyDustMassFunction/Pozzi2020_z000p100.hdf5
+    - filename: GalaxyDustMassFunction/Pozzi2020_z001p800.hdf5
+    - filename: GalaxyDustMassFunction/Beeston2018_z000p000.hdf5

--- a/colibre/auto_plotter/gas_fraction_plots.yml
+++ b/colibre/auto_plotter/gas_fraction_plots.yml
@@ -1,0 +1,183 @@
+h2_frac_func_stellar_mass:
+  type: "scatter"
+  legend_loc: "lower left"
+  selection_mask: "derived_quantities.xcoldgass_sel"
+  comment: r"$10^9 M_{\odot} < M_{\ast} < 10^{11.5} M_{\odot}$"
+  x:
+    quantity: "apertures.mass_star_30_kpc"
+    units: Solar_Mass
+    start: 1e9
+    end: 4e11
+  y:
+    quantity: "derived_quantities.h2_to_stellar_mass"
+    units: "Solar_Mass / Solar_Mass"
+    start: 1e-4
+    end: 100
+  median:
+    plot: true
+    log: true
+    number_of_bins: 9
+    start:
+      value: 1e9
+      units: Solar_Mass
+    end:
+      value: 4e11
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-H2 Fraction
+    section: H_2 Fractions
+  observational_data:
+    - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
+
+h2_frac_func_ssfr:
+  type: "scatter"
+  legend_loc: "upper right"
+  selection_mask: "derived_quantities.xcoldgass_sel"
+  comment: r"$10^9 M_{\odot} < M_{\ast} < 10^{11.5} M_{\odot}$"
+  x:
+    quantity: "derived_quantities.specific_sfr_gas_30_kpc"
+    units: "1 / Gigayear"
+    start: 1e-4
+    end: 1e4
+  y:
+    quantity: "derived_quantities.h2_to_stellar_mass"
+    units: "Solar_Mass / Solar_Mass"
+    start: 1e-4
+    end: 100
+  median:
+    plot: true
+    log: true
+    number_of_bins: 29
+    start:
+      value: 1e-4
+      units: "1 / Gigayear"
+    end:
+      value: 1e4
+      units: "1 / Gigayear"
+  metadata:
+    title: Stellar Mass-H2 Fraction
+    section: H_2 Fractions
+  observational_data:
+    - filename: GalaxyH2Fractions/Saintonge2017_abcissa_sSFR.hdf5
+
+h2_frac_func_stellar_surface_density:
+  type: "scatter"
+  legend_loc: "lower left"
+  selection_mask: "derived_quantities.xcoldgass_sel"
+  comment: r"$10^9 M_{\odot} < M_{\ast} < 10^{11.5} M_{\odot}$"
+  x:
+    quantity: "derived_quantities.mu_star"
+    units: "Solar_Mass / (kpc**2)"
+    start: 1e6
+    end: 1e11
+  y:
+    quantity: "derived_quantities.h2_to_stellar_mass"
+    units: "Solar_Mass / Solar_Mass"
+    start: 1e-4
+    end: 100
+  median:
+    plot: true
+    log: true
+    number_of_bins: 9
+    start:
+      value: 1e5
+      units: "Solar_Mass / (kpc**2)"
+    end:
+      value: 1e11
+      units: "Solar_Mass / (kpc**2)"
+  metadata:
+    title: Stellar Mass Surface Density-H2 Fraction
+    section: H_2 Fractions
+  observational_data:
+    - filename: GalaxyH2Fractions/Saintonge2017_abcissa_mu_star.hdf5
+
+hi_frac_func_stellar_mass:
+  type: "scatter"
+  legend_loc: "lower left"
+  selection_mask: "derived_quantities.xgass_sel"
+  comment: r"$10^9 M_{\odot} < M_{\ast} < 10^{11.5} M_{\odot}$"
+  x:
+    quantity: "apertures.mass_star_30_kpc"
+    units: Solar_Mass
+    start: 1e9
+    end: 4e11
+  y:
+    quantity: "derived_quantities.hi_to_stellar_mass"
+    units: "Solar_Mass / Solar_Mass"
+    start: 1e-4
+    end: 100
+  median:
+    plot: true
+    log: true
+    number_of_bins: 9
+    start:
+      value: 1e9
+      units: Solar_Mass
+    end:
+      value: 4e11
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-HI Fraction
+    section: H_I Fractions
+  observational_data:
+    - filename: GalaxyHIFractions/Catinella2018_abcissa_M_star.hdf5
+
+hi_frac_func_ssfr:
+  type: "scatter"
+  legend_loc: "lower right"
+  selection_mask: "derived_quantities.xgass_sel"
+  x:
+    quantity: "derived_quantities.specific_sfr_gas_30_kpc"
+    units: "1 / Gigayear"
+    start: 1e-4
+    end: 1e4
+  y:
+    quantity: "derived_quantities.hi_to_stellar_mass"
+    units: "Solar_Mass / Solar_Mass"
+    start: 1e-4
+    end: 100
+  median:
+    plot: true
+    log: true
+    number_of_bins: 29
+    start:
+      value: 1e-4
+      units: "1 / Gigayear"
+    end:
+      value: 1e4
+      units: "1 / Gigayear"
+  metadata:
+    title: Stellar Mass-HI Fraction
+    section: H_I Fractions
+  observational_data:
+    - filename: GalaxyHIFractions/Catinella2018_abcissa_sSFR.hdf5
+
+hi_frac_func_stellar_surface_density:
+  type: "scatter"
+  legend_loc: "lower left"
+  selection_mask: "derived_quantities.xgass_sel"
+  x:
+    quantity: "derived_quantities.mu_star"
+    units: "Solar_Mass / (kpc**2)"
+    start: 1e6
+    end: 1e11
+  y:
+    quantity: "derived_quantities.hi_to_stellar_mass"
+    units: "Solar_Mass / Solar_Mass"
+    start: 1e-4
+    end: 100
+  median:
+    plot: true
+    log: true
+    number_of_bins: 9
+    start:
+      value: 1e5
+      units: "Solar_Mass / (kpc**2)"
+    end:
+      value: 1e11
+      units: "Solar_Mass / (kpc**2)"
+  metadata:
+    title: Stellar Mass Surface Density-HI Fraction
+    section: H_I Fractions
+  observational_data:
+    - filename: GalaxyHIFractions/Catinella2018_abcissa_mu_star.hdf5

--- a/colibre/auto_plotter/gas_fraction_plots.yml
+++ b/colibre/auto_plotter/gas_fraction_plots.yml
@@ -26,7 +26,7 @@ h2_frac_func_stellar_mass:
       units: Solar_Mass
   metadata:
     title: Stellar Mass-H$_2$ Fraction
-    section: H_2 Fractions
+    section: Hydrogen Species H_2 Fractions
     caption: Galaxy H_$2$ fraction as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
@@ -59,7 +59,7 @@ h2_frac_func_ssfr:
       units: "1 / Gigayear"
   metadata:
     title: sSFR-H$_2$ Fraction
-    section: H_2 Fractions
+    section: Hydrogen Species H_2 Fractions
     caption: Galaxy H_$2$ fraction as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_sSFR.hdf5
@@ -92,7 +92,7 @@ h2_frac_func_stellar_surface_density:
       units: "Solar_Mass / (kpc**2)"
   metadata:
     title: Stellar Mass Surface Density-H$_2$ Fraction
-    section: H_2 Fractions
+    section: Hydrogen Species H_2 Fractions
     caption: Galaxy H_$2$ fraction as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_mu_star.hdf5
@@ -125,7 +125,7 @@ hi_frac_func_stellar_mass:
       units: Solar_Mass
   metadata:
     title: Stellar Mass-HI Fraction
-    section: HI Fractions
+    section: Hydrogen Species HI Fractions
     caption: Galaxy HI fraction as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_M_star.hdf5
@@ -157,7 +157,7 @@ hi_frac_func_ssfr:
       units: "1 / Gigayear"
   metadata:
     title: sSFR-HI Fraction
-    section: HI Fractions
+    section: Hydrogen Species HI Fractions
     caption: Galaxy HI fraction as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_sSFR.hdf5
@@ -189,7 +189,7 @@ hi_frac_func_stellar_surface_density:
       units: "Solar_Mass / (kpc**2)"
   metadata:
     title: Stellar Mass Surface Density-HI Fraction
-    section: HI Fractions
+    section: Hydrogen Species HI Fractions
     caption: Galaxy HI fraction as a function of stellar mass surface density in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_mu_star.hdf5

--- a/colibre/auto_plotter/gas_fraction_plots.yml
+++ b/colibre/auto_plotter/gas_fraction_plots.yml
@@ -1,7 +1,7 @@
 h2_frac_func_stellar_mass:
   type: "scatter"
   legend_loc: "lower left"
-  selection_mask: "derived_quantities.xcoldgass_sel"
+  selection_mask: "derived_quantities.xcoldgass_galaxy_selection"
   comment: r"$10^9 M_{\odot} < M_{\ast} < 10^{11.5} M_{\odot}$"
   x:
     quantity: "apertures.mass_star_100_kpc"
@@ -34,7 +34,7 @@ h2_frac_func_stellar_mass:
 h2_frac_func_ssfr:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.xcoldgass_sel"
+  selection_mask: "derived_quantities.xcoldgass_galaxy_selection"
   comment: r"$10^9 M_{\odot} < M_{\ast} < 10^{11.5} M_{\odot}$"
   x:
     quantity: "derived_quantities.specific_sfr_gas_100_kpc"
@@ -67,7 +67,7 @@ h2_frac_func_ssfr:
 h2_frac_func_stellar_surface_density:
   type: "scatter"
   legend_loc: "lower left"
-  selection_mask: "derived_quantities.xcoldgass_sel"
+  selection_mask: "derived_quantities.xcoldgass_galaxy_selection"
   comment: r"$10^9 M_{\odot} < M_{\ast} < 10^{11.5} M_{\odot}$"
   x:
     quantity: "derived_quantities.mu_star"
@@ -92,7 +92,7 @@ h2_frac_func_stellar_surface_density:
       units: "Solar_Mass / (kpc**2)"
   metadata:
     title: Stellar Mass Surface Density-H$_2$ Fraction
-    section: H_2 Fraction
+    section: H_2 Fractions
     caption: Galaxy H_$2$ fraction as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_mu_star.hdf5
@@ -100,7 +100,7 @@ h2_frac_func_stellar_surface_density:
 hi_frac_func_stellar_mass:
   type: "scatter"
   legend_loc: "lower left"
-  selection_mask: "derived_quantities.xgass_sel"
+  selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: r"$10^9 M_{\odot} < M_{\ast} < 10^{11.5} M_{\odot}$"
   x:
     quantity: "apertures.mass_star_100_kpc"
@@ -133,7 +133,7 @@ hi_frac_func_stellar_mass:
 hi_frac_func_ssfr:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.xgass_sel"
+  selection_mask: "derived_quantities.xgass_galaxy_selection"
   x:
     quantity: "derived_quantities.specific_sfr_gas_100_kpc"
     units: "1 / Gigayear"
@@ -165,7 +165,7 @@ hi_frac_func_ssfr:
 hi_frac_func_stellar_surface_density:
   type: "scatter"
   legend_loc: "lower left"
-  selection_mask: "derived_quantities.xgass_sel"
+  selection_mask: "derived_quantities.xgass_galaxy_selection"
   x:
     quantity: "derived_quantities.mu_star"
     units: "Solar_Mass / (kpc**2)"

--- a/colibre/auto_plotter/gas_fraction_plots.yml
+++ b/colibre/auto_plotter/gas_fraction_plots.yml
@@ -4,10 +4,10 @@ h2_frac_func_stellar_mass:
   selection_mask: "derived_quantities.xcoldgass_sel"
   comment: r"$10^9 M_{\odot} < M_{\ast} < 10^{11.5} M_{\odot}$"
   x:
-    quantity: "apertures.mass_star_30_kpc"
+    quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 4e11
+    end: 1e12
   y:
     quantity: "derived_quantities.h2_to_stellar_mass"
     units: "Solar_Mass / Solar_Mass"
@@ -15,17 +15,19 @@ h2_frac_func_stellar_mass:
     end: 100
   median:
     plot: true
+    adaptive: true
     log: true
-    number_of_bins: 9
+    number_of_bins: 15
     start:
       value: 1e9
       units: Solar_Mass
     end:
-      value: 4e11
+      value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-H2 Fraction
+    title: Stellar Mass-H$_2$ Fraction
     section: H_2 Fractions
+    caption: Galaxy H_$2$ fraction as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
 
@@ -35,7 +37,7 @@ h2_frac_func_ssfr:
   selection_mask: "derived_quantities.xcoldgass_sel"
   comment: r"$10^9 M_{\odot} < M_{\ast} < 10^{11.5} M_{\odot}$"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_30_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
     units: "1 / Gigayear"
     start: 1e-4
     end: 1e4
@@ -46,8 +48,9 @@ h2_frac_func_ssfr:
     end: 100
   median:
     plot: true
+    adaptive: true
     log: true
-    number_of_bins: 29
+    number_of_bins: 40
     start:
       value: 1e-4
       units: "1 / Gigayear"
@@ -55,8 +58,9 @@ h2_frac_func_ssfr:
       value: 1e4
       units: "1 / Gigayear"
   metadata:
-    title: Stellar Mass-H2 Fraction
+    title: sSFR-H$_2$ Fraction
     section: H_2 Fractions
+    caption: Galaxy H_$2$ fraction as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_sSFR.hdf5
 
@@ -77,8 +81,9 @@ h2_frac_func_stellar_surface_density:
     end: 100
   median:
     plot: true
+    adaptive: true
     log: true
-    number_of_bins: 9
+    number_of_bins: 25
     start:
       value: 1e5
       units: "Solar_Mass / (kpc**2)"
@@ -86,8 +91,9 @@ h2_frac_func_stellar_surface_density:
       value: 1e11
       units: "Solar_Mass / (kpc**2)"
   metadata:
-    title: Stellar Mass Surface Density-H2 Fraction
-    section: H_2 Fractions
+    title: Stellar Mass Surface Density-H$_2$ Fraction
+    section: H_2 Fraction
+    caption: Galaxy H_$2$ fraction as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_mu_star.hdf5
 
@@ -97,10 +103,10 @@ hi_frac_func_stellar_mass:
   selection_mask: "derived_quantities.xgass_sel"
   comment: r"$10^9 M_{\odot} < M_{\ast} < 10^{11.5} M_{\odot}$"
   x:
-    quantity: "apertures.mass_star_30_kpc"
+    quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 4e11
+    end: 1e12
   y:
     quantity: "derived_quantities.hi_to_stellar_mass"
     units: "Solar_Mass / Solar_Mass"
@@ -108,17 +114,19 @@ hi_frac_func_stellar_mass:
     end: 100
   median:
     plot: true
+    adaptive: true
     log: true
-    number_of_bins: 9
+    number_of_bins: 15
     start:
       value: 1e9
       units: Solar_Mass
     end:
-      value: 4e11
+      value: 1e12
       units: Solar_Mass
   metadata:
     title: Stellar Mass-HI Fraction
-    section: H_I Fractions
+    section: HI Fractions
+    caption: Galaxy HI fraction as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_M_star.hdf5
 
@@ -127,7 +135,7 @@ hi_frac_func_ssfr:
   legend_loc: "lower right"
   selection_mask: "derived_quantities.xgass_sel"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_30_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
     units: "1 / Gigayear"
     start: 1e-4
     end: 1e4
@@ -138,8 +146,9 @@ hi_frac_func_ssfr:
     end: 100
   median:
     plot: true
+    adaptive: true
     log: true
-    number_of_bins: 29
+    number_of_bins: 40
     start:
       value: 1e-4
       units: "1 / Gigayear"
@@ -147,8 +156,9 @@ hi_frac_func_ssfr:
       value: 1e4
       units: "1 / Gigayear"
   metadata:
-    title: Stellar Mass-HI Fraction
-    section: H_I Fractions
+    title: sSFR-HI Fraction
+    section: HI Fractions
+    caption: Galaxy HI fraction as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -168,8 +178,9 @@ hi_frac_func_stellar_surface_density:
     end: 100
   median:
     plot: true
+    adaptive: true
     log: true
-    number_of_bins: 9
+    number_of_bins: 25
     start:
       value: 1e5
       units: "Solar_Mass / (kpc**2)"
@@ -178,6 +189,7 @@ hi_frac_func_stellar_surface_density:
       units: "Solar_Mass / (kpc**2)"
   metadata:
     title: Stellar Mass Surface Density-HI Fraction
-    section: H_I Fractions
+    section: HI Fractions
+    caption: Galaxy HI fraction as a function of stellar mass surface density in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_mu_star.hdf5

--- a/colibre/auto_plotter/gas_fraction_plots.yml
+++ b/colibre/auto_plotter/gas_fraction_plots.yml
@@ -9,7 +9,7 @@ h2_frac_func_stellar_mass:
     start: 1e9
     end: 1e12
   y:
-    quantity: "derived_quantities.h2_to_stellar_mass"
+    quantity: "derived_quantities.h2_to_stellar_mass_100_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -42,7 +42,7 @@ h2_frac_func_ssfr:
     start: 1e-4
     end: 1e4
   y:
-    quantity: "derived_quantities.h2_to_stellar_mass"
+    quantity: "derived_quantities.h2_to_stellar_mass_100_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -70,12 +70,12 @@ h2_frac_func_stellar_surface_density:
   selection_mask: "derived_quantities.xcoldgass_galaxy_selection"
   comment: r"$10^9 M_{\odot} < M_{\ast} < 10^{11.5} M_{\odot}$"
   x:
-    quantity: "derived_quantities.mu_star"
+    quantity: "derived_quantities.mu_star_100_kpc"
     units: "Solar_Mass / (kpc**2)"
     start: 1e6
     end: 1e11
   y:
-    quantity: "derived_quantities.h2_to_stellar_mass"
+    quantity: "derived_quantities.h2_to_stellar_mass_100_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -108,7 +108,7 @@ hi_frac_func_stellar_mass:
     start: 1e9
     end: 1e12
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass"
+    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -140,7 +140,7 @@ hi_frac_func_ssfr:
     start: 1e-4
     end: 1e4
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass"
+    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -167,12 +167,12 @@ hi_frac_func_stellar_surface_density:
   legend_loc: "lower left"
   selection_mask: "derived_quantities.xgass_galaxy_selection"
   x:
-    quantity: "derived_quantities.mu_star"
+    quantity: "derived_quantities.mu_star_100_kpc"
     units: "Solar_Mass / (kpc**2)"
     start: 1e6
     end: 1e11
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass"
+    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100

--- a/colibre/auto_plotter/gas_mass_function.yml
+++ b/colibre/auto_plotter/gas_mass_function.yml
@@ -3,7 +3,7 @@ hi_mass_function:
   legend_loc: "lower left"
   number_of_bins: 30
   x:
-    quantity: "derived_quantities.neutral_hydrogen_mass"
+    quantity: "derived_quantities.neutral_hydrogen_mass_100_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
@@ -23,7 +23,7 @@ h2_mass_function:
   legend_loc: "lower left"
   number_of_bins: 30
   x:
-    quantity: "derived_quantities.molecular_hydrogen_mass"
+    quantity: "derived_quantities.molecular_hydrogen_mass_100_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12

--- a/colibre/auto_plotter/gas_mass_function.yml
+++ b/colibre/auto_plotter/gas_mass_function.yml
@@ -1,5 +1,5 @@
 hi_mass_function:
-  type: "adaptivemassfunction"
+  type: "massfunction"
   legend_loc: "lower left"
   number_of_bins: 30
   x:
@@ -19,7 +19,7 @@ hi_mass_function:
     - filename: GalaxyHIMassFunction/Jones2018.hdf5
 
 h2_mass_function:
-  type: "adaptivemassfunction"
+  type: "massfunction"
   legend_loc: "lower left"
   number_of_bins: 30
   x:

--- a/colibre/auto_plotter/gas_mass_function.yml
+++ b/colibre/auto_plotter/gas_mass_function.yml
@@ -1,0 +1,37 @@
+hi_mass_function:
+  type: "massfunction"
+  legend_loc: "lower left"
+  number_of_bins: 25
+  x:
+    quantity: "derived_quantities.neutral_hydrogen_masses"
+    units: Solar_Mass
+    start: 1e6
+    end: 4e11
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 1.316 # (1e-0.5)
+  metadata:
+    title: HI Mass Function 
+    section: Hydrogen Species Mass Functions
+  observational_data:   
+    - filename: GalaxyHIMassFunction/Jones2018.hdf5
+
+h2_mass_function:
+  type: "massfunction"
+  legend_loc: "lower left"
+  number_of_bins: 25
+  x:
+    quantity: "derived_quantities.molecular_hydrogen_masses"
+    units: Solar_Mass
+    start: 1e6
+    end: 4e11
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 1.316 # (1e-0.5)
+  metadata:
+    title: H2 Mass Function
+    section: Hydrogen Species Mass Functions
+  observational_data:
+    - filename: GalaxyH2MassFunction/Fletcher2020.hdf5

--- a/colibre/auto_plotter/gas_mass_function.yml
+++ b/colibre/auto_plotter/gas_mass_function.yml
@@ -1,12 +1,12 @@
 hi_mass_function:
-  type: "massfunction"
+  type: "adaptivemassfunction"
   legend_loc: "lower left"
-  number_of_bins: 25
+  number_of_bins: 30
   x:
-    quantity: "derived_quantities.neutral_hydrogen_masses"
+    quantity: "derived_quantities.neutral_hydrogen_mass"
     units: Solar_Mass
     start: 1e6
-    end: 4e11
+    end: 1e12
   y:
     units: 1/Mpc**3
     start: 1e-6
@@ -14,18 +14,19 @@ hi_mass_function:
   metadata:
     title: HI Mass Function 
     section: Hydrogen Species Mass Functions
+    caption: 100 kpc aperture Galaxy HI Mass Function, showing all galaxies with a fixed bin-width of 0.2 dex.
   observational_data:   
     - filename: GalaxyHIMassFunction/Jones2018.hdf5
 
 h2_mass_function:
-  type: "massfunction"
+  type: "adaptivemassfunction"
   legend_loc: "lower left"
-  number_of_bins: 25
+  number_of_bins: 30
   x:
-    quantity: "derived_quantities.molecular_hydrogen_masses"
+    quantity: "derived_quantities.molecular_hydrogen_mass"
     units: Solar_Mass
     start: 1e6
-    end: 4e11
+    end: 1e12
   y:
     units: 1/Mpc**3
     start: 1e-6
@@ -33,5 +34,6 @@ h2_mass_function:
   metadata:
     title: H2 Mass Function
     section: Hydrogen Species Mass Functions
+    caption: 100 kpc aperture Galaxy H_$2$ Mass Function, showing all galaxies with a fixed bin-width of 0.2 dex.
   observational_data:
     - filename: GalaxyH2MassFunction/Fletcher2020.hdf5

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -17,7 +17,7 @@ matplotlib_stylesheet: mnras.mplstyle
 
 # Jinja2 template that gets fed the swiftsimio metadata
 # object for you to describe the run with.
-description_template: description_mod.html
+description_template: description.html
 
 # Location and description of additional figures
 scripts:

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -17,7 +17,7 @@ matplotlib_stylesheet: mnras.mplstyle
 
 # Jinja2 template that gets fed the swiftsimio metadata
 # object for you to describe the run with.
-description_template: description.html
+description_template: description_mod.html
 
 # Location and description of additional figures
 scripts:
@@ -81,4 +81,27 @@ scripts:
     title: Number of steps vs. cosmic time
     section: Run Performance
     output_file: simulation_time_number_of_steps.png
- 
+  - filename: scripts/density_temperature_species.py
+    caption: Density-temperature diagram shaded by H2 mass fraction.
+    output_file: subgrid_density_temperature_H2.png
+    section: Hydrogen Phase Density-Temperature
+    title: H2
+    additional_arguments:
+      hydrogen_species: H2
+      quantity_type: subgrid
+  - filename: scripts/density_temperature_species.py
+    caption: Density-temperature diagram shaded by HI mass fraction.
+    output_file: subgrid_density_temperature_HI.png
+    section: Hydrogen Phase Density-Temperature
+    title: HI
+    additional_arguments:
+      hydrogen_species: HI
+      quantity_type: subgrid
+  - filename: scripts/density_temperature_species.py
+    caption: Density-temperature diagram shaded by HII mass fraction.
+    output_file: subgrid_density_temperature_HII.png
+    section: Hydrogen Phase Density-Temperature
+    title: HII
+    additional_arguments:
+      hydrogen_species: HII
+      quantity_type: subgrid

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -142,6 +142,10 @@ gal_area = (
 )
 mstar_100 = catalogue.projected_apertures.projected_1_mass_star_100_kpc
 
+# Selection functions for the xGASS and xCOLDGASS surveys, used for the H species fraction comparison.
+# Note these are identical mass selections, but are separated to keep survey selections explicit
+# and to allow more detailed selection criteria to be added for each.
+
 self.xgass_galaxy_selection = np.logical_and(
     catalogue.apertures.mass_star_100_kpc > unyt.unyt_quantity(10 ** 9, "Solar_Mass"),
     catalogue.apertures.mass_star_100_kpc

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -136,7 +136,7 @@ total_dust_mass.name = "$M_{\\rm dust}$ not found"
 setattr(self, f"total_dust_masses", total_dust_mass)
 
 # species fraction properties
-gas_mass = catalogue.masses.m_gas
+gas_mass = catalogue.apertures.mass_gas_100_kpc
 gal_area = (
     2 * np.pi * catalogue.projected_apertures.projected_1_rhalfmass_star_100_kpc ** 2
 )
@@ -161,38 +161,36 @@ self.xcoldgass_galaxy_selection = np.logical_and(
 self.mu_star = mstar_100 / gal_area
 self.mu_star.name = "$\\pi R_{*, 100 {\\rm kpc}}^2 / M_{*, 100 {\\rm kpc}}$"
 
-self.neutral_hydrogen_mass = catalogue.masses.m_star * 0.0
-self.molecular_hydrogen_mass = catalogue.masses.m_star * 0.0
-self.h2_to_stellar_mass = catalogue.apertures.zmet_star_100_kpc * 0.0
-self.hi_to_stellar_mass = catalogue.apertures.zmet_star_100_kpc * 0.0
-
-self.neutral_hydrogen_mass.name = "HI Mass (100 kpc)"
-self.hi_to_stellar_mass.name = "HI to Stellar Mass Fraction (100 kpc)"
-self.molecular_hydrogen_mass.name = "H$_2$ Mass (100 kpc)"
-self.h2_to_stellar_mass.name = "H$_2$ to Stellar Mass Fraction (100 kpc)"
-
 try:
-    H_frac = catalogue.element_mass_fractions.element_0
-    # NB: this is designed for CHIMES species arrays
-    try:
-        self.neutral_hydrogen_mass = (
-            gas_mass * H_frac * catalogue.species_fractions.species_1
-        )
-        self.hi_to_stellar_mass = self.neutral_hydrogen_mass / catalogue.masses.m_star
-    except AttributeError:
-        self.neutral_hydrogen_mass.name += " not found (no species field)"
-        self.hi_to_stellar_mass.name += " not calculable (no species field)"
-    try:
-        self.molecular_hydrogen_mass = (
-            gas_mass * H_frac * catalogue.species_fractions.species_7
-        )
-        self.h2_to_stellar_mass = self.molecular_hydrogen_mass / catalogue.masses.m_star
-    except AttributeError:
-        self.molecular_hydrogen_mass.name += " not found (no species field)"
-        self.h2_to_stellar_mass.name += " not calculable (no species field)"
+   H_frac = catalogue.element_mass_fractions.element_0
+   hydrogen_frac_error = ""
+except:
+   H_frac = 0.0
+   hydrogen_frac_error = "(no H abundance)"
+   
+   
+# Test for CHIMES arrays
+try:
+   species_1 = catalogue.species_fractions.species_1
+   species_7 = catalogue.species_fractions.species_7
+   species_frac_error = ""
+except:
+   species_1 = 0.0
+   species_7 = 0.0
+   species_frac_error = "(no species field)"
+   
+total_error = f" {species_frac_error}{hydrogen_frac_error}"
 
-except AttributeError:
-    self.molecular_hydrogen_mass.name += " not found (no H abundance)"
-    self.neutral_hydrogen_mass.name += " not found (no H abundance)"
-    self.hi_to_stellar_mass.name += " not calculable (no H abundance)"
-    self.h2_to_stellar_mass.name += " not calculable (no H abundance)"
+self.neutral_hydrogen_mass = gas_mass * H_frac * species_1
+self.hi_mass_to_stellar_mass_100_kpc = (
+   self.neutral_hydrogen_mass / catalogue.apertures.mass_star_100_kpc
+)
+self.molecular_hydrogen_mass = gas_mass * H_frac * species_7
+self.h2_mass_to_stellar_mass_100_kpc = (
+   self.molecular_hydrogen_mass / catalogue.apertures.mass_star_100_kpc
+)
+
+self.neutral_hydrogen_mass.name = f"HI Mass (100 kpc){total_error}"
+self.hi_to_stellar_mass.name = f"HI to Stellar Mass Fraction (100 kpc){total_error}"
+self.molecular_hydrogen_mass.name = f"H$_2$ Mass (100 kpc){total_error}"
+self.h2_to_stellar_mass.name = f"H$_2$ to Stellar Mass Fraction (100 kpc){total_error}"

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -133,7 +133,7 @@ total_dust_mass = total_dust_fraction * catalogue.masses.m_star
 total_dust_mass.name = "$M_{\\rm dust}$ not found"
 
 
-setattr(self, f"total_dust_masses", total_dust_mass)
+setattr(self, f"total_dust_masses_100_kpc", total_dust_mass)
 
 # species fraction properties
 gas_mass = catalogue.apertures.mass_gas_100_kpc
@@ -158,8 +158,8 @@ self.xcoldgass_galaxy_selection = np.logical_and(
     < unyt.unyt_quantity(10 ** (11.5), "Solar_Mass"),
 )
 
-self.mu_star = mstar_100 / gal_area
-self.mu_star.name = "$\\pi R_{*, 100 {\\rm kpc}}^2 / M_{*, 100 {\\rm kpc}}$"
+self.mu_star_100_kpc = mstar_100 / gal_area
+self.mu_star_100_kpc.name = "$\\pi R_{*, 100 {\\rm kpc}}^2 / M_{*, 100 {\\rm kpc}}$"
 
 try:
    H_frac = catalogue.element_mass_fractions.element_0
@@ -181,16 +181,16 @@ except:
    
 total_error = f" {species_frac_error}{hydrogen_frac_error}"
 
-self.neutral_hydrogen_mass = gas_mass * H_frac * species_1
-self.hi_mass_to_stellar_mass_100_kpc = (
-   self.neutral_hydrogen_mass / catalogue.apertures.mass_star_100_kpc
+self.neutral_hydrogen_mass_100_kpc = gas_mass * H_frac * species_1
+self.hi_to_stellar_mass_100_kpc = (
+   self.neutral_hydrogen_mass_100_kpc / catalogue.apertures.mass_star_100_kpc
 )
-self.molecular_hydrogen_mass = gas_mass * H_frac * species_7
-self.h2_mass_to_stellar_mass_100_kpc = (
-   self.molecular_hydrogen_mass / catalogue.apertures.mass_star_100_kpc
+self.molecular_hydrogen_mass_100_kpc = gas_mass * H_frac * species_7
+self.h2_to_stellar_mass_100_kpc = (
+   self.molecular_hydrogen_mass_100_kpc / catalogue.apertures.mass_star_100_kpc
 )
 
-self.neutral_hydrogen_mass.name = f"HI Mass (100 kpc){total_error}"
-self.hi_to_stellar_mass.name = f"HI to Stellar Mass Fraction (100 kpc){total_error}"
-self.molecular_hydrogen_mass.name = f"H$_2$ Mass (100 kpc){total_error}"
-self.h2_to_stellar_mass.name = f"H$_2$ to Stellar Mass Fraction (100 kpc){total_error}"
+self.neutral_hydrogen_mass_100_kpc.name = f"HI Mass (100 kpc){total_error}"
+self.hi_to_stellar_mass_100_kpc.name = f"HI to Stellar Mass Fraction (100 kpc){total_error}"
+self.molecular_hydrogen_mass_100_kpc.name = f"H$_2$ Mass (100 kpc){total_error}"
+self.h2_to_stellar_mass_100_kpc.name = f"H$_2$ to Stellar Mass Fraction (100 kpc){total_error}"

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -120,14 +120,6 @@ for aperture_size in aperture_sizes:
     setattr(self, f"stellar_mass_to_halo_mass_{aperture_size}_kpc", smhm)
 
 # if present iterate through available dust types
-
-
-# print(getattr(catalogue.dust_mass_fractions, 'dust_0'))
-
-# print([getattr(catalogue.dust_mass_fractions, sub_path) for sub_path in dir(catalogue.dust_mass_fractions) if sub_path.startswith('dust_')])
-
-print("done")
-
 try:
     dust_fields = []
     for sub_path in dir(catalogue.dust_mass_fractions):

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -118,3 +118,44 @@ for aperture_size in aperture_sizes:
     smhm.name = name
 
     setattr(self, f"stellar_mass_to_halo_mass_{aperture_size}_kpc", smhm)
+
+# iterate through available dust types
+dust_idx = 0
+total_dust_fraction = metal_mass_fraction_gas*0.
+while 1:
+    if not hasattr(catalogue.dust_mass_fractions, f"dust_{dust_idx}"):
+        break
+    total_dust_fraction += getattr(catalogue.dust_mass_fractions, f"dust_{dust_idx}")
+    dust_idx += 1
+
+
+total_dust_mass = total_dust_fraction * catalogue.apertures.mass_gas_30_kpc
+total_dust_mass.name = "$M_{\\rm dust}$"
+
+setattr(self, f"total_dust_masses", total_dust_mass)
+
+#species fraction properties
+gas_mass = catalogue.masses.m_gas
+H_frac = catalogue.element_mass_fractions.element_0
+gal_area = np.pi * catalogue.projected_apertures.projected_2_rhalfmass_star_30_kpc**2
+mstar_30 = catalogue.projected_apertures.projected_2_mass_star_30_kpc.to('Msun')
+
+# NB: this is designed for CHIMES species arrays
+self.neutral_hydrogen_masses = gas_mass * H_frac * catalogue.species_fractions.species_1
+self.ionized_hydrogen_masses = gas_mass * H_frac * catalogue.species_fractions.species_2
+self.molecular_hydrogen_masses =  gas_mass * H_frac * catalogue.species_fractions.species_7
+self.hi_to_stellar_mass = self.neutral_hydrogen_masses / catalogue.masses.m_star
+self.h2_to_stellar_mass = self.molecular_hydrogen_masses / catalogue.masses.m_star
+self.mu_star = mstar_30 / gal_area
+
+self.xgass_sel = (mstar_30 > (1e9 * mstar_30.units)) * (mstar_30 < (pow(10,11.5) * mstar_30.units))
+self.xcoldgass_sel = (mstar_30 > (1e9 * mstar_30.units)) * (mstar_30 < (pow(10,11.5) * mstar_30.units))
+
+self.neutral_hydrogen_masses.name = "HI Mass"
+self.molecular_hydrogen_masses.name = "H2 Mass"
+self.ionized_hydrogen_masses.name = "HII Mass"
+
+self.hi_to_stellar_mass.name = 'HI to Stellar Mass Fraction'
+self.h2_to_stellar_mass.name = 'H2 to Stellar Mass Fraction'
+
+self.mu_star.name = f"Stellar Surface Density"

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -120,18 +120,26 @@ for aperture_size in aperture_sizes:
     setattr(self, f"stellar_mass_to_halo_mass_{aperture_size}_kpc", smhm)
 
 # if present iterate through available dust types
+
+
+# print(getattr(catalogue.dust_mass_fractions, 'dust_0'))
+
+# print([getattr(catalogue.dust_mass_fractions, sub_path) for sub_path in dir(catalogue.dust_mass_fractions) if sub_path.startswith('dust_')])
+
+print("done")
+
 try:
-    total_dust_fraction = sum(
-        [
-            getattr(catalogue.dust_mass_fractions, sub_path)
-            for sub_path in catalogue.dust_mass_fractions.valid_sub_paths
-        ]
-    )
+    dust_fields = []
+    for sub_path in dir(catalogue.dust_mass_fractions):
+        if sub_path.startswith("dust_"):
+            dust_fields.append(getattr(catalogue.dust_mass_fractions, sub_path))
+    total_dust_fraction = sum(dust_fields)
 except AttributeError:
     total_dust_fraction = np.zeros(stellar_mass.size)
 
 total_dust_mass = total_dust_fraction * catalogue.masses.m_star
 total_dust_mass.name = "$M_{\\rm dust}$ not found"
+
 
 setattr(self, f"total_dust_masses", total_dust_mass)
 

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -170,8 +170,8 @@ self.molecular_hydrogen_mass = catalogue.masses.m_star * 0.0
 self.h2_to_stellar_mass = catalogue.apertures.zmet_star_100_kpc * 0.0
 self.hi_to_stellar_mass = catalogue.apertures.zmet_star_100_kpc * 0.0
 
-self.molecular_hydrogen_mass.name = "HI Mass (100 kpc)"
-self.h2_to_stellar_mass.name = "HI to Stellar Mass Fraction (100 kpc)"
+self.neutral_hydrogen_mass.name = "HI Mass (100 kpc)"
+self.hi_to_stellar_mass.name = "HI to Stellar Mass Fraction (100 kpc)"
 self.molecular_hydrogen_mass.name = "H$_2$ Mass (100 kpc)"
 self.h2_to_stellar_mass.name = "H$_2$ to Stellar Mass Fraction (100 kpc)"
 
@@ -197,6 +197,6 @@ try:
 
 except AttributeError:
     self.molecular_hydrogen_mass.name += " not found (no H abundance)"
-    self.neutrsal_hydrogen_mass.name += " not found (no H abundance)"
+    self.neutral_hydrogen_mass.name += " not found (no H abundance)"
     self.hi_to_stellar_mass.name += " not calculable (no H abundance)"
     self.h2_to_stellar_mass.name += " not calculable (no H abundance)"

--- a/colibre/scripts/density_temperature_species.py
+++ b/colibre/scripts/density_temperature_species.py
@@ -1,0 +1,191 @@
+"""
+Makes a rho-T plot. Uses the swiftsimio library.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+
+from unyt import mh, cm
+from matplotlib.colors import LogNorm, ListedColormap, BoundaryNorm
+from matplotlib.animation import FuncAnimation
+from matplotlib.cm import get_cmap
+
+# Set the limits of the figure.
+density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+temperature_bounds = [10 ** (0), 10 ** (9.5)]  # in K
+dustfracs_bounds = [-2, 0]  # In metal mass fraction
+min_dustfracs = 10**dustfracs_bounds[0]
+bins = 256
+
+
+def get_data(filename, prefix_rho, prefix_T, species):
+    """
+    Grabs the data (T in Kelvin and density in mh / cm^3).
+    """
+
+    data = load(filename)
+
+    number_density = (getattr(data.gas, f"{prefix_rho}densities").to_physical() / mh).to(cm ** -3)
+    temperature = getattr(data.gas, f"{prefix_T}temperatures").to_physical().to("K")
+    masses = data.gas.masses.to_physical().to("Msun")
+    
+    sfracs = getattr(data.gas.species_fractions, species)
+    if species == 'H2':
+        sfracs *= 2.
+    sfracs[sfracs < min_dustfracs] = min_dustfracs
+
+    return number_density.value, temperature.value, sfracs.value, masses.value
+
+
+def make_hist(filename, density_bounds, temperature_bounds, bins, prefix_rho='', prefix_T='', species='HI'):
+    """
+    Makes the histogram for filename with bounds as lower, higher
+    for the bins and "bins" the number of bins along each dimension.
+
+    Also returns the edges for pcolormesh to use.
+    """
+
+    density_bins = np.logspace(
+        np.log10(density_bounds[0]), np.log10(density_bounds[1]), bins
+    )
+    temperature_bins = np.logspace(
+        np.log10(temperature_bounds[0]), np.log10(temperature_bounds[1]), bins
+    )
+    
+    nH, T, D, Mg = get_data(filename, prefix_rho, prefix_T,species)
+
+    H, density_edges, temperature_edges = np.histogram2d(
+        nH, T, bins=[density_bins, temperature_bins], weights=D*Mg
+    )
+    H_norm, _, _ = np.histogram2d(nH, T, bins=[density_bins, temperature_bins], weights=Mg)
+
+    # Avoid div/0
+    mask = H_norm == 0.0
+    H[mask] = None
+    H_norm[mask] = 1.0
+
+    return np.ma.array((H / H_norm).T, mask=mask.T), density_edges, temperature_edges
+
+
+def setup_axes(number_of_simulations: int, prop_type='hydro'):
+    """
+    Creates the figure and axis object. Creates a grid of a x b subplots
+    that add up to at least number_of_simulations.
+    """
+
+    sqrt_number_of_simulations = np.sqrt(number_of_simulations)
+    horizontal_number = int(np.ceil(sqrt_number_of_simulations))
+    # Ensure >= number_of_simulations plots in a grid
+    vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
+
+    fig, ax = plt.subplots(
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+    )
+
+    ax = np.array([ax]) if number_of_simulations == 1 else ax
+
+    if horizontal_number * vertical_number > number_of_simulations:
+        for axis in ax.flat[number_of_simulations:]:
+            axis.axis("off")
+
+    # Set all valid on bottom row to have the horizontal axis label.
+    for axis in np.atleast_2d(ax)[:][-1]:
+        if prop_type == 'hydro':
+            axis.set_xlabel("Density [$n_H$ cm$^{-3}$]")
+        elif prop_type == 'subgrid':
+            axis.set_xlabel("Subgrid Physical Density [$n_H$ cm$^{-3}$]")
+        else:
+            raise Exception("Unrecognised property type.")
+    for axis in np.atleast_2d(ax).T[:][0]:
+        if prop_type == 'hydro':
+            axis.set_ylabel("Temperature [K]")
+        elif prop_type == 'subgrid':
+            axis.set_ylabel("Subgrid Temperature [K]")
+
+    ax.flat[0].loglog()
+
+    return fig, ax
+
+
+def make_single_image(
+    filenames,
+    names,
+    number_of_simulations,
+    density_bounds,
+    temperature_bounds,
+    bins,
+    output_path,
+    prop_type,
+    species,
+):
+    """
+    Makes a single plot of rho-T
+    """
+
+    if prop_type == 'subgrid':
+        prefix_rho = 'subgrid_physical_'
+        prefix_T = 'subgrid_'
+    else:
+        prefix_rho = ''
+        prefix_T = ''
+
+    fig, ax = setup_axes(number_of_simulations=number_of_simulations, prop_type=prop_type)
+
+    hists = []
+
+    for filename in filenames:
+        hist, d, T = make_hist(filename, density_bounds, temperature_bounds, bins, prefix_rho, prefix_T, species)
+        hists.append(hist)
+
+    smap = get_cmap('cividis')
+    ncols = 10
+    collist = []
+    for i in range(ncols):
+        collist.append(smap(i/float(ncols-1)))
+        
+    cmap = ListedColormap(collist)
+
+    norm = BoundaryNorm(np.linspace(dustfracs_bounds[0], dustfracs_bounds[1], ncols+1), ncols)
+
+    vmax = np.max([np.max(hist) for hist in hists])
+
+    for hist, name, axis in zip(hists, names, ax.flat):
+        mappable = axis.pcolormesh(d, T, np.log10(hist), cmap=cmap, norm=norm)
+        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+
+    fig.colorbar(mappable, ax=ax.ravel().tolist(), label=f"{species} Mass Fraction")
+    fig.savefig(f"{output_path}/{prefix_T}density_temperature_{species}.png")
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(
+        description="Basic density-temperature figure.",
+        additional_arguments={"quantity_type": "hydro",
+                              "hydrogen_species": "HI"})
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+    
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        number_of_simulations=arguments.number_of_inputs,
+        density_bounds=density_bounds,
+        temperature_bounds=temperature_bounds,
+        bins=bins,
+        output_path=arguments.output_directory,
+        prop_type=arguments.quantity_type,
+        species=arguments.hydrogen_species,
+    )
+

--- a/colibre/vrconfig_example.cfg
+++ b/colibre/vrconfig_example.cfg
@@ -1,0 +1,195 @@
+#Configuration file for analysing Hydro
+#runs 3DFOF + substructure algorithm, demands subhalos and FOF halos be self-bound, calculates many properties
+#Units currently set to take in as input, Mpc, 1e10 solar masses, km/s, output in same units
+#To set temporally unique halo ids, alter Snapshot_value=SNAP to appropriate value. Ie: for snapshot 12, change SNAP to 12
+
+################################
+#input options
+#set up to use SWIFT HDF input, load gas, star, bh and dark matter
+################################
+HDF_name_convention=6 #HDF SWIFT naming convention
+Input_includes_dm_particle=1 #include dark matter particles in hydro input
+Input_includes_gas_particle=1 #include gas particles in hydro input
+Input_includes_star_particle=1 #include star particles in hydro input
+Input_includes_bh_particle=1 #include bh particles in hydro input
+Input_includes_wind_particle=0 #include wind particles in hydro input (used by Illustris and moves particle type 0 to particle type 3 when decoupled from hydro forces). Here shown as example
+Input_includes_tracer_particle=0 #include tracer particles in hydro input (used by Illustris). Here shown as example
+Input_includes_extradm_particle=0 #include extra dm particles stored in particle type 2 and type 3, useful for zooms
+
+Halo_core_phase_merge_dist=0.25 #merge substructures if difference in dispersion normalised distance is < this value
+Apply_phase_merge_to_host=1 #merge substructures with background if centrally located and phase-distance is small
+
+#units conversion from input input to desired internal unit
+Length_input_unit_conversion_to_output_unit=1.0 #default code unit,
+Velocity_input_unit_conversion_to_output_unit=1.0 #default velocity unit,
+Mass_input_unit_conversion_to_output_unit=1.0 #default mass unit,
+#assumes input is in 1e10 msun, Mpc and km/s and output units are the same
+Gravity=43.0211349 #for 1e10 Msun, km/s and Mpc
+Hubble_unit=100.0 # assuming units are km/s and Mpc, then value of Hubble in km/s/Mpc
+#converting hydro quantities
+Stellar_age_input_is_cosmological_scalefactor=1
+Metallicity_input_unit_conversion_to_output_unit=1.0
+Stellar_age_input_unit_conversion_to_output_unit=1.0
+Star_formation_rate_input_unit_conversion_to_output_unit=1.0
+
+#set the units of the output by providing conversion to a defined unit
+#conversion of output length units to kpc
+Length_unit_to_kpc=1000.0
+#conversion of output velocity units to km/s
+Velocity_to_kms=1.0
+#conversion of output mass units to solar masses
+Mass_to_solarmass=1.0e10
+Metallicity_to_solarmetallicity=1.0
+Star_formation_rate_to_solarmassperyear=1.0
+Stellar_age_to_yr=1.0
+#ensures that output is physical and not comoving distances per little h
+Comoving_units=0
+
+#sets the total buffer size in bytes used to store temporary particle information
+#of mpi read threads before they are broadcast to the appropriate waiting non-read threads
+#if not set, default value is equivalent to 1e6 particles per mpi process, quite large
+#but significantly minimises the number of send/receives
+#in this example the buffer size is roughly that for a send/receive of 10000 particles
+#for 100 mpi processes
+MPI_particle_total_buf_size=100000000
+
+################################
+#search related options
+################################
+
+#how to search a simulation
+Particle_search_type=1 #search dark matter particles only
+#for baryon search
+Baryon_searchflag=2 #if 1 search for baryons separately using phase-space search when identifying substructures, 2 allows special treatment in field FOF linking and phase-space substructure search, 0 treat the same as dark matter particles
+#for search for substruture
+Search_for_substructure=1 #if 0, end search once field objects are found
+#also useful for zoom simulations or simulations of individual objects, setting this flag means no field structure search is run
+Singlehalo_search=0 #if file is single halo in which one wishes to search for substructure. Here disabled.
+#additional option for field haloes
+Keep_FOF=0 #if field 6DFOF search is done, allows to keep structures found in 3DFOF (can be interpreted as the inter halo stellar mass when only stellar search is used).\n
+
+#minimum size for structures
+Minimum_size=20 #min 20 particles
+Minimum_halo_size=32 #if field halos have different minimum sizes, otherwise set to -1.
+
+#for field fof halo search
+FoF_Field_search_type=5 #5 3DFOF search for field halos, 4 for 6DFOF clean up of field halos, 3 for 6DFOF with velocity scale distinct for each initial 3D FOF candidate
+Halo_3D_linking_length=0.20
+
+#for mean field estimates and local velocity density distribution funciton estimator related quantiites, rarely need to change this
+Local_velocity_density_approximate_calculation=1 #calculates velocity density using approximative (and quicker) near neighbour search
+Cell_fraction = 0.01 #fraction of field fof halo used to determine mean velocity distribution function. Typical values are ~0.005-0.02
+Grid_type=1 #normal entropy based grid, shouldn't have to change
+Nsearch_velocity=32 #number of velocity neighbours used to calculate local velocity distribution function. Typial values are ~32
+Nsearch_physical=256 #numerof physical neighbours from which the nearest velocity neighbour set is based. Typical values are 128-512
+
+#for substructure search, rarely ever need to change this
+FoF_search_type=1 #default phase-space FOF search. Don't really need to change
+Iterative_searchflag=1 #iterative substructure search, for substructure find initial candidate substructures with smaller linking lengths then expand search region
+Outlier_threshold=2.5 #outlier threshold for a particle to be considered residing in substructure, that is how dynamically distinct a particle is. Typical values are >2
+Substructure_physical_linking_length=0.10
+Velocity_ratio=2.0 #ratio of speeds used in phase-space FOF
+Velocity_opening_angle=0.10 #angle between velocities. 18 degrees here, typical values are ~10-30
+Velocity_linking_length=0.20 #where scaled by structure dispersion
+Significance_level=1.0 #how significant a substructure is relative to Poisson noise. Values >= 1 are fine.
+
+#for iterative substructure search, rarely ever need to change this
+Iterative_threshold_factor=1.0 #change in threshold value when using iterative search. Here no increase in threshold if iterative or not
+Iterative_linking_length_factor=2.0 #increase in final linking final iterative substructure search 
+Iterative_Vratio_factor=1.0 #change in Vratio when using iterative search. no change in vratio
+Iterative_ThetaOp_factor=1.0 #change in velocity opening angle. no change in velocity opening angle
+
+#for checking for halo merger remnants, which are defined as large, well separated phase-space density maxima
+Halo_core_search=2 # searches for separate 6dfof cores in field haloes, and then more than just flags halo as merging, assigns particles to each merging "halo". 2 is full separation, 1 is flagging, 0 is off
+#if searching for cores, linking lengths. likely does not need to change much
+Use_adaptive_core_search=0 #calculate dispersions in configuration & vel space to determine linking lengths
+Use_phase_tensor_core_growth=2 #use full stepped phase-space tensor assignment
+Halo_core_ellx_fac=0.7 #how linking lengths are changed when searching for local 6DFOF cores,
+Halo_core_ellv_fac=2.0 #how velocity lengths based on dispersions are changed when searching for local 6DFOF cores
+Halo_core_ncellfac=0.005 #fraction of total halo particle number setting min size of a local 6DFOF core
+Halo_core_num_loops=8 #number of loops to iteratively search for cores
+Halo_core_loop_ellx_fac=0.75 #how much to change the configuration space linking per iteration
+Halo_core_loop_ellv_fac=1.0 #how much to change the velocity space linking per iteration
+Halo_core_loop_elln_fac=1.2 #how much to change the min number of particles per iteration
+Halo_core_phase_significance=2.0 #how significant a core must be in terms of dispersions (sigma) significance
+
+################################
+#Unbinding options (VELOCIraptor is able to accurately identify tidal debris so particles need not be bound to a structure)
+################################
+
+#unbinding related items
+Unbind_flag=1 #run unbinding
+#objects must have particles that meet the allowed kinetic to potential ratio AND also have some total fraction that are completely bound.
+Unbinding_type=0
+#alpha factor used to determine whether particle is "bound" alaph*T+W<0. For standard subhalo catalogues use >0.9 but if interested in tidal debris 0.2-0.5
+Allowed_kinetic_potential_ratio=0.95
+Min_bound_mass_frac=0.65 #minimum bound mass fraction
+#run unbinding of field structures, aka halos. This is useful for sams and 6DFOF halos but may not be useful if interested in 3DFOF mass functions.
+Bound_halos=0
+#don't keep background potential when unbinding
+Keep_background_potential=1
+#use all particles to determine velocity frame for unbinding
+Frac_pot_ref=1.0
+Min_npot_ref=20
+#reference frame only meaningful if calculating velocity frame using subset of particles in object. Can use radially sorted fraction of particles about minimum potential or centre of mass
+Kinetic_reference_frame_type=0
+Unbinding_max_unbound_removal_fraction_per_iteration=0.5
+Unbinding_max_unbound_fraction=0.95
+Unbinding_max_unbound_fraction_allowed=0.005
+
+################################
+#Calculation of properties related options
+################################
+Virial_density=500 #user defined virial overdensity. Note that 200 rho_c, 200 rho_m and BN98 are already calculated.
+#when calculating properties, for field objects calculate inclusive masses
+Inclusive_halo_masses=3 #calculate inclusive masses for halos using full Spherical overdensity apertures
+#ensures that output is physical and not comoving distances per little h
+Comoving_units=0
+#calculate more (sub)halo properties (like angular momentum in spherical overdensity apertures, both inclusive and exclusive)
+Extensive_halo_properties_output=1
+Extensive_gas_properties_output=1
+Extensive_star_properties_output=1
+#calculate aperture masses
+Calculate_aperture_quantities=1 
+Number_of_apertures=5
+Aperture_values_in_kpc=5,10,30,50,100,
+Number_of_projected_apertures=5
+Projected_aperture_values_in_kpc=5,10,30,50,100,
+#calculate radial profiles
+Calculate_radial_profiles=1
+Number_of_radial_profile_bin_edges=20
+#default radial normalisation log rad bins, normed by R200crit, Integer flag of 0 is log bins and R200crit norm. 
+Radial_profile_norm=0
+Radial_profile_bin_edges=-2.,-1.87379263,-1.74758526,-1.62137789,-1.49517052,-1.36896316,-1.24275579,-1.11654842,-0.99034105,-0.86413368,-0.73792631,-0.61171894,-0.48551157,-0.3593042,-0.23309684,-0.10688947,0.0193179,0.14552527,0.27173264,0.39794001,
+Iterate_cm_flag=0 #do not interate to determine centre-of-mass
+Sort_by_binding_energy=1 #sort particles by binding energy
+Reference_frame_for_properties=2 #use the minimum potential as reference frame about which to calculate properties 
+
+################################
+#output related
+################################
+
+Write_group_array_file=0 #do not write a group array file
+Separate_output_files=0 #do not separate output into field and substructure files similar to subfind
+Binary_output=2 #Use HDF5 output (binary output 1, ascii 0, and HDF 2)
+#output particles residing in the spherical overdensity apertures of halos, only the particles exclusively belonging to halos
+Spherical_overdensity_halo_particle_list_output=1
+
+#halo ids are adjusted by this value * 1000000000000 (or 1000000 if code compiled with the LONGINTS option turned off)
+#to ensure that halo ids are temporally unique. So if you had 100 snapshots, for snap 100 set this to 100 and 100*1000000000000 will
+#be added to the halo id as set for this snapshot, so halo 1 becomes halo 100*1000000000000+1 and halo 1 of snap 0 would just have ID=1
+
+#ALTER THIS as part of a script to get temporally unique ids
+Snapshot_value=SNAP
+
+Gas_internal_property_names=SpeciesFractions,SpeciesFractions,SpeciesFractions,ElementMassFractions,
+Gas_internal_property_index_in_file=1,2,7,0,
+Gas_internal_property_calculation_type =averagemassweighted,averagemassweighted,averagemassweighted,averagemassweighted,
+
+
+################################
+#other options
+################################
+Verbose=0 #how talkative do you want the code to be, 0 not much, 1 a lot, 2 chatterbox
+
+


### PR DESCRIPTION
*Number of changes to provide Hydrogen Species plots:*

- Added template VR config file: `colibre/vrconfig_example.cfg` 
- Added local universe observational species fractions comparison plots  H2 (Saintonge+17) and HI (Catinella+18)
- Added HI and H2 mass fractions for local Universe
- Added phase plots coloured by species fractions

*Notes*:

This is designed for COLIBRE runs using `--with-cooling=CHIMES` , as the VR config file requires knowledge of which H species are assigned to which column. It would be better if this was universal for cooling modes, but CHIMES is the current default so have written it for that case. This update takes advantage of recent updates to the pipeline script to allow argument feeding.

Marking as WIP, in case there are better ways to integrate in the VR configuration. This also foreshadows issues with upcoming dust plots which should be stable for different dust models.