### PR TITLE
Two tiny (stylistic) fixes

### DIFF
--- a/colibre/description.html
+++ b/colibre/description.html
@@ -28,8 +28,8 @@
 <h4>Gravitational Softening</h4>
 <table>
     <tr>
-        <th colspan=2>Baryons [kpc]</th>
-        <th colspan=2>Dark Matter [kpc]</th>
+        <th colspan=2>Baryons</th>
+        <th colspan=2>Dark Matter</th>
     </tr>
     <tr>
         <th>Max Physical</th>

--- a/colibre/scripts/SNII_density_distribution.py
+++ b/colibre/scripts/SNII_density_distribution.py
@@ -9,12 +9,6 @@ import unyt
 from unyt import mh, cm
 
 from swiftsimio import load
-
-try:
-    plt.style.use("mnras.mplstyle")
-except:
-    pass
-
 from swiftpipeline.argumentparser import ScriptArgumentParser
 
 arguments = ScriptArgumentParser(

--- a/colibre/scripts/birth_density_distribution.py
+++ b/colibre/scripts/birth_density_distribution.py
@@ -9,12 +9,6 @@ import unyt
 from unyt import mh, cm
 
 from swiftsimio import load
-
-try:
-    plt.style.use("mnras.mplstyle")
-except:
-    pass
-
 from swiftpipeline.argumentparser import ScriptArgumentParser
 
 arguments = ScriptArgumentParser(

--- a/colibre/scripts/wallclock_number_of_steps.py
+++ b/colibre/scripts/wallclock_number_of_steps.py
@@ -8,12 +8,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from swiftsimio import load
-
-try:
-    plt.style.use("mnras.mplstyle")
-except:
-    pass
-
 from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 

--- a/colibre/scripts/wallclock_simulation_time.py
+++ b/colibre/scripts/wallclock_simulation_time.py
@@ -8,12 +8,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from swiftsimio import load
-
-try:
-    plt.style.use("mnras.mplstyle")
-except:
-    pass
-
 from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 

--- a/eagle-xl/description.html
+++ b/eagle-xl/description.html
@@ -28,8 +28,8 @@
 <h4>Gravitational Softening</h4>
 <table>
     <tr>
-        <th colspan=2>Baryons [kpc]</th>
-        <th colspan=2>Dark Matter [kpc]</th>
+        <th colspan=2>Baryons</th>
+        <th colspan=2>Dark Matter</th>
     </tr>
     <tr>
         <th>Max Physical</th>


### PR DESCRIPTION
- **First**
![Screenshot from 2020-10-21 00-39-46](https://user-images.githubusercontent.com/20153933/96656001-364fd100-133f-11eb-854d-3abc4ffde818.png)


Since we are now using `get_if_present_float() / get_if_present_int()`, which add units to the parameters we pass to the functions  _by default_, specifying **kpc** next to **baryons** & **dark matter** in the image above is redundant.

- **Second**

![Screenshot from 2020-10-21 00-39-23](https://user-images.githubusercontent.com/20153933/96656154-87f85b80-133f-11eb-9bd6-bdc6a0d4fe50.png)

In certain cases,
```
try:	
    plt.style.use("mnras.mplstyle")	
except:	
    pass
```
seems to give undesired padding to the figures (_left panel of the figure above_). Removing those 5 lines of code shrinks the panning layer to zero  (_right panel of the figure above_), which is what we want.