### PR TITLE
Changed gas_masses and max_temperatures to promote better comparisons…

### DIFF
--- a/eagle-xl/scripts/gas_masses.py
+++ b/eagle-xl/scripts/gas_masses.py
@@ -51,6 +51,8 @@ def make_single_image(
         (line,) = ax.plot(bins, h, label=name)
         ax.axvline(x=m_split, color=line.get_color(), ls="--", lw=0.2)
 
+    ax.legend()
+
     fig.savefig(f"{output_path}/gas_masses.png")
 
     return

--- a/eagle-xl/scripts/gas_masses.py
+++ b/eagle-xl/scripts/gas_masses.py
@@ -42,7 +42,7 @@ def make_single_image(
     fig, ax = plt.subplots()
     ax.set_xlabel("Gas Particle Masses $M_{\\rm gas}$ [10$^6$ M$_\odot$]")
     ax.set_ylabel("Counts [-]")
-    ax.loglog()
+    ax.semilogy()
 
     for filename, name in zip(filenames, names):
         m_gas, m_split = get_data(filename)

--- a/eagle-xl/scripts/max_temperatures.py
+++ b/eagle-xl/scripts/max_temperatures.py
@@ -26,54 +26,25 @@ def get_data(filename):
     return gas_max_T
 
 
-def setup_axes(T_bounds, number_of_simulations: int):
-    """
-    Creates the figure and axis object. Creates a grid of a x b subplots
-    that add up to at least number_of_simulations.
-    """
-
-    sqrt_number_of_simulations = np.sqrt(number_of_simulations)
-    horizontal_number = int(np.ceil(sqrt_number_of_simulations))
-    # Ensure >= number_of_simulations plots in a grid
-    vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
-
-    fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
-    )
-
-    ax = np.array([ax]) if number_of_simulations == 1 else ax
-
-    if horizontal_number * vertical_number > number_of_simulations:
-        for axis in ax.flat[number_of_simulations:]:
-            axis.axis("off")
-
-    # Set all valid on bottom row to have the horizontal axis label.
-    for axis in np.atleast_2d(ax)[:][-1]:
-        axis.set_xlabel("Gas Max. Temperature $T_{\\rm max}$ [K]")
-        axis.set_xscale("log")
-        axis.set_xlim(T_bounds)
-
-    for axis in np.atleast_2d(ax).T[:][0]:
-        axis.set_ylabel("Counts [-]")
-        axis.set_yscale("log")
-
-    return fig, ax
-
-
 def make_single_image(filenames, names, T_bounds, number_of_simulations, output_path):
     """
     Makes a single histogram of the gas particle max temperatures.
     """
 
-    fig, ax = setup_axes(T_bounds, number_of_simulations=number_of_simulations)
+    fig, ax = plt.subplots()
 
-    for filename, name, axis in zip(filenames, names, ax.flat):
+    ax.set_xlabel("Gas Max. Temperature $T_{\\rm max}$ [K]")
+    ax.set_ylabel("Counts [-]")
+    ax.loglog()
+
+    for filename, name in zip(filenames, names):
         T_max = get_data(filename)
         h, bin_edges = np.histogram(np.log10(T_max), range=np.log10(T_bounds), bins=250)
         bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
         bins = 10 ** bins
-        axis.plot(bins, h)
-        axis.text(0.975, 0.975, name, ha="right", va="top", transform=axis.transAxes)
+        ax.plot(bins, h, label=name)
+
+    ax.legend()
 
     fig.savefig(f"{output_path}/gas_max_temperatures.png")
 


### PR DESCRIPTION
… between runs

Before even though we were only plotting a single line, each run was plotted on a single sub-figure. I don't think this is the best way of showing off the data. See the below for the 'improved' figures that use one sub-figure but multiple coloured lines.

![gas_masses](https://user-images.githubusercontent.com/7839515/96861042-71472700-145b-11eb-85ff-122a005d92db.png)

![gas_max_temperatures](https://user-images.githubusercontent.com/7839515/96861073-7c01bc00-145b-11eb-99cb-8a38dfaa9d27.png)

