### PR TITLE
Add Tmax histogram and N of steps vs. sim-time plot to colibre

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -61,14 +61,24 @@ scripts:
     title: Density of the gas heated by SNII
     section: Density distributions
     output_file: SNII_density_distribution.png
+  - filename: scripts/max_temperatures.py
+    caption: Maximal temperature recorded by gas particles throughout the entire simulation.
+    output_file: gas_max_temperatures.png
+    section: Histograms
+    title: Maximal Temperature reached by gas particles
   - filename: scripts/wallclock_simulation_time.py
     caption: The cosmic time as a function of the wall-clock time.
     title: Cosmic time vs. wall-clock time
     section: Run Performance
     output_file: wallclock_simulation_time.png
   - filename: scripts/wallclock_number_of_steps.py
-    caption: The cumulative number of the simulation time-steps as a function of the wall-clock times.
+    caption: The cumulative number of the simulation time-steps as a function of the wall-clock time.
     title: The number of steps vs. wall-clock time
     section: Run Performance
     output_file: wallclock_number_of_steps.png
+  - filename: scripts/simulation_time_number_of_steps.py
+    caption: The cumulative number of the simulation time-steps as a function of the cosmic time.
+    title: Number of steps vs. cosmic time
+    section: Run Performance
+    output_file: simulation_time_number_of_steps.png
  

--- a/colibre/scripts/max_temperatures.py
+++ b/colibre/scripts/max_temperatures.py
@@ -1,0 +1,77 @@
+"""
+Makes a histogram of the gas particle max temperature. Uses the swiftsimio library.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+
+from unyt import unyt_quantity
+from matplotlib.colors import LogNorm
+from matplotlib.animation import FuncAnimation
+
+T_bounds = [1e5, 3e10]
+
+
+def get_data(filename):
+    """
+    Grabs the data
+    """
+
+    data = load(filename)
+
+    gas_max_T = data.gas.maximal_temperatures.to("K")
+
+    return gas_max_T
+
+
+def make_single_image(filenames, names, T_bounds, number_of_simulations, output_path):
+    """
+    Makes a single histogram of the gas particle max temperatures.
+    """
+
+    fig, ax = plt.subplots()
+
+    ax.set_xlabel("Gas Max. Temperature $T_{\\rm max}$ [K]")
+    ax.set_ylabel("Counts [-]")
+    ax.loglog()
+
+    for filename, name in zip(filenames, names):
+        T_max = get_data(filename)
+        h, bin_edges = np.histogram(np.log10(T_max), range=np.log10(T_bounds), bins=250)
+        bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
+        bins = 10 ** bins
+        ax.plot(bins, h, label=name)
+
+    ax.legend()
+    ax.set_xlim(*T_bounds)
+
+    fig.savefig(f"{output_path}/gas_max_temperatures.png")
+
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(
+        description="Basic gas particle max temperature histogram."
+    )
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        T_bounds=T_bounds,
+        number_of_simulations=arguments.number_of_inputs,
+        output_path=arguments.output_directory,
+    )

--- a/colibre/scripts/simulation_time_number_of_steps.py
+++ b/colibre/scripts/simulation_time_number_of_steps.py
@@ -1,0 +1,62 @@
+"""
+Plots simulation time v.s. number of steps.
+"""
+
+import unyt
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+from swiftpipeline.argumentparser import ScriptArgumentParser
+from glob import glob
+
+arguments = ScriptArgumentParser(
+    description="Creates a run performance plot: number of steps versus simulation time"
+)
+
+run_names = arguments.name_list
+run_directories = [f"{directory}" for directory in arguments.directory_list]
+snapshot_names = [f"{snapshot}" for snapshot in arguments.snapshot_list]
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+fig, ax = plt.subplots()
+
+for run_name, run_directory, snapshot_name in zip(
+    run_names, run_directories, snapshot_names
+):
+
+    timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
+    timesteps_filename = timesteps_glob[0]
+    snapshot_filename = f"{run_directory}/{snapshot_name}"
+
+    snapshot = load(snapshot_filename)
+    data = np.genfromtxt(
+        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
+    ).T
+
+    sim_time = unyt.unyt_array(data[1], units=snapshot.units.time).to("Gyr")
+    number_of_steps = np.arange(sim_time.size) / 1e6
+
+    # Simulation data plotting
+    (mpl_line,) = ax.plot(sim_time, number_of_steps, label=run_name)
+
+    ax.scatter(
+        sim_time[-1],
+        number_of_steps[-1],
+        color=mpl_line.get_color(),
+        marker=".",
+        zorder=10,
+    )
+
+ax.set_xlim(0, None)
+ax.set_ylim(0, None)
+
+ax.legend(loc="lower right")
+
+ax.set_ylabel("Number of steps [millions]")
+ax.set_xlabel("Simulation time [Gyr]")
+
+fig.savefig(f"{output_path}/simulation_time_number_of_steps.png")


### PR DESCRIPTION
Add two plots to colibre pipeline config

1.  A histogram showing the distribution of maximal temperatures (merely copied from the eagle-XL config)
2. A  performance plot showing the dependence of the number of simulation time-steps on the cosmic time.