### PR TITLE
Add redshift axis to run-performance plots

### DIFF
--- a/colibre/scripts/SNII_density_distribution.py
+++ b/colibre/scripts/SNII_density_distribution.py
@@ -13,7 +13,7 @@ from swiftpipeline.argumentparser import ScriptArgumentParser
 
 arguments = ScriptArgumentParser(
     description="Creates a plot showing the distribution of the gas densities recorded "
-                "when the gas was last heated by SNII, split by redshift"
+    "when the gas was last heated by SNII, split by redshift"
 )
 
 snapshot_filenames = [

--- a/colibre/scripts/simulation_time_number_of_steps.py
+++ b/colibre/scripts/simulation_time_number_of_steps.py
@@ -27,8 +27,8 @@ fig, ax = plt.subplots()
 # We will need to keep track of the maximum cosmic time reached in the simulation(s)
 t_max = unyt.unyt_array(0.0, units="Gyr")
 
-for idx, (run_name, run_directory, snapshot_name) in enumerate(zip(
-    run_names, run_directories, snapshot_names)
+for idx, (run_name, run_directory, snapshot_name) in enumerate(
+    zip(run_names, run_directories, snapshot_names)
 ):
 
     timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")

--- a/colibre/scripts/simulation_time_number_of_steps.py
+++ b/colibre/scripts/simulation_time_number_of_steps.py
@@ -11,9 +11,6 @@ from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 
-# Import EAGLE cosmology object
-from astropy.cosmology import Planck13
-
 arguments = ScriptArgumentParser(
     description="Creates a run performance plot: number of steps versus simulation time"
 )
@@ -30,8 +27,8 @@ fig, ax = plt.subplots()
 # We will need to keep track of the maximum cosmic time reached in the simulation(s)
 t_max = unyt.unyt_array(0.0, units="Gyr")
 
-for run_name, run_directory, snapshot_name in zip(
-    run_names, run_directories, snapshot_names
+for idx, (run_name, run_directory, snapshot_name) in enumerate(zip(
+    run_names, run_directories, snapshot_names)
 ):
 
     timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
@@ -39,6 +36,11 @@ for run_name, run_directory, snapshot_name in zip(
     snapshot_filename = f"{run_directory}/{snapshot_name}"
 
     snapshot = load(snapshot_filename)
+
+    # Read cosmology from the first run in the list
+    if idx == 0:
+        cosmology = snapshot.metadata.cosmology
+
     data = np.genfromtxt(
         timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
     ).T
@@ -68,7 +70,7 @@ ax2 = ax.twiny()
 z_ticks = np.array([0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 3.0, 10.0])
 
 # To place the new ticks onto the X-axis we need to know the corresponding cosmic times
-t_ticks = Planck13.age(z_ticks).value
+t_ticks = cosmology.age(z_ticks).value
 
 # Attach the ticks to the second X-axis
 ax2.set_xticks(t_ticks)

--- a/colibre/scripts/simulation_time_number_of_steps.py
+++ b/colibre/scripts/simulation_time_number_of_steps.py
@@ -11,6 +11,9 @@ from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 
+# Import EAGLE cosmology object
+from astropy.cosmology import Planck13
+
 arguments = ScriptArgumentParser(
     description="Creates a run performance plot: number of steps versus simulation time"
 )
@@ -23,6 +26,9 @@ output_path = arguments.output_directory
 plt.style.use(arguments.stylesheet_location)
 
 fig, ax = plt.subplots()
+
+# We will need to keep track of the maximum cosmic time reached in the simulation(s)
+t_max = unyt.unyt_array(0., units="Gyr")
 
 for run_name, run_directory, snapshot_name in zip(
     run_names, run_directories, snapshot_names
@@ -38,6 +44,11 @@ for run_name, run_directory, snapshot_name in zip(
     ).T
 
     sim_time = unyt.unyt_array(data[1], units=snapshot.units.time).to("Gyr")
+
+    # Update the maximum cosmic time if needed
+    if sim_time[-1] > t_max:
+        t_max = sim_time[-1]
+
     number_of_steps = np.arange(sim_time.size) / 1e6
 
     # Simulation data plotting
@@ -50,13 +61,29 @@ for run_name, run_directory, snapshot_name in zip(
         marker=".",
         zorder=10,
     )
+# Create second X-axis (to plot redshift alongside the cosmic time)
+ax2 = ax.twiny()
 
-ax.set_xlim(0, None)
+# z ticks along the second X-axis we want to display
+z_ticks = np.array([0, 0.2, 0.5, 1, 1.5, 2, 3, 10])
+
+# To place the new ticks onto the X-axis we need to know the corresponding cosmic times
+t_ticks = Planck13.age(z_ticks).value
+
+# Attach the ticks to the second X-axis
+ax2.set_xticks(t_ticks)
+
+# Format the ticks' labels
+ax2.set_xticklabels(["%2.1f" % z_tick for z_tick in z_ticks])
+
+ax.set_xlim(0, t_max * 1.05)
+ax2.set_xlim(0, t_max * 1.05)
 ax.set_ylim(0, None)
 
 ax.legend(loc="lower right")
 
 ax.set_ylabel("Number of steps [millions]")
 ax.set_xlabel("Simulation time [Gyr]")
+ax2.set_xlabel("Redshift z")
 
 fig.savefig(f"{output_path}/simulation_time_number_of_steps.png")

--- a/colibre/scripts/simulation_time_number_of_steps.py
+++ b/colibre/scripts/simulation_time_number_of_steps.py
@@ -74,7 +74,7 @@ t_ticks = Planck13.age(z_ticks).value
 ax2.set_xticks(t_ticks)
 
 # Format the ticks' labels
-ax2.set_xticklabels(["%2.1f" % z_tick for z_tick in z_ticks])
+ax2.set_xticklabels(["$%2.1f$" % z_tick for z_tick in z_ticks])
 
 ax.set_xlim(0, t_max * 1.05)
 ax2.set_xlim(0, t_max * 1.05)

--- a/colibre/scripts/simulation_time_number_of_steps.py
+++ b/colibre/scripts/simulation_time_number_of_steps.py
@@ -64,7 +64,7 @@ for run_name, run_directory, snapshot_name in zip(
 # Create second X-axis (to plot redshift alongside the cosmic time)
 ax2 = ax.twiny()
 
-# z ticks along the second X-axis we want to display
+# z ticks along the second X-axis
 z_ticks = np.array([0, 0.2, 0.5, 1, 1.5, 2, 3, 10])
 
 # To place the new ticks onto the X-axis we need to know the corresponding cosmic times

--- a/colibre/scripts/simulation_time_number_of_steps.py
+++ b/colibre/scripts/simulation_time_number_of_steps.py
@@ -28,7 +28,7 @@ plt.style.use(arguments.stylesheet_location)
 fig, ax = plt.subplots()
 
 # We will need to keep track of the maximum cosmic time reached in the simulation(s)
-t_max = unyt.unyt_array(0., units="Gyr")
+t_max = unyt.unyt_array(0.0, units="Gyr")
 
 for run_name, run_directory, snapshot_name in zip(
     run_names, run_directories, snapshot_names
@@ -65,7 +65,7 @@ for run_name, run_directory, snapshot_name in zip(
 ax2 = ax.twiny()
 
 # z ticks along the second X-axis
-z_ticks = np.array([0, 0.2, 0.5, 1, 1.5, 2, 3, 10])
+z_ticks = np.array([0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 3.0, 10.0])
 
 # To place the new ticks onto the X-axis we need to know the corresponding cosmic times
 t_ticks = Planck13.age(z_ticks).value

--- a/colibre/scripts/star_formation_history.py
+++ b/colibre/scripts/star_formation_history.py
@@ -45,8 +45,8 @@ fig, ax = plt.subplots()
 
 ax.loglog()
 
-for idx, (snapshot_filename, sfr_filename, name) in enumerate(zip(
-    snapshot_filenames, sfr_filenames, names)
+for idx, (snapshot_filename, sfr_filename, name) in enumerate(
+    zip(snapshot_filenames, sfr_filenames, names)
 ):
     data = np.genfromtxt(sfr_filename).T
 

--- a/colibre/scripts/star_formation_history.py
+++ b/colibre/scripts/star_formation_history.py
@@ -14,6 +14,10 @@ from swiftsimio import load
 
 from load_sfh_data import read_obs_data
 
+# Import EAGLE cosmology object
+from astropy.cosmology import Planck13, z_at_value
+from astropy.units import Gyr
+
 sfr_output_units = unyt.msun / (unyt.year * unyt.Mpc ** 3)
 
 from swiftpipeline.argumentparser import ScriptArgumentParser
@@ -116,11 +120,6 @@ for index, observation in enumerate(observational_data):
         )
     observation_labels.append(observation.description)
 
-
-ax.set_xlabel("Redshift $z$")
-ax.set_ylabel(r"SFR Density $\dot{\rho}_*$ [M$_\odot$ yr$^{-1}$ Mpc$^{-3}$]")
-
-
 redshift_ticks = np.array([0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0, 100.0])
 redshift_labels = [
     "$0$",
@@ -139,10 +138,6 @@ a_ticks = 1.0 / (redshift_ticks + 1.0)
 
 ax.set_xticks(a_ticks)
 ax.set_xticklabels(redshift_labels)
-ax.tick_params(axis="x", which="minor", bottom=False)
-
-ax.set_xlim(1.02, 0.07)
-ax.set_ylim(1.8e-4, 1.7)
 
 observation_legend = ax.legend(
     observation_lines, observation_labels, markerfirst=True, loc=3, fontsize=4, ncol=2
@@ -153,5 +148,33 @@ simulation_legend = ax.legend(
 )
 
 ax.add_artist(observation_legend)
+
+# Create second X-axis (to plot cosmic time alongside redshift)
+ax2 = ax.twiny()
+ax2.set_xscale('log')
+
+# Cosmic time ticks (in Gyr) along the second X-axis we want to display
+t_ticks = np.array([0.5, 1, 2, 4, 6, 8, 10, Planck13.age(1.0e-5).value])
+
+# To place the new ticks onto the X-axis we need to know the corresponding scale factors
+a_ticks_2axis = [1. / (1.+z_at_value(Planck13.age, t_tick * Gyr)) for t_tick in t_ticks]
+
+# Attach the ticks to the second X-axis
+ax2.set_xticks(a_ticks_2axis)
+
+# Format the ticks' labels
+ax2.set_xticklabels(["$%2.1f$" % t_tick for t_tick in t_ticks])
+
+# Final adjustments of the first and second X axes
+ax.tick_params(axis="x", which="minor", bottom=False)
+ax2.tick_params(axis="x", which="minor", top=False)
+
+ax.set_ylim(1.8e-4, 1.7)
+ax.set_xlim(1.02, 0.07)
+ax2.set_xlim(1.02, 0.07)
+
+ax.set_xlabel("Redshift $z$")
+ax.set_ylabel(r"SFR Density $\dot{\rho}_*$ [M$_\odot$ yr$^{-1}$ Mpc$^{-3}$]")
+ax2.set_xlabel("Cosmic time [Gyr]")
 
 fig.savefig(f"{output_path}/star_formation_history.png")

--- a/colibre/scripts/star_formation_history.py
+++ b/colibre/scripts/star_formation_history.py
@@ -151,13 +151,15 @@ ax.add_artist(observation_legend)
 
 # Create second X-axis (to plot cosmic time alongside redshift)
 ax2 = ax.twiny()
-ax2.set_xscale('log')
+ax2.set_xscale("log")
 
 # Cosmic-time ticks (in Gyr) along the second X-axis
-t_ticks = np.array([0.5, 1, 2, 4, 6, 8, 10, Planck13.age(1.0e-5).value])
+t_ticks = np.array([0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, Planck13.age(1.0e-5).value])
 
 # To place the new ticks onto the X-axis we need to know the corresponding scale factors
-a_ticks_2axis = [1. / (1.+z_at_value(Planck13.age, t_tick * Gyr)) for t_tick in t_ticks]
+a_ticks_2axis = [
+    1.0 / (1.0 + z_at_value(Planck13.age, t_tick * Gyr)) for t_tick in t_ticks
+]
 
 # Attach the ticks to the second X-axis
 ax2.set_xticks(a_ticks_2axis)

--- a/colibre/scripts/star_formation_history.py
+++ b/colibre/scripts/star_formation_history.py
@@ -15,7 +15,7 @@ from swiftsimio import load
 from load_sfh_data import read_obs_data
 
 # Import EAGLE cosmology object
-from astropy.cosmology import Planck13, z_at_value
+from astropy.cosmology import z_at_value
 from astropy.units import Gyr
 
 sfr_output_units = unyt.msun / (unyt.year * unyt.Mpc ** 3)
@@ -45,12 +45,17 @@ fig, ax = plt.subplots()
 
 ax.loglog()
 
-for snapshot_filename, sfr_filename, name in zip(
-    snapshot_filenames, sfr_filenames, names
+for idx, (snapshot_filename, sfr_filename, name) in enumerate(zip(
+    snapshot_filenames, sfr_filenames, names)
 ):
     data = np.genfromtxt(sfr_filename).T
 
     snapshot = load(snapshot_filename)
+
+    # Read cosmology from the first run in the list
+    if idx == 0:
+        cosmology = snapshot.metadata.cosmology
+
     units = snapshot.units
     boxsize = snapshot.metadata.boxsize
     box_volume = boxsize[0] * boxsize[1] * boxsize[2]
@@ -154,11 +159,11 @@ ax2 = ax.twiny()
 ax2.set_xscale("log")
 
 # Cosmic-time ticks (in Gyr) along the second X-axis
-t_ticks = np.array([0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, Planck13.age(1.0e-5).value])
+t_ticks = np.array([0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, cosmology.age(1.0e-5).value])
 
 # To place the new ticks onto the X-axis we need to know the corresponding scale factors
 a_ticks_2axis = [
-    1.0 / (1.0 + z_at_value(Planck13.age, t_tick * Gyr)) for t_tick in t_ticks
+    1.0 / (1.0 + z_at_value(cosmology.age, t_tick * Gyr)) for t_tick in t_ticks
 ]
 
 # Attach the ticks to the second X-axis

--- a/colibre/scripts/star_formation_history.py
+++ b/colibre/scripts/star_formation_history.py
@@ -153,7 +153,7 @@ ax.add_artist(observation_legend)
 ax2 = ax.twiny()
 ax2.set_xscale('log')
 
-# Cosmic time ticks (in Gyr) along the second X-axis we want to display
+# Cosmic-time ticks (in Gyr) along the second X-axis
 t_ticks = np.array([0.5, 1, 2, 4, 6, 8, 10, Planck13.age(1.0e-5).value])
 
 # To place the new ticks onto the X-axis we need to know the corresponding scale factors
@@ -165,7 +165,7 @@ ax2.set_xticks(a_ticks_2axis)
 # Format the ticks' labels
 ax2.set_xticklabels(["$%2.1f$" % t_tick for t_tick in t_ticks])
 
-# Final adjustments of the first and second X axes
+# Final adjustments
 ax.tick_params(axis="x", which="minor", bottom=False)
 ax2.tick_params(axis="x", which="minor", top=False)
 

--- a/colibre/scripts/wallclock_simulation_time.py
+++ b/colibre/scripts/wallclock_simulation_time.py
@@ -11,6 +11,9 @@ from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 
+# Import EAGLE cosmology object
+from astropy.cosmology import Planck13
+
 arguments = ScriptArgumentParser(
     description="Creates a run performance plot: simulation time versus wall-clock time"
 )
@@ -23,6 +26,9 @@ output_path = arguments.output_directory
 plt.style.use(arguments.stylesheet_location)
 
 fig, ax = plt.subplots()
+
+# We will need to keep track of the maximum cosmic time reached in the simulation(s)
+t_max = unyt.unyt_array(0., units="Gyr")
 
 for run_name, run_directory, snapshot_name in zip(
     run_names, run_directories, snapshot_names
@@ -38,6 +44,11 @@ for run_name, run_directory, snapshot_name in zip(
     ).T
 
     sim_time = unyt.unyt_array(data[1], units=snapshot.units.time).to("Gyr")
+
+    # Update the maximum cosmic time if needed
+    if sim_time[-1] > t_max:
+        t_max = sim_time[-1]
+
     wallclock_time = unyt.unyt_array(np.cumsum(data[-2]), units="ms").to("Hour")
 
     # Simulation data plotting
@@ -51,12 +62,29 @@ for run_name, run_directory, snapshot_name in zip(
         zorder=10,
     )
 
-ax.set_xlim(0, None)
+# Create second Y-axis (to plot redshift alongside the cosmic time)
+ax2 = ax.twinx()
+
+# z ticks along the second Y-axis we want to display
+z_ticks = np.array([0, 0.2, 0.5, 1, 1.5, 2, 3,  5, 10])
+
+# To place the new ticks onto the Y-axis we need to know the corresponding cosmic times
+t_ticks = Planck13.age(z_ticks).value
+
+# Attach the ticks to the second Y-axis
+ax2.set_yticks(t_ticks)
+
+# Format the ticks' labels
+ax2.set_yticklabels(["%2.1f" % z_tick for z_tick in z_ticks])
+
+ax.set_ylim(0, t_max * 1.05)
+ax2.set_ylim(0, t_max * 1.05)
 ax.set_xlim(0, None)
 
 ax.legend(loc="lower right")
 
 ax.set_ylabel("Simulation time [Gyr]")
+ax2.set_ylabel("Redshift z")
 ax.set_xlabel("Wallclock time [Hours]")
 
 fig.savefig(f"{output_path}/wallclock_simulation_time.png")

--- a/colibre/scripts/wallclock_simulation_time.py
+++ b/colibre/scripts/wallclock_simulation_time.py
@@ -27,8 +27,8 @@ fig, ax = plt.subplots()
 # We will need to keep track of the maximum cosmic time reached in the simulation(s)
 t_max = unyt.unyt_array(0.0, units="Gyr")
 
-for idx, (run_name, run_directory, snapshot_name) in enumerate(zip(
-    run_names, run_directories, snapshot_names)
+for idx, (run_name, run_directory, snapshot_name) in enumerate(
+    zip(run_names, run_directories, snapshot_names)
 ):
 
     timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")

--- a/colibre/scripts/wallclock_simulation_time.py
+++ b/colibre/scripts/wallclock_simulation_time.py
@@ -28,7 +28,7 @@ plt.style.use(arguments.stylesheet_location)
 fig, ax = plt.subplots()
 
 # We will need to keep track of the maximum cosmic time reached in the simulation(s)
-t_max = unyt.unyt_array(0., units="Gyr")
+t_max = unyt.unyt_array(0.0, units="Gyr")
 
 for run_name, run_directory, snapshot_name in zip(
     run_names, run_directories, snapshot_names
@@ -66,7 +66,7 @@ for run_name, run_directory, snapshot_name in zip(
 ax2 = ax.twinx()
 
 # z ticks along the second Y-axis
-z_ticks = np.array([0, 0.2, 0.5, 1, 1.5, 2, 3,  5, 10])
+z_ticks = np.array([0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0])
 
 # To place the new ticks onto the Y-axis we need to know the corresponding cosmic times
 t_ticks = Planck13.age(z_ticks).value

--- a/colibre/scripts/wallclock_simulation_time.py
+++ b/colibre/scripts/wallclock_simulation_time.py
@@ -75,7 +75,7 @@ t_ticks = Planck13.age(z_ticks).value
 ax2.set_yticks(t_ticks)
 
 # Format the ticks' labels
-ax2.set_yticklabels(["%2.1f" % z_tick for z_tick in z_ticks])
+ax2.set_yticklabels(["$%2.1f$" % z_tick for z_tick in z_ticks])
 
 ax.set_ylim(0, t_max * 1.05)
 ax2.set_ylim(0, t_max * 1.05)

--- a/colibre/scripts/wallclock_simulation_time.py
+++ b/colibre/scripts/wallclock_simulation_time.py
@@ -65,7 +65,7 @@ for run_name, run_directory, snapshot_name in zip(
 # Create second Y-axis (to plot redshift alongside the cosmic time)
 ax2 = ax.twinx()
 
-# z ticks along the second Y-axis we want to display
+# z ticks along the second Y-axis
 z_ticks = np.array([0, 0.2, 0.5, 1, 1.5, 2, 3,  5, 10])
 
 # To place the new ticks onto the Y-axis we need to know the corresponding cosmic times

--- a/colibre/scripts/wallclock_simulation_time.py
+++ b/colibre/scripts/wallclock_simulation_time.py
@@ -11,9 +11,6 @@ from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 
-# Import EAGLE cosmology object
-from astropy.cosmology import Planck13
-
 arguments = ScriptArgumentParser(
     description="Creates a run performance plot: simulation time versus wall-clock time"
 )
@@ -30,8 +27,8 @@ fig, ax = plt.subplots()
 # We will need to keep track of the maximum cosmic time reached in the simulation(s)
 t_max = unyt.unyt_array(0.0, units="Gyr")
 
-for run_name, run_directory, snapshot_name in zip(
-    run_names, run_directories, snapshot_names
+for idx, (run_name, run_directory, snapshot_name) in enumerate(zip(
+    run_names, run_directories, snapshot_names)
 ):
 
     timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
@@ -39,6 +36,11 @@ for run_name, run_directory, snapshot_name in zip(
     snapshot_filename = f"{run_directory}/{snapshot_name}"
 
     snapshot = load(snapshot_filename)
+
+    # Read cosmology from the first run in the list
+    if idx == 0:
+        cosmology = snapshot.metadata.cosmology
+
     data = np.genfromtxt(
         timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
     ).T
@@ -69,7 +71,7 @@ ax2 = ax.twinx()
 z_ticks = np.array([0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0])
 
 # To place the new ticks onto the Y-axis we need to know the corresponding cosmic times
-t_ticks = Planck13.age(z_ticks).value
+t_ticks = cosmology.age(z_ticks).value
 
 # Attach the ticks to the second Y-axis
 ax2.set_yticks(t_ticks)


### PR DESCRIPTION
Add redshift ticks to run-performance plots. The ticks will be attached to the second Y (or X) axis

To do the conversion from z to cosmic time I use **Planck13** cosmology, which is available in `astropy.cosmology`

Planck13 cosmology is the cosmology adopted in EAGLE and currently used in COLIBRE.

**Examples:**

_Before the change_

![simulation_time_number_of_steps_before](https://user-images.githubusercontent.com/20153933/97084550-34745f00-1618-11eb-9563-978beebf2266.png)
![wallclock_simulation_time_before](https://user-images.githubusercontent.com/20153933/97084551-350cf580-1618-11eb-8aa6-b750ec021e04.png)


_After the change_

![simulation_time_number_of_steps](https://user-images.githubusercontent.com/20153933/97084559-40f8b780-1618-11eb-8c10-fb4b62c5c426.png)
![wallclock_simulation_time](https://user-images.githubusercontent.com/20153933/97084560-41914e00-1618-11eb-8939-4b2a71bdbd4a.png)

