### PR TITLE
New stellar birth density plots

### DIFF
--- a/colibre/auto_plotter/stellar_birth_densities.yml
+++ b/colibre/auto_plotter/stellar_birth_densities.yml
@@ -9,8 +9,8 @@ stellar_birth_density_halo_mass_average_all_100:
   y:
     quantity: "stellar_birth_densities.average"
     units: "mh/cm**3"
-    start: 1e-1
-    end: 1e6
+    start: 5e0
+    end: 5e5
   median:
     plot: true
     log: true
@@ -38,8 +38,8 @@ stellar_birth_density_halo_mass_max_all_100:
   y:
     quantity: "stellar_birth_densities.max"
     units: "mh/cm**3"
-    start: 1e-1
-    end: 1e6
+    start: 5e0
+    end: 5e5
   median:
     plot: true
     log: true
@@ -67,8 +67,8 @@ stellar_birth_density_stellar_mass_average_all_100:
   y:
     quantity: "stellar_birth_densities.average"
     units: "mh/cm**3"
-    start: 1e-1
-    end: 1e6
+    start: 5e0
+    end: 5e5
   median:
     plot: true
     log: true
@@ -96,8 +96,8 @@ stellar_birth_density_stellar_mass_max_all_100:
   y:
     quantity: "stellar_birth_densities.max"
     units: "mh/cm**3"
-    start: 1e-1
-    end: 1e6
+    start: 5e0
+    end: 5e5
   median:
     plot: true
     log: true

--- a/colibre/auto_plotter/stellar_birth_densities.yml
+++ b/colibre/auto_plotter/stellar_birth_densities.yml
@@ -1,0 +1,115 @@
+stellar_birth_density_halo_mass_average_all_100:
+  type: "scatter"
+  legend_loc: "upper left"
+  x:
+    quantity: "masses.mass_200crit"
+    units: Solar_Mass
+    start: 1e8
+    end: 1e13
+  y:
+    quantity: "stellar_birth_densities.average"
+    units: "mh/cm**3"
+    start: 1e-1
+    end: 1e6
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 25
+    start:
+      value: 1e8
+      units: Solar_Mass
+    end:
+      value: 1e13
+      units: Solar_Mass
+  metadata:
+    title: Average Stellar Birth Density-Halo Mass relation
+    caption: Includes all haloes, including subhaloes.
+    section: Stellar Birth Densities
+
+stellar_birth_density_halo_mass_max_all_100:
+  type: "scatter"
+  legend_loc: "upper left"
+  x:
+    quantity: "masses.mass_200crit"
+    units: Solar_Mass
+    start: 1e8
+    end: 1e13
+  y:
+    quantity: "stellar_birth_densities.max"
+    units: "mh/cm**3"
+    start: 1e-1
+    end: 1e6
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 25
+    start:
+      value: 1e8
+      units: Solar_Mass
+    end:
+      value: 1e13
+      units: Solar_Mass
+  metadata:
+    title: Maximal Stellar Birth Density-Halo Mass relation
+    caption: Includes all haloes, including subhaloes.
+    section: Stellar Birth Densities
+
+stellar_birth_density_stellar_mass_average_all_100:
+  type: "scatter"
+  legend_loc: "upper left"
+  x:
+    quantity: "apertures.mass_star_100_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    quantity: "stellar_birth_densities.average"
+    units: "mh/cm**3"
+    start: 1e-1
+    end: 1e6
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 25
+    start:
+      value: 1e6
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Average Stellar Birth Density-Stellar Mass relation
+    caption: Includes all haloes, including subhaloes.
+    section: Stellar Birth Densities
+
+stellar_birth_density_stellar_mass_max_all_100:
+  type: "scatter"
+  legend_loc: "upper left"
+  x:
+    quantity: "apertures.mass_star_100_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    quantity: "stellar_birth_densities.max"
+    units: "mh/cm**3"
+    start: 1e-1
+    end: 1e6
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 25
+    start:
+      value: 1e6
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Maximal Stellar Birth Density-Stellar Mass relation
+    caption: Includes all haloes, including subhaloes.
+    section: Stellar Birth Densities

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -54,12 +54,12 @@ scripts:
   - filename: scripts/birth_density_distribution.py
     caption: Distributions of stellar birth densities, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars.
     title: Stellar Birth Densities
-    section: Density distributions
+    section: Stellar Birth Densities
     output_file: birth_density_distribution.png
   - filename: scripts/SNII_density_distribution.py
     caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles.
     title: Density of the gas heated by SNII
-    section: Density distributions
+    section: Feedback Densities
     output_file: SNII_density_distribution.png
   - filename: scripts/metallicity_evolution.py
     caption: Evolution of the metal mass in gas and stars per unit co-moving volume.

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -56,6 +56,16 @@ scripts:
     title: Stellar Birth Densities
     section: Stellar Birth Densities
     output_file: birth_density_distribution.png
+  - filename: scripts/birth_density_redshift.py
+    caption: Stellar birth densities vs redshift diagram. The pixel colour indicates the number of stellar particle in the pixel.
+    title: Stellar Birth Densities-Redshift 
+    section: Stellar Birth Densities
+    output_file: birth_density_redshift.png
+  - filename: scripts/birth_density_metallicity.py
+    caption: Stellar birth densities vs metallicity diagram. The pixel colour indicates the number of stellar particle in the pixel. At a given birth density, particles with metallicities lower than the smallest value along the Y axis are placed in the lowest-metallicity bin.
+    title: Stellar Birth Densities-Metallicity 
+    section: Stellar Birth Densities
+    output_file: birth_density_metallicity.png
   - filename: scripts/SNII_density_distribution.py
     caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles.
     title: Density of the gas heated by SNII

--- a/colibre/scripts/birth_density_metallicity.py
+++ b/colibre/scripts/birth_density_metallicity.py
@@ -1,0 +1,155 @@
+"""
+Makes a stellar-birth-density vs. metallicity 2D plot. Uses the swiftsimio library.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+
+from unyt import mh, cm
+from matplotlib.colors import LogNorm
+
+# Set the limits of the figure.
+density_bounds = [0.01, 1e5]  # in nh/cm^3
+metal_mass_fraction_bounds = [1e-7, 1]  # dimensionless
+bins = 128
+
+
+def get_data(filename):
+    """
+    Grabs the data (MMF and stellar birth density in mh / cm^3).
+    """
+
+    data = load(filename)
+
+    birth_densities = (data.stars.birth_densities / mh).to(cm ** -3)
+    try:
+        metal_mass_fractions = data.stars.smoothed_metal_mass_fractions.value
+    except AttributeError:
+        metal_mass_fractions = data.stars.metal_mass_fractions.value
+
+    below_Z_min = np.where(metal_mass_fractions < metal_mass_fraction_bounds[0])
+    metal_mass_fractions[below_Z_min] = metal_mass_fraction_bounds[0]
+
+    return birth_densities.value, metal_mass_fractions
+
+
+def make_hist(filename, density_bounds, metal_mass_fraction_bounds, bins):
+    """
+    Makes the histogram for filename with bounds as lower, higher
+    for the bins and "bins" the number of bins along each dimension.
+
+    Also returns the edges for pcolormesh to use.
+    """
+
+    density_bins = np.logspace(
+        np.log10(density_bounds[0]), np.log10(density_bounds[1]), bins
+    )
+    metal_mass_fraction_bins = np.logspace(
+        np.log10(metal_mass_fraction_bounds[0]),
+        np.log10(metal_mass_fraction_bounds[1]),
+        bins,
+    )
+
+    H, density_edges, metal_mass_fraction_edges = np.histogram2d(
+        *get_data(filename), bins=[density_bins, metal_mass_fraction_bins]
+    )
+
+    return H.T, density_edges, metal_mass_fraction_edges
+
+
+def setup_axes(number_of_simulations: int):
+    """
+    Creates the figure and axis object. Creates a grid of a x b subplots
+    that add up to at least number_of_simulations.
+    """
+
+    sqrt_number_of_simulations = np.sqrt(number_of_simulations)
+    horizontal_number = int(np.ceil(sqrt_number_of_simulations))
+    # Ensure >= number_of_simulations plots in a grid
+    vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
+
+    fig, ax = plt.subplots(
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+    )
+
+    ax = np.array([ax]) if number_of_simulations == 1 else ax
+
+    if horizontal_number * vertical_number > number_of_simulations:
+        for axis in ax.flat[number_of_simulations:]:
+            axis.axis("off")
+
+    # Set all valid on bottom row to have the horizontal axis label.
+    for axis in np.atleast_2d(ax)[:][-1]:
+        axis.set_xlabel("Stellar Birth Density $\\rho_B$ [$n_H$ cm$^{-3}$]")
+
+    for axis in np.atleast_2d(ax).T[:][0]:
+        axis.set_ylabel("Smoothed MMF $Z$")
+
+    ax.flat[0].loglog()
+
+    return fig, ax
+
+
+def make_single_image(
+    filenames,
+    names,
+    number_of_simulations,
+    density_bounds,
+    metal_mass_fraction_bounds,
+    bins,
+    output_path,
+):
+    """
+    Makes a single plot of rho_birth-MMF
+    """
+
+    fig, ax = setup_axes(number_of_simulations=number_of_simulations)
+
+    hists = []
+
+    for filename in filenames:
+        hist, d, Z = make_hist(
+            filename, density_bounds, metal_mass_fraction_bounds, bins
+        )
+        hists.append(hist)
+
+    vmax = np.max([np.max(hist) for hist in hists])
+
+    for hist, name, axis in zip(hists, names, ax.flat):
+        mappable = axis.pcolormesh(d, Z, hist, norm=LogNorm(vmin=1, vmax=vmax))
+        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+
+    fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Number of stellar particles")
+
+    fig.savefig(f"{output_path}/birth_density_metallicity.png")
+
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(
+        description="Stellar-birth-density vs. metallicity phase plot."
+    )
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        number_of_simulations=arguments.number_of_inputs,
+        density_bounds=density_bounds,
+        metal_mass_fraction_bounds=metal_mass_fraction_bounds,
+        bins=bins,
+        output_path=arguments.output_directory,
+    )

--- a/colibre/scripts/birth_density_redshift.py
+++ b/colibre/scripts/birth_density_redshift.py
@@ -1,0 +1,144 @@
+"""
+Makes a  stellar-birth-density vs. redshift 2D plot. Uses the swiftsimio library.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+
+from unyt import mh, cm
+from matplotlib.colors import LogNorm
+
+# Set the limits of the figure.
+density_bounds = [0.01, 1e5]  # in nh/cm^3
+redshift_bounds = [-1.5, 12]  # in K
+bins = 128
+
+
+def get_data(filename):
+    """
+    Grabs the data (z and stellar birth density in mh / cm^3).
+    """
+
+    data = load(filename)
+
+    birth_densities = (data.stars.birth_densities / mh).to(cm ** -3)
+    birth_redshifts = 1 / data.stars.birth_scale_factors.value - 1
+
+    return birth_densities.value, birth_redshifts
+
+
+def make_hist(filename, density_bounds, redshift_bounds, bins):
+    """
+    Makes the histogram for filename with bounds as lower, higher
+    for the bins and "bins" the number of bins along each dimension.
+
+    Also returns the edges for pcolormesh to use.
+    """
+
+    density_bins = np.logspace(
+        np.log10(density_bounds[0]), np.log10(density_bounds[1]), bins
+    )
+    redshift_bins = np.linspace(redshift_bounds[0], redshift_bounds[1], bins)
+
+    H, density_edges, redshift_edges = np.histogram2d(
+        *get_data(filename), bins=[density_bins, redshift_bins]
+    )
+
+    return H.T, density_edges, redshift_edges
+
+
+def setup_axes(number_of_simulations: int):
+    """
+    Creates the figure and axis object. Creates a grid of a x b subplots
+    that add up to at least number_of_simulations.
+    """
+
+    sqrt_number_of_simulations = np.sqrt(number_of_simulations)
+    horizontal_number = int(np.ceil(sqrt_number_of_simulations))
+    # Ensure >= number_of_simulations plots in a grid
+    vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
+
+    fig, ax = plt.subplots(
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+    )
+
+    ax = np.array([ax]) if number_of_simulations == 1 else ax
+
+    if horizontal_number * vertical_number > number_of_simulations:
+        for axis in ax.flat[number_of_simulations:]:
+            axis.axis("off")
+
+    # Set all valid on bottom row to have the horizontal axis label.
+    for axis in np.atleast_2d(ax)[:][-1]:
+        axis.set_xlabel("Stellar Birth Density $\\rho_B$ [$n_H$ cm$^{-3}$]")
+
+    for axis in np.atleast_2d(ax).T[:][0]:
+        axis.set_ylabel("Redshift $z$")
+
+    ax.flat[0].set_xscale("log")
+    ax.flat[0].invert_yaxis()
+
+    return fig, ax
+
+
+def make_single_image(
+    filenames,
+    names,
+    number_of_simulations,
+    density_bounds,
+    redshift_bounds,
+    bins,
+    output_path,
+):
+    """
+    Makes a single plot of rho_birth-z
+    """
+
+    fig, ax = setup_axes(number_of_simulations=number_of_simulations)
+
+    hists = []
+
+    for filename in filenames:
+        hist, d, z = make_hist(filename, density_bounds, redshift_bounds, bins)
+        hists.append(hist)
+
+    vmax = np.max([np.max(hist) for hist in hists])
+
+    for hist, name, axis in zip(hists, names, ax.flat):
+        mappable = axis.pcolormesh(d, z, hist, norm=LogNorm(vmin=1, vmax=vmax))
+        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+
+    fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Number of stellar particles")
+
+    fig.savefig(f"{output_path}/birth_density_redshift.png")
+
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(
+        description="Stellar-birth-density vs. redshift phase plot."
+    )
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        number_of_simulations=arguments.number_of_inputs,
+        density_bounds=density_bounds,
+        redshift_bounds=redshift_bounds,
+        bins=bins,
+        output_path=arguments.output_directory,
+    )


### PR DESCRIPTION
This one is a pretty big one.

In this update, I introduce

- two new scripts (stellar birth density vs. redshift and stellar birth density vs. metallicity). In order to create these two plots, I merely took the template from the temperature-density diagram script. 
- Max & average stellar birth density as a function of stellar mass and as a function of halo mass, for each halo. To create these plots, in addition to this pull request, I created a stellar-birth-density registration function [HERE](https://github.com/SWIFTSIM/velociraptor-python/pull/32) and update the velociraptor config as shown [HERE](https://gitlab.cosma.dur.ac.uk/EAGLE/swift-colibre/-/merge_requests/143).

**Examples** This is how the stellar-birth-density section is expected to look like following this update

![Screenshot from 2020-10-26 21-08-26](https://user-images.githubusercontent.com/20153933/97227512-e1e0a180-17d5-11eb-80d9-11f0888c3fb5.png)

and in the **comparison** mode

![Screenshot from 2020-10-26 21-55-43](https://user-images.githubusercontent.com/20153933/97227708-29ffc400-17d6-11eb-9df6-68a24faf249c.png)

@JBorrow @MatthieuSchaller 