### PR TITLE
Shorten labels in the new stellar birth density scripts

### DIFF
--- a/colibre/scripts/birth_density_metallicity.py
+++ b/colibre/scripts/birth_density_metallicity.py
@@ -82,7 +82,7 @@ def setup_axes(number_of_simulations: int):
 
     # Set all valid on bottom row to have the horizontal axis label.
     for axis in np.atleast_2d(ax)[:][-1]:
-        axis.set_xlabel("Stellar Birth Density $\\rho_B$ [$n_H$ cm$^{-3}$]")
+        axis.set_xlabel("$\\rho_B$ [$n_H$ cm$^{-3}$]")
 
     for axis in np.atleast_2d(ax).T[:][0]:
         axis.set_ylabel("Smoothed MMF $Z$")

--- a/colibre/scripts/birth_density_redshift.py
+++ b/colibre/scripts/birth_density_redshift.py
@@ -72,7 +72,7 @@ def setup_axes(number_of_simulations: int):
 
     # Set all valid on bottom row to have the horizontal axis label.
     for axis in np.atleast_2d(ax)[:][-1]:
-        axis.set_xlabel("Stellar Birth Density $\\rho_B$ [$n_H$ cm$^{-3}$]")
+        axis.set_xlabel("$\\rho_B$ [$n_H$ cm$^{-3}$]")
 
     for axis in np.atleast_2d(ax).T[:][0]:
         axis.set_ylabel("Redshift $z$")


### PR DESCRIPTION
It is good practice to have explicit labels for axes, but in run-comparison cases this might lead to problems.

Namely, In the two new scripts the labels are too long
![Screenshot from 2020-10-27 13-29-37](https://user-images.githubusercontent.com/20153933/97302337-35480380-1859-11eb-8d4c-ab4896261c70.png)


Sorry for not catching it earlier.
