### PR TITLE
Small improvements and fixes to colibre cfg

### DIFF
--- a/colibre/auto_plotter/stellar_birth_densities.yml
+++ b/colibre/auto_plotter/stellar_birth_densities.yml
@@ -1,4 +1,4 @@
-stellar_birth_density_halo_mass_average_all_100:
+stellar_birth_density_halo_mass_logaverage_all_100:
   type: "scatter"
   legend_loc: "upper left"
   x:
@@ -7,7 +7,7 @@ stellar_birth_density_halo_mass_average_all_100:
     start: 1e8
     end: 1e13
   y:
-    quantity: "stellar_birth_densities.average"
+    quantity: "stellar_birth_densities.logaverage"
     units: "mh/cm**3"
     start: 5e0
     end: 5e5
@@ -23,7 +23,7 @@ stellar_birth_density_halo_mass_average_all_100:
       value: 1e13
       units: Solar_Mass
   metadata:
-    title: Average Stellar Birth Density-Halo Mass relation
+    title: Log-average Stellar Birth Density-Halo Mass relation
     caption: Includes all haloes, including subhaloes.
     section: Stellar Birth Densities
 
@@ -56,7 +56,7 @@ stellar_birth_density_halo_mass_max_all_100:
     caption: Includes all haloes, including subhaloes.
     section: Stellar Birth Densities
 
-stellar_birth_density_stellar_mass_average_all_100:
+stellar_birth_density_stellar_mass_logaverage_all_100:
   type: "scatter"
   legend_loc: "upper left"
   x:
@@ -65,7 +65,7 @@ stellar_birth_density_stellar_mass_average_all_100:
     start: 1e6
     end: 1e12
   y:
-    quantity: "stellar_birth_densities.average"
+    quantity: "stellar_birth_densities.logaverage"
     units: "mh/cm**3"
     start: 5e0
     end: 5e5
@@ -81,7 +81,7 @@ stellar_birth_density_stellar_mass_average_all_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Average Stellar Birth Density-Stellar Mass relation
+    title: Log-average Stellar Birth Density-Stellar Mass relation
     caption: Includes all haloes, including subhaloes.
     section: Stellar Birth Densities
 

--- a/colibre/auto_plotter/stellar_mass_halo_mass.yml
+++ b/colibre/auto_plotter/stellar_mass_halo_mass.yml
@@ -9,7 +9,7 @@ stellar_mass_halo_mass_M200_all_100:
   y:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 5e4
+    start: 9e3
     end: 1e12
   median:
     plot: true
@@ -40,7 +40,7 @@ stellar_mass_halo_mass_MBN98_all_100:
   y:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 5e4
+    start: 9e3
     end: 1e12
   median:
     plot: true
@@ -74,7 +74,7 @@ stellar_mass_halo_mass_M200_centrals_100:
   y:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 5e4
+    start: 9e3
     end: 1e12
   median:
     plot: true
@@ -108,7 +108,7 @@ stellar_mass_halo_mass_MBN98_centrals_100:
   y:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 5e4
+    start: 9e3
     end: 1e12
   median:
     plot: true
@@ -203,7 +203,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_100:
   x:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 5e4
+    start: 9e3
     end: 1e12
   y:
     quantity: "derived_quantities.stellar_mass_to_halo_mass_200crit_100_kpc"
@@ -216,7 +216,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_100:
     adaptive: true
     number_of_bins: 30
     start:
-      value: 5e4
+      value: 9e3
       units: Solar_Mass
     end:
       value: 1e12
@@ -237,7 +237,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
   x:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 5e4
+    start: 9e3
     end: 1e12
   y:
     quantity: "derived_quantities.stellar_mass_to_halo_mass_bn98_100_kpc"
@@ -250,7 +250,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
     adapive: true
     number_of_bins: 30
     start:
-      value: 5e4
+      value: 9e3
       units: Solar_Mass
     end:
       value: 1e12
@@ -274,7 +274,7 @@ stellar_mass_halo_mass_M200_all_30:
   y:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
-    start: 5e4
+    start: 9e3
     end: 1e12
   median:
     plot: true
@@ -308,7 +308,7 @@ stellar_mass_halo_mass_M200_centrals_30:
   y:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
-    start: 5e4
+    start: 9e3
     end: 1e12
   median:
     plot: true
@@ -373,7 +373,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_30:
   x:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
-    start: 5e4
+    start: 9e3
     end: 1e12
   y:
     quantity: "derived_quantities.stellar_mass_to_halo_mass_200crit_30_kpc"
@@ -386,7 +386,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_30:
     adaptive: true
     number_of_bins: 30
     start:
-      value: 5e4
+      value: 9e3
       units: Solar_Mass
     end:
       value: 1e12

--- a/colibre/auto_plotter/stellar_mass_halo_mass.yml
+++ b/colibre/auto_plotter/stellar_mass_halo_mass.yml
@@ -9,7 +9,7 @@ stellar_mass_halo_mass_M200_all_100:
   y:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 1e6
+    start: 5e4
     end: 1e12
   median:
     plot: true
@@ -40,7 +40,7 @@ stellar_mass_halo_mass_MBN98_all_100:
   y:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 1e6
+    start: 5e4
     end: 1e12
   median:
     plot: true
@@ -59,7 +59,7 @@ stellar_mass_halo_mass_MBN98_all_100:
     section: Stellar Mass-Halo Mass
     show_on_webpage: false
   observational_data:
-    - filename: GalaxyStellarMassHaloMass/Behroozi2019_z000p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019_z001p000.hdf5
 
 stellar_mass_halo_mass_M200_centrals_100:
   type: "scatter"
@@ -74,7 +74,7 @@ stellar_mass_halo_mass_M200_centrals_100:
   y:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 1e6
+    start: 5e4
     end: 1e12
   median:
     plot: true
@@ -108,7 +108,7 @@ stellar_mass_halo_mass_MBN98_centrals_100:
   y:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 1e6
+    start: 5e4
     end: 1e12
   median:
     plot: true
@@ -126,7 +126,7 @@ stellar_mass_halo_mass_MBN98_centrals_100:
     caption: Includes only central haloes.
     section: Stellar Mass-Halo Mass
   observational_data:
-    - filename: GalaxyStellarMassHaloMass/Behroozi2019_z000p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019_z001p000.hdf5
       
 stellar_mass_halo_mass_M200_centrals_ratio_100:
   type: "scatter"
@@ -193,7 +193,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_100:
     caption: Includes only central haloes.
     section: Stellar Mass-Halo Mass
   observational_data:
-    - filename: GalaxyStellarMassHaloMass/Behroozi2019Ratio_z000p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019Ratio_z001p000.hdf5
 
 stellar_mass_halo_mass_M200_centrals_ratio_stellar_100:
   type: "scatter"
@@ -203,7 +203,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_100:
   x:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 1e6
+    start: 5e4
     end: 1e12
   y:
     quantity: "derived_quantities.stellar_mass_to_halo_mass_200crit_100_kpc"
@@ -216,7 +216,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_100:
     adaptive: true
     number_of_bins: 30
     start:
-      value: 1e6
+      value: 5e4
       units: Solar_Mass
     end:
       value: 1e12
@@ -237,7 +237,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
   x:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 1e6
+    start: 5e4
     end: 1e12
   y:
     quantity: "derived_quantities.stellar_mass_to_halo_mass_bn98_100_kpc"
@@ -250,7 +250,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
     adapive: true
     number_of_bins: 30
     start:
-      value: 1e6
+      value: 5e4
       units: Solar_Mass
     end:
       value: 1e12
@@ -261,7 +261,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
     section: Stellar Mass-Halo Mass
     show_on_webpage: false
   observational_data:
-    - filename: GalaxyStellarMassHaloMass/Behroozi2019RatioStellar_z000p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019RatioStellar_z001p000.hdf5
 
 stellar_mass_halo_mass_M200_all_30:
   type: "scatter"
@@ -274,7 +274,7 @@ stellar_mass_halo_mass_M200_all_30:
   y:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
-    start: 1e6
+    start: 5e4
     end: 1e12
   median:
     plot: true
@@ -308,7 +308,7 @@ stellar_mass_halo_mass_M200_centrals_30:
   y:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
-    start: 1e6
+    start: 5e4
     end: 1e12
   median:
     plot: true
@@ -373,7 +373,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_30:
   x:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
-    start: 1e6
+    start: 5e4
     end: 1e12
   y:
     quantity: "derived_quantities.stellar_mass_to_halo_mass_200crit_30_kpc"
@@ -386,7 +386,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_30:
     adaptive: true
     number_of_bins: 30
     start:
-      value: 1e6
+      value: 5e4
       units: Solar_Mass
     end:
       value: 1e12

--- a/colibre/auto_plotter/stellar_mass_halo_mass.yml
+++ b/colibre/auto_plotter/stellar_mass_halo_mass.yml
@@ -59,7 +59,7 @@ stellar_mass_halo_mass_MBN98_all_100:
     section: Stellar Mass-Halo Mass
     show_on_webpage: false
   observational_data:
-    - filename: GalaxyStellarMassHaloMass/Behroozi2019_z001p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019_z000p000.hdf5
 
 stellar_mass_halo_mass_M200_centrals_100:
   type: "scatter"
@@ -126,7 +126,7 @@ stellar_mass_halo_mass_MBN98_centrals_100:
     caption: Includes only central haloes.
     section: Stellar Mass-Halo Mass
   observational_data:
-    - filename: GalaxyStellarMassHaloMass/Behroozi2019_z001p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019_z000p000.hdf5
       
 stellar_mass_halo_mass_M200_centrals_ratio_100:
   type: "scatter"
@@ -193,7 +193,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_100:
     caption: Includes only central haloes.
     section: Stellar Mass-Halo Mass
   observational_data:
-    - filename: GalaxyStellarMassHaloMass/Behroozi2019Ratio_z001p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019Ratio_z000p000.hdf5
 
 stellar_mass_halo_mass_M200_centrals_ratio_stellar_100:
   type: "scatter"
@@ -261,7 +261,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
     section: Stellar Mass-Halo Mass
     show_on_webpage: false
   observational_data:
-    - filename: GalaxyStellarMassHaloMass/Behroozi2019RatioStellar_z001p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019RatioStellar_z000p000.hdf5
 
 stellar_mass_halo_mass_M200_all_30:
   type: "scatter"

--- a/colibre/description.html
+++ b/colibre/description.html
@@ -128,6 +128,31 @@
 <p>Disabled</p>
 {% endif %}
 
+<h4>Dust</h4>
+{% if data.metadata.subgrid_scheme.get("Dust Model", False) %}
+<table>
+    <tr>
+        <th>Parameter</th>
+        <th>Value</th>
+    </tr>
+    <tr>
+        <td>Dust Model</td>
+        <td>{{ data.metadata.subgrid_scheme["Dust Model"].decode("utf-8") }}</td>
+    </tr>
+    <tr>
+        <td>With Coupling to Cooling</td>
+        <td>{{ data.metadata.parameters | get_if_present_int("DustEvolution:pair_to_cooling") }}</td>
+    </tr>
+    <tr>
+        <td>Clumping Factor</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("DustEvolution:clumping_factor") }}</td>
+    </tr>
+</table>
+
+{% else %}
+<p>No dust</p>
+{% endif %}
+
 <h4>Entropy Floor</h4>
 {% if data.metadata.parameters.get("COLIBREEntropyFloor:Jeans_density_norm_H_p_cm3", False) %}
 <table>


### PR DESCRIPTION
**A bunch of small improvements and fixes to colibre config.**

- Extend the stellar-mass axis down to 5e4 solar mass in all SMHM plots 
- Fix the bug (it should be logaverage not (linear) average)
- Add basic info on the dust model to html page.

