### PR TITLE
Fix average of log stellar birth density plots

### DIFF
--- a/colibre/auto_plotter/stellar_birth_densities.yml
+++ b/colibre/auto_plotter/stellar_birth_densities.yml
@@ -1,4 +1,4 @@
-stellar_birth_density_halo_mass_logaverage_all_100:
+stellar_birth_density_halo_mass_average_of_log_all:
   type: "scatter"
   legend_loc: "upper left"
   x:
@@ -7,9 +7,9 @@ stellar_birth_density_halo_mass_logaverage_all_100:
     start: 1e8
     end: 1e13
   y:
-    quantity: "stellar_birth_densities.logaverage"
+    quantity: "derived_quantities.average_of_log_stellar_birth_density"
     units: "mh/cm**3"
-    start: 5e0
+    start: 5e-2
     end: 5e5
   median:
     plot: true
@@ -23,11 +23,11 @@ stellar_birth_density_halo_mass_logaverage_all_100:
       value: 1e13
       units: Solar_Mass
   metadata:
-    title: Log-average Stellar Birth Density-Halo Mass relation
+    title: Average of log Stellar Birth Density-Halo Mass relation
     caption: Includes all haloes, including subhaloes.
     section: Stellar Birth Densities
 
-stellar_birth_density_halo_mass_max_all_100:
+stellar_birth_density_halo_mass_max_all:
   type: "scatter"
   legend_loc: "upper left"
   x:
@@ -38,7 +38,7 @@ stellar_birth_density_halo_mass_max_all_100:
   y:
     quantity: "stellar_birth_densities.max"
     units: "mh/cm**3"
-    start: 5e0
+    start: 5e-2
     end: 5e5
   median:
     plot: true
@@ -56,18 +56,18 @@ stellar_birth_density_halo_mass_max_all_100:
     caption: Includes all haloes, including subhaloes.
     section: Stellar Birth Densities
 
-stellar_birth_density_stellar_mass_logaverage_all_100:
+stellar_birth_density_stellar_mass_average_of_log_all_100:
   type: "scatter"
   legend_loc: "upper left"
   x:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 1e6
+    start: 1e4
     end: 1e12
   y:
-    quantity: "stellar_birth_densities.logaverage"
+    quantity: "derived_quantities.average_of_log_stellar_birth_density"
     units: "mh/cm**3"
-    start: 5e0
+    start: 5e-2
     end: 5e5
   median:
     plot: true
@@ -81,7 +81,7 @@ stellar_birth_density_stellar_mass_logaverage_all_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Log-average Stellar Birth Density-Stellar Mass relation
+    title: Average of log Stellar Birth Density-Stellar Mass relation
     caption: Includes all haloes, including subhaloes.
     section: Stellar Birth Densities
 
@@ -91,12 +91,12 @@ stellar_birth_density_stellar_mass_max_all_100:
   x:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
-    start: 1e6
+    start: 1e4
     end: 1e12
   y:
     quantity: "stellar_birth_densities.max"
     units: "mh/cm**3"
-    start: 5e0
+    start: 5e-2
     end: 5e5
   median:
     plot: true

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -18,7 +18,10 @@ This file calculates:
     + metallicity_in_solar (star_metallicity_in_solar_{x}_kpc, 30, 100 kpc)
         Metallicity in solar units (relative to metal_mass_fraction).
     + stellar_mass_to_halo_mass_{x}_kpc for 30 and 100 kpc
-        Stellar Mass / Halo Mass (mass_200crit) for 30 and 100 kpc apertures.
+        Stellar Mass / Halo Mass (both mass_200crit and mass_bn98) for 30 and 100 kpc
+        apertures.
+    + average of log of stellar birth densities (average_of_log_stellar_birth_density)
+        velociraptor outputs the log of the quantity we need, so we take exp(...) of it
 """
 
 aperture_sizes = [30, 100]
@@ -168,35 +171,58 @@ self.mu_star_100_kpc = mstar_100 / gal_area
 self.mu_star_100_kpc.name = "$\\pi R_{*, 100 {\\rm kpc}}^2 / M_{*, 100 {\\rm kpc}}$"
 
 try:
-   H_frac = catalogue.element_mass_fractions.element_0
-   hydrogen_frac_error = ""
+    H_frac = catalogue.element_mass_fractions.element_0
+    hydrogen_frac_error = ""
 except:
-   H_frac = 0.0
-   hydrogen_frac_error = "(no H abundance)"
-   
-   
+    H_frac = 0.0
+    hydrogen_frac_error = "(no H abundance)"
+
+
 # Test for CHIMES arrays
 try:
-   species_1 = catalogue.species_fractions.species_1
-   species_7 = catalogue.species_fractions.species_7
-   species_frac_error = ""
+    species_1 = catalogue.species_fractions.species_1
+    species_7 = catalogue.species_fractions.species_7
+    species_frac_error = ""
 except:
-   species_1 = 0.0
-   species_7 = 0.0
-   species_frac_error = "(no species field)"
-   
+    species_1 = 0.0
+    species_7 = 0.0
+    species_frac_error = "(no species field)"
+
 total_error = f" {species_frac_error}{hydrogen_frac_error}"
 
 self.neutral_hydrogen_mass_100_kpc = gas_mass * H_frac * species_1
 self.hi_to_stellar_mass_100_kpc = (
-   self.neutral_hydrogen_mass_100_kpc / catalogue.apertures.mass_star_100_kpc
+    self.neutral_hydrogen_mass_100_kpc / catalogue.apertures.mass_star_100_kpc
 )
 self.molecular_hydrogen_mass_100_kpc = gas_mass * H_frac * species_7
 self.h2_to_stellar_mass_100_kpc = (
-   self.molecular_hydrogen_mass_100_kpc / catalogue.apertures.mass_star_100_kpc
+    self.molecular_hydrogen_mass_100_kpc / catalogue.apertures.mass_star_100_kpc
 )
 
 self.neutral_hydrogen_mass_100_kpc.name = f"HI Mass (100 kpc){total_error}"
-self.hi_to_stellar_mass_100_kpc.name = f"HI to Stellar Mass Fraction (100 kpc){total_error}"
+self.hi_to_stellar_mass_100_kpc.name = (
+    f"HI to Stellar Mass Fraction (100 kpc){total_error}"
+)
 self.molecular_hydrogen_mass_100_kpc.name = f"H$_2$ Mass (100 kpc){total_error}"
-self.h2_to_stellar_mass_100_kpc.name = f"H$_2$ to Stellar Mass Fraction (100 kpc){total_error}"
+self.h2_to_stellar_mass_100_kpc.name = (
+    f"H$_2$ to Stellar Mass Fraction (100 kpc){total_error}"
+)
+
+# Formatting script for average of the log of stellar birth densities
+try:
+    average_log_n_b = catalogue.stellar_birth_densities.logaverage
+    stellar_mass = catalogue.apertures.mass_star_100_kpc
+
+    exp_average_log_n_b = unyt.unyt_array(
+        np.exp(average_log_n_b), units=average_log_n_b.units
+    )
+
+    # Ensure haloes with zero stellar mass have zero stellar birth densities
+    no_stellar_mass = stellar_mass <= unyt.unyt_quantity(0.0, stellar_mass.units)
+    exp_average_log_n_b[no_stellar_mass] = unyt.unyt_quantity(0.0, average_log_n_b.units)
+
+    name = "Stellar Birth Density (average of log)"
+    exp_average_log_n_b.name = name
+    setattr(self, "average_of_log_stellar_birth_density", exp_average_log_n_b)
+except AttributeError:
+    pass


### PR DESCRIPTION
**1. Why this PR:**

The plots with averages of log stellar birth densities were **empty**

![Screenshot from 2020-11-02 00-03-47](https://user-images.githubusercontent.com/20153933/97817802-fffb4580-1c9e-11eb-8c7e-4fdf903b84e7.png)

and also these plots had confusing Y-axis labels: **logaverage** in place of **average of log**

This PR fixes the above mentioned.

**2. Other minor improvements:**

I extended the axis limits in all stellar-birth-density vs stellar mass/halo mass plots so that no data can escape the plots.

**3. Examples of the new plots:**

![stellar_birth_density_halo_mass_average_of_log_all](https://user-images.githubusercontent.com/20153933/97817878-61bbaf80-1c9f-11eb-9a90-7aeb735a565b.png)
![stellar_birth_density_halo_mass_max_all](https://user-images.githubusercontent.com/20153933/97817880-62544600-1c9f-11eb-98fc-2cbfc71fe6c9.png)
![stellar_birth_density_stellar_mass_average_of_log_all_100](https://user-images.githubusercontent.com/20153933/97817881-62ecdc80-1c9f-11eb-8dba-cc43bc176426.png)
![stellar_birth_density_stellar_mass_max_all_100](https://user-images.githubusercontent.com/20153933/97817882-62ecdc80-1c9f-11eb-9cef-efa8f5ebb47a.png)

**4. Example of the stellar birth density section on the web-page containing the new plots:**
![Screenshot from 2020-11-02 00-11-50](https://user-images.githubusercontent.com/20153933/97817995-0c33d280-1ca0-11eb-9227-b31ed43762c6.png)






