### PR TITLE
Add redshift metallicity script

### DIFF
--- a/colibre/auto_plotter/stellar_birth_densities.yml
+++ b/colibre/auto_plotter/stellar_birth_densities.yml
@@ -75,7 +75,7 @@ stellar_birth_density_stellar_mass_average_of_log_all_100:
     adaptive: true
     number_of_bins: 25
     start:
-      value: 1e6
+      value: 1e4
       units: Solar_Mass
     end:
       value: 1e12
@@ -104,7 +104,7 @@ stellar_birth_density_stellar_mass_max_all_100:
     adaptive: true
     number_of_bins: 25
     start:
-      value: 1e6
+      value: 1e4
       units: Solar_Mass
     end:
       value: 1e12

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -56,16 +56,21 @@ scripts:
     title: Stellar Birth Densities
     section: Stellar Birth Densities
     output_file: birth_density_distribution.png
-  - filename: scripts/birth_density_redshift.py
-    caption: Stellar birth densities vs redshift diagram. The pixel colour indicates the number of stellar particle in the pixel.
-    title: Stellar Birth Densities-Redshift 
-    section: Stellar Birth Densities
-    output_file: birth_density_redshift.png
   - filename: scripts/birth_density_metallicity.py
-    caption: Stellar birth densities vs metallicity diagram. The pixel colour indicates the number of stellar particle in the pixel. At a given birth density, particles with metallicities lower than the smallest value along the Y axis are placed in the lowest-metallicity bin.
-    title: Stellar Birth Densities-Metallicity 
+    caption: Stellar birth densities vs metallicity diagram. The pixel colour indicates the number of stellar particles in the pixel. At a given birth density, particles with metallicities lower than the smallest value along the Y axis are placed in the lowest-metallicity bin.
+    title: Stellar Birth Densities-Metallicity
     section: Stellar Birth Densities
     output_file: birth_density_metallicity.png
+  - filename: scripts/birth_density_redshift.py
+    caption: Stellar birth densities vs redshift diagram. The pixel colour indicates the number of stellar particles in the pixel.
+    title: Stellar Birth Densities-Redshift
+    section: Stellar Birth Densities
+    output_file: birth_density_redshift.png
+  - filename: scripts/metallicity_redshift.py
+    caption: Stellar metallicity vs redshift diagram. The pixel colour indicates the number of stellar particles in the pixel. At a given redshift, particles with metallicities lower than the smallest value along the X axis are placed in the lowest-metallicity bin.
+    title: Stellar Metallicity-Redshift
+    section: Stellar Birth Densities
+    output_file: metallicity_redshift.png
   - filename: scripts/SNII_density_distribution.py
     caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles.
     title: Density of the gas heated by SNII

--- a/colibre/scripts/birth_density_metallicity.py
+++ b/colibre/scripts/birth_density_metallicity.py
@@ -12,7 +12,7 @@ from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
 density_bounds = [0.01, 1e5]  # in nh/cm^3
-metal_mass_fraction_bounds = [1e-7, 1]  # dimensionless
+metal_mass_fraction_bounds = [1e-4, 0.5]  # dimensionless
 bins = 128
 
 
@@ -30,7 +30,9 @@ def get_data(filename):
         metal_mass_fractions = data.stars.metal_mass_fractions.value
 
     below_Z_min = np.where(metal_mass_fractions < metal_mass_fraction_bounds[0])
-    metal_mass_fractions[below_Z_min] = metal_mass_fraction_bounds[0]
+
+    # Stars with Z < lowest Z in the figure should be added to the lowest-Z bin
+    metal_mass_fractions[below_Z_min] = metal_mass_fraction_bounds[0] * (1. + 1e-3/bins)
 
     return birth_densities.value, metal_mass_fractions
 

--- a/colibre/scripts/birth_density_redshift.py
+++ b/colibre/scripts/birth_density_redshift.py
@@ -12,7 +12,7 @@ from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
 density_bounds = [0.01, 1e5]  # in nh/cm^3
-redshift_bounds = [-1.5, 12]
+redshift_bounds = [-1.5, 12]  # dimensionless
 bins = 128
 
 

--- a/colibre/scripts/metallicity_redshift.py
+++ b/colibre/scripts/metallicity_redshift.py
@@ -32,7 +32,9 @@ def get_data(filename):
     below_Z_min = np.where(metal_mass_fractions < metal_mass_fraction_bounds[0])
 
     # Stars with Z < lowest Z in the figure should be added to the lowest-Z bin
-    metal_mass_fractions[below_Z_min] = metal_mass_fraction_bounds[0] * (1. + 1e-3/bins)
+    metal_mass_fractions[below_Z_min] = metal_mass_fraction_bounds[0] * (
+        1.0 + 1e-3 / bins
+    )
 
     return metal_mass_fractions, birth_redshifts
 
@@ -46,7 +48,9 @@ def make_hist(filename, metal_mass_fraction_bounds, redshift_bounds, bins):
     """
 
     metal_mass_fraction_bins = np.logspace(
-        np.log10(metal_mass_fraction_bounds[0]), np.log10(metal_mass_fraction_bounds[1]), bins
+        np.log10(metal_mass_fraction_bounds[0]),
+        np.log10(metal_mass_fraction_bounds[1]),
+        bins,
     )
     redshift_bins = np.linspace(redshift_bounds[0], redshift_bounds[1], bins)
 
@@ -109,7 +113,9 @@ def make_single_image(
     hists = []
 
     for filename in filenames:
-        hist, Z, z = make_hist(filename, metal_mass_fraction_bounds, redshift_bounds, bins)
+        hist, Z, z = make_hist(
+            filename, metal_mass_fraction_bounds, redshift_bounds, bins
+        )
         hists.append(hist)
 
     vmax = np.max([np.max(hist) for hist in hists])

--- a/colibre/scripts/metallicity_redshift.py
+++ b/colibre/scripts/metallicity_redshift.py
@@ -11,7 +11,7 @@ from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
 metal_mass_fraction_bounds = [1e-4, 0.5]  # dimensionless
-redshift_bounds = [-1.5, 12]
+redshift_bounds = [-1.5, 12]  # dimensionless
 bins = 128
 
 


### PR DESCRIPTION
 Add the **redshift-metallicity** script to complete the density-metallicity-redshift cube.

**1. Example:** (the plot on the right is the new one)

![Screenshot from 2020-11-03 13-31-13](https://user-images.githubusercontent.com/20153933/97985761-fe359d00-1dd8-11eb-88c2-91ed5726f6ac.png)

**2. Other minor changes in this PR**
- A number of typos in the comments have been fixed
- Axis limits adjusted as suggested by Joop
- Decrease the stellar mass at which the adaptive binning begins, in stellar birth density - stellar-mass plots from 1e6 to 1e4 Msolar