### PR TITLE
Add the critical-density line from DV&S2012 to 2 plots

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -52,7 +52,7 @@ scripts:
     section: Metal Mass Fractions
     title: Metal Mass Fraction Distribution
   - filename: scripts/birth_density_distribution.py
-    caption: Distributions of stellar birth densities, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars.
+    caption: Distributions of stellar birth densities, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median stellar birth-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for f_t=10.
     title: Stellar Birth Densities
     section: Stellar Birth Densities
     output_file: birth_density_distribution.png
@@ -72,7 +72,7 @@ scripts:
     section: Stellar Birth Densities
     output_file: metallicity_redshift.png
   - filename: scripts/SNII_density_distribution.py
-    caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles.
+    caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles. The dashed vertical lines show the median SNII gas-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for f_t=10.
     title: Density of the gas heated by SNII
     section: Feedback Densities
     output_file: SNII_density_distribution.png

--- a/colibre/scripts/SNII_density_distribution.py
+++ b/colibre/scripts/SNII_density_distribution.py
@@ -47,7 +47,7 @@ def critical_density_DVS2012(
     Returns
     -------
 
-    output: float
+    n_Hc: float
         The critical density expressed in hydrogen particles per cubic centimetre
     """
 
@@ -55,7 +55,7 @@ def critical_density_DVS2012(
     g = np.power(X_H, -1.0 / 3.0) * f_X
 
     # Critical density
-    n_H = (
+    n_Hc = (
         31.0
         * np.power(T_K / 10.0 ** 7.5, 3.0 / 2.0)
         * np.power(f_t / 10.0, -3.0 / 2.0)
@@ -65,7 +65,7 @@ def critical_density_DVS2012(
         * np.power(g / 0.14, 3.0 / 2.0)
     )  # Eq. 18 in DV&S2012
 
-    return n_H
+    return n_Hc
 
 
 arguments = ScriptArgumentParser(

--- a/colibre/scripts/SNII_density_distribution.py
+++ b/colibre/scripts/SNII_density_distribution.py
@@ -39,8 +39,8 @@ def critical_density_DVS2012(
     X_H: Average mass fraction of hydrogen
 
     f_t: float
-        The ratio of the sound crossing time-scale (through an SPH kernel)
-        to the cooling time-scale (at temperature T_K)
+        The ratio of the cooling time-scale (at temperature T_K) to the sound crossing
+        time-scale (through the SPH kernel corresponding to M_gas and n_Hc)
 
     mu: Mean molecular weight of the heated gas (0.6 assumes the gas is fully ionised)
 

--- a/colibre/scripts/SNII_density_distribution.py
+++ b/colibre/scripts/SNII_density_distribution.py
@@ -11,6 +11,63 @@ from unyt import mh, cm
 from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
 
+
+def critical_density_DVS2012(
+    T_K: float = 10.0 ** 7.5,
+    M_gas: float = 7.0e4,
+    N_ngb: float = 48.0,
+    X_H: float = 0.752,
+    f_t: float = 10.0,
+    mu: float = 0.6,
+) -> float:
+    """
+    Computes the critical density from C. Dalla Vecchia & J. Schaye 2012
+    (2012MNRAS.426..140D), below which the gas is subject to (strong) radiation energy
+    losses.
+
+    Parameters
+    ----------
+
+    T_K: float
+        Heating temperature in SNII / AGN feedback [in K]
+
+    M_gas: float
+        Gas mass resolution [in Solar masses]
+
+    N_ngb: Target number of gas neighbours in the stellar / BH kernel
+
+    X_H: Average mass fraction of hydrogen
+
+    f_t: float
+        The ratio of the sound crossing time-scale (through an SPH kernel)
+        to the cooling time-scale (at temperature T_K)
+
+    mu: Mean molecular weight of the heated gas (0.6 assumes the gas is fully ionised)
+
+    Returns
+    -------
+
+    output: float
+        The critical density expressed in hydrogen particles per cubic centimetre
+    """
+
+    f_X = X_H / (1.0 + X_H) / (1.0 + 3.0 * X_H)  # Eq. 14 in DV&S2012
+    g = np.power(X_H, -1.0 / 3.0) * f_X
+
+    # Critical density
+    n_H = (
+        31.0
+        * np.power(T_K / 10.0 ** 7.5, 3.0 / 2.0)
+        * np.power(f_t / 10.0, -3.0 / 2.0)
+        * np.power(M_gas / 7.0e4, -1.0 / 2.0)
+        * np.power(N_ngb / 48.0, -1.0 / 2.0)
+        * np.power(mu / 0.6, -9.0 / 4.0)
+        * np.power(g / 0.14, 3.0 / 2.0)
+    )  # Eq. 18 in DV&S2012
+
+    return n_H
+
+
 arguments = ScriptArgumentParser(
     description="Creates a plot showing the distribution of the gas densities recorded "
     "when the gas was last heated by SNII, split by redshift"
@@ -82,6 +139,18 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         "$z > 3$": gas_SNII_densities[gas_SNII_redshifts > 3],
     }
 
+    # Compute the critical density from DV&S2012
+    SNII_heating_temperature = float(
+        snapshot.metadata.parameters["COLIBREFeedback:SNII_delta_T_K"].decode("utf-8")
+    )  # in K
+    N_ngb_target = snapshot.metadata.hydro_scheme["Kernel target N_ngb"][0]
+    X_H = snapshot.metadata.hydro_scheme["Hydrogen mass fraction"][0]
+    M_gas = snapshot.metadata.initial_mass_table.gas.to("Msun")  # in Solar Masses
+
+    n_crit = critical_density_DVS2012(
+        T_K=SNII_heating_temperature, M_gas=M_gas.value, N_ngb=N_ngb_target, X_H=X_H
+    )
+
     for redshift, ax in ax_dict.items():
         data = np.concatenate(
             [
@@ -112,6 +181,10 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
             alpha=0.5,
         )
 
+        # Add the DV&S2012 line
+        ax.axvline(
+            n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5,
+        )
 
 axes[0].legend(loc="upper right", markerfirst=False)
 axes[2].set_xlabel(

--- a/colibre/scripts/birth_density_distribution.py
+++ b/colibre/scripts/birth_density_distribution.py
@@ -47,7 +47,7 @@ def critical_density_DVS2012(
     Returns
     -------
 
-    output: float
+    n_Hc: float
         The critical density expressed in hydrogen particles per cubic centimetre
     """
 
@@ -55,7 +55,7 @@ def critical_density_DVS2012(
     g = np.power(X_H, -1.0 / 3.0) * f_X
 
     # Critical density
-    n_H = (
+    n_Hc = (
         31.0
         * np.power(T_K / 10.0 ** 7.5, 3.0 / 2.0)
         * np.power(f_t / 10.0, -3.0 / 2.0)
@@ -65,7 +65,7 @@ def critical_density_DVS2012(
         * np.power(g / 0.14, 3.0 / 2.0)
     )  # Eq. 18 in DV&S2012
 
-    return n_H
+    return n_Hc
 
 
 arguments = ScriptArgumentParser(

--- a/colibre/scripts/birth_density_distribution.py
+++ b/colibre/scripts/birth_density_distribution.py
@@ -39,8 +39,8 @@ def critical_density_DVS2012(
     X_H: Average mass fraction of hydrogen
 
     f_t: float
-        The ratio of the sound crossing time-scale (through an SPH kernel)
-        to the cooling time-scale (at temperature T_K)
+        The ratio of the cooling time-scale (at temperature T_K) to the sound crossing
+        time-scale (through the SPH kernel corresponding to M_gas and n_Hc)
 
     mu: Mean molecular weight of the heated gas (0.6 assumes the gas is fully ionised)
 


### PR DESCRIPTION
**1. Why this PR** 
There was a request to add the critical-density line from DV&S2012 

**2. The definition of the critical density** 
[Dalla Vecchia, Claudio; Schaye, Joop (2012)](https://ui.adsabs.harvard.edu/abs/2012MNRAS.426..140D/abstract), eq. 18


**3. Example of the new plots** 
Two plots have been modified

- Stellar birth-density distirbution
- SNII gas-density distribution

http://swift.dur.ac.uk/COLIBREPlots/chaikin/individual_runs/With_AGN/L006N188/With_BH_mergers/z0.0_EOS_gamma2_T8e3_n1e2_T20/