### PR TITLE
Make all HI, HII, H2 mass fraction plots compatible with CHIMES

### DIFF
--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -273,7 +273,7 @@ except AttributeError:
             self,
             f"gas_neutral_H_to_stellar_fraction_{aperture_size}_kpc",
             unyt.unyt_array(
-                catalogue.masses.m_gas,
+                ones,
                 name="$M_{{\\rm HI + H_2}} / M_*$ ({aperture_size} kpc) not found, showing $1$",
             ),
         )
@@ -281,7 +281,7 @@ except AttributeError:
             self,
             f"gas_molecular_H_to_molecular_plus_stellar_fraction_{aperture_size}_kpc",
             unyt.unyt_array(
-                catalogue.masses.m_gas,
+                ones,
                 name=f"$M_{{\\rm H_2}} / (M_* + M_{{\\rm H_2}})$ ({aperture_size} kpc) not found, showing $1$",
             ),
         )
@@ -289,7 +289,7 @@ except AttributeError:
             self,
             f"gas_molecular_H_to_neutral_fraction_{aperture_size}_kpc",
             unyt.unyt_array(
-                catalogue.masses.m_gas,
+                ones,
                 name=f"$M_{{\\rm H_2}} / M_{{\\rm HI + H_2}}$ ({aperture_size} kpc) not found, showing $1$",
             ),
         )

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -128,7 +128,7 @@ for aperture_size in aperture_sizes:
     setattr(self, f"stellar_mass_to_halo_mass_bn98_{aperture_size}_kpc", smhm)
 
 
-# if present iterate through available dust types
+# If present, iterate through available dust types
 try:
     dust_fields = []
     for sub_path in dir(catalogue.dust_mass_fractions):
@@ -146,12 +146,17 @@ total_dust_mass.name = name
 
 setattr(self, f"total_dust_masses_100_kpc", total_dust_mass)
 
-# Now HI masses
-
+# Get HI masses
 try:
     gas_mass = catalogue.masses.m_gas
     H_frac = getattr(catalogue.element_mass_fractions, "element_0")
-    HI_frac = getattr(catalogue.species_fractions, "species_0")
+
+    # Try CHIMES arrays
+    if hasattr(catalogue.species_fractions, "species_7"):
+        HI_frac = getattr(catalogue.species_fractions, "species_1")
+    # If species_7 doesn't exist, switch to the (default) Table-cooling case
+    else:
+        HI_frac = getattr(catalogue.species_fractions, "species_0")
 
     HI_mass = gas_mass * H_frac * HI_frac
     HI_mass.name = "$M_{\\rm HI}$"
@@ -167,15 +172,19 @@ except AttributeError:
         ),
     )
 
-
-# Now H2 masses
-
+# Get H2 masses
 try:
     gas_mass = catalogue.masses.m_gas
     H_frac = getattr(catalogue.element_mass_fractions, "element_0")
-    H2_frac = getattr(catalogue.species_fractions, "species_2")
 
-    H2_mass = gas_mass * H_frac * H2_frac * 2
+    # Try CHIMES arrays
+    if hasattr(catalogue.species_fractions, "species_7"):
+        H2_frac = getattr(catalogue.species_fractions, "species_7")
+    # If species_7 doesn't exist, switch to the (default) Table-cooling case
+    else:
+        H2_frac = getattr(catalogue.species_fractions, "species_2")
+
+    H2_mass = gas_mass * H_frac * H2_frac * 2.0
     H2_mass.name = "$M_{\\rm H_2}$"
 
     setattr(self, "gas_H2_mass_Msun", H2_mass)
@@ -189,13 +198,19 @@ except AttributeError:
         ),
     )
 
-# Now neutral H masses and fractions
-
+# Get neutral H masses and fractions
 try:
     gas_mass = catalogue.masses.m_gas
     H_frac = getattr(catalogue.element_mass_fractions, "element_0")
-    HI_frac = getattr(catalogue.species_fractions, "species_0")
-    H2_frac = getattr(catalogue.species_fractions, "species_2")
+
+    # Try CHIMES arrays
+    if hasattr(catalogue.species_fractions, "species_7"):
+        HI_frac = getattr(catalogue.species_fractions, "species_1")
+        H2_frac = getattr(catalogue.species_fractions, "species_7")
+    # If species_7 doesn't exist, switch to the (default) Table-cooling case
+    else:
+        HI_frac = getattr(catalogue.species_fractions, "species_0")
+        H2_frac = getattr(catalogue.species_fractions, "species_2")
 
     HI_mass = gas_mass * H_frac * HI_frac
     H2_mass = gas_mass * H_frac * H2_frac * 2


### PR DESCRIPTION
**Why this PR**
Currently, not all (cold) gas mass-fraction plots are compatible with `CHIMES`. That's because `Table` and `CHIMES` cooling have different indices for the same species arrays.

**Note that**
We discussed it some time ago, and there has already been a fix like this one but for different plots.