### PR TITLE
Strip _z???p??? suffixes in multi-z obs data in SMHM plots

### DIFF
--- a/colibre/auto_plotter/stellar_mass_halo_mass.yml
+++ b/colibre/auto_plotter/stellar_mass_halo_mass.yml
@@ -28,7 +28,7 @@ stellar_mass_halo_mass_M200_all_100:
     section: Stellar Mass-Halo Mass
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013.hdf5
-    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_z000p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200.hdf5
 
 stellar_mass_halo_mass_MBN98_all_100:
   type: "scatter"
@@ -59,8 +59,8 @@ stellar_mass_halo_mass_MBN98_all_100:
     caption: Includes all haloes, including subhaloes.
     section: Stellar Mass-Halo Mass
   observational_data:
-    - filename: GalaxyStellarMassHaloMass/Behroozi2019_z000p000.hdf5
-    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_z000p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98.hdf5
 
 stellar_mass_halo_mass_M200_centrals_100:
   type: "scatter"
@@ -94,7 +94,7 @@ stellar_mass_halo_mass_M200_centrals_100:
     section: Stellar Mass-Halo Mass
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013.hdf5
-    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_z000p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200.hdf5
 
 stellar_mass_halo_mass_MBN98_centrals_100:
   type: "scatter"
@@ -127,8 +127,8 @@ stellar_mass_halo_mass_MBN98_centrals_100:
     caption: Includes only central haloes.
     section: Stellar Mass-Halo Mass
   observational_data:
-    - filename: GalaxyStellarMassHaloMass/Behroozi2019_z000p000.hdf5
-    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_z000p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98.hdf5
       
 stellar_mass_halo_mass_M200_centrals_ratio_100:
   type: "scatter"
@@ -162,7 +162,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_100:
     section: Stellar Mass-Halo Mass
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013Ratio.hdf5
-    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_z000p000_Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_Ratio.hdf5
 
 stellar_mass_halo_mass_MBN98_centrals_ratio_100:
   type: "scatter"
@@ -195,8 +195,8 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_100:
     caption: Includes only central haloes.
     section: Stellar Mass-Halo Mass
   observational_data:
-    - filename: GalaxyStellarMassHaloMass/Behroozi2019Ratio_z000p000.hdf5
-    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_z000p000_Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_Ratio.hdf5
 
 stellar_mass_halo_mass_M200_centrals_ratio_stellar_100:
   type: "scatter"
@@ -230,7 +230,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_100:
     section: Stellar Mass-Halo Mass
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013RatioStellar.hdf5
-    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_z000p000_RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_RatioStellar.hdf5
       
 stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
   type: "scatter"
@@ -263,8 +263,8 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
     caption: Includes only central haloes.
     section: Stellar Mass-Halo Mass
   observational_data:
-    - filename: GalaxyStellarMassHaloMass/Behroozi2019RatioStellar_z000p000.hdf5
-    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_z000p000_RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_RatioStellar.hdf5
 
 stellar_mass_halo_mass_M200_all_30:
   type: "scatter"
@@ -297,7 +297,7 @@ stellar_mass_halo_mass_M200_all_30:
     show_on_webpage: false
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013.hdf5
-    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_z000p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200.hdf5
 
 stellar_mass_halo_mass_M200_centrals_30:
   type: "scatter"
@@ -332,7 +332,7 @@ stellar_mass_halo_mass_M200_centrals_30:
     show_on_webpage: false
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013.hdf5
-    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_z000p000.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200.hdf5
 
 stellar_mass_halo_mass_M200_centrals_ratio_30:
   type: "scatter"
@@ -367,7 +367,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_30:
     show_on_webpage: false
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013Ratio.hdf5
-    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_z000p000_Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_Ratio.hdf5
 
 stellar_mass_halo_mass_M200_centrals_ratio_stellar_30:
   type: "scatter"
@@ -402,4 +402,4 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_30:
     show_on_webpage: false
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013RatioStellar.hdf5
-    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_z000p000_RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_RatioStellar.hdf5


### PR DESCRIPTION
In this PR, I change the way multi-z observational data files are loaded for SMHM plots.

More precisely, we no longer need the suffixes `_z???p???` in Schaye15 and Berhoozi19 data files' names because multi-z data is now contained in a single `.hdf5` file.

This PR depends on [this PR](https://github.com/SWIFTSIM/velociraptor-comparison-data/pull/54). I.e. the latter needs to be merged first.