### PR TITLE
New dust plots

### DIFF
--- a/colibre/auto_plotter/depletion_relations.yml
+++ b/colibre/auto_plotter/depletion_relations.yml
@@ -1,0 +1,42 @@
+oxygen_abundance_v_dust_to_gas:
+  type: "scatter"
+  legend_loc: "lower right"
+  selection_mask: "derived_quantities.valid_abundances"
+  x:
+    quantity: "derived_quantities.gas_o_abundance"
+    units: "dimensionless"
+    start: 6.8
+    end: 9.2
+    log: false
+  y:
+    quantity: "derived_quantities.dust_to_gas_ratio_100_kpc"
+    units: "dimensionless"
+    start: 1e-7
+    end: 0.01
+  median:
+    plot: true
+    log: false
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 7
+      units: "dimensionless"
+    end:
+      value: 10
+      units: "dimensionless"
+    lower:
+      value: 0
+      units: "dimensionless"
+    upper:
+      value: 1
+      units: "dimensionless"
+  metadata:
+    title:  Oxygen abundance vs dust-to-gas ratio (100 kpc)
+    caption: Dust-to-gas mass ratio as a function of oxygen number density abundance.
+    section: Dust Depletion Relations
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyMetallicityDusttoGasRatio/RemyRuyer2014_Data_COMW.hdf5
+    - filename: GalaxyMetallicityDusttoGasRatio/RemyRuyer2014_BPL_COMW.hdf5
+    - filename: GalaxyMetallicityDusttoGasRatio/RemyRuyer2014_Data_COZ.hdf5
+    - filename: GalaxyMetallicityDusttoGasRatio/RemyRuyer2014_BPL_COZ.hdf5

--- a/colibre/auto_plotter/dust_scaling_relations.yml
+++ b/colibre/auto_plotter/dust_scaling_relations.yml
@@ -1,0 +1,104 @@
+hi_stellar_fraction_dust_to_metal_ratio:
+  type: "scatter"
+  legend_loc: "upper right"
+  selection_mask: "derived_quantities.is_active_100_kpc"
+  x:
+    quantity: "derived_quantities.dust_to_metal_ratio_100_kpc"
+    units: "dimensionless"
+    start: 1e-3
+    end: 5
+    log: true
+  y:
+    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    units: "dimensionless"
+    start: 3e-2
+    end: 5
+    log: true
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 1e-3
+      units: "dimensionless"
+    end:
+      value: 5
+      units: "dimensionless"
+  metadata:
+    title: HI-to-stellar mass ratio vs dust-to-metal ratio
+    caption: HI to stellar mass ratio as a function of the dust-to-metal ratio measured in 100kpc apertures
+    section: Dust Scaling Relations
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyHItoStellarFractionDusttoMetalRatio/DeLooze20_composite_median.hdf5
+
+hi_stellar_fraction_dust_to_stellar_ratio:
+  type: "scatter"
+  legend_loc: "upper right"
+  selection_mask: "derived_quantities.is_active_100_kpc"
+  x:
+    quantity: "derived_quantities.dust_to_stellar_ratio_100_kpc"
+    units: "dimensionless"
+    start: 1e-4
+    end: 1e-2
+    log: true
+  y:
+    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    units: "dimensionless"
+    start: 3e-2
+    end: 5
+    log: true
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 1e-4
+      units: "dimensionless"
+    end:
+      value: 1e-2
+      units: "dimensionless"
+  metadata:
+    title: HI-to-stellar mass ratio vs dust-to-stellar mass ratio
+    caption: HI to stellar mass ratio as a function of the dust-to-stellar mass ratio measured in 100kpc apertures
+    section: Dust Scaling Relations
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyHItoStellarFractionDusttoStellarRatio/DeLooze20_composite_median.hdf5
+
+hi_stellar_fraction_o_abundance:
+  type: "scatter"
+  legend_loc: "upper right"
+  selection_mask: "derived_quantities.is_active_100_kpc"
+  x:
+    quantity: "derived_quantities.gas_o_abundance"
+    units: "dimensionless"
+    start: 6.8
+    end: 9.2
+    log: false
+  y:
+    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    units: "dimensionless"
+    start: 3e-2
+    end: 5
+    log: true
+  median:
+    plot: true
+    log: false
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 6.8
+      units: "dimensionless"
+    end:
+      value: 9.2
+      units: "dimensionless"
+  metadata:
+    title: HI-to-stellar mass ratio vs Oxygen abundance
+    caption: HI to stellar mass ratio as a function of the gas-phase Oxygen abundance measured in 100kpc apertures
+    section: Dust Scaling Relations
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyHItoStellarFractionMetallicity/DeLooze20_composite_median.hdf5

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -10,7 +10,7 @@ auto_plotter_registration: registration.py
 
 # Location of the 'observational data' repository and its compiled
 # contents.
-observational_data_directory: ../../observational_data
+observational_data_directory: ../observational_data
 
 # Style sheet to be used throughout with plotting
 matplotlib_stylesheet: mnras.mplstyle
@@ -199,13 +199,6 @@ scripts:
     output_file: subgrid_density_temperature_HII.png
     section: Hydrogen Phase Density-Temperature
     title: HII
-  - filename: scripts/density_temperature_dust2metal.py
-    caption: Density-temperature diagram shaded by the total fraction of metals in the dust phase.
-    output_file: density_temperature_dust2metal.png
-    section: Density-Temperature
-    title: Dust-to-metal Ratio
-    additional_arguments:
-      quantity_type: hydro
   - filename: scripts/density_species_interp.py
     caption: Co-plot of species fractions (left y-axis) and the dust-to-metal ratio (right y-axis) as a function opf gas density. If available, solid green line shows explicitly modelled dust-to-metal ratio, while dashed green is interpolated from the Ploeckinger+20 tables.
     output_file: density_vs_species_fraction.png

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -10,7 +10,7 @@ auto_plotter_registration: registration.py
 
 # Location of the 'observational data' repository and its compiled
 # contents.
-observational_data_directory: ../observational_data
+observational_data_directory: ../../observational_data
 
 # Style sheet to be used throughout with plotting
 matplotlib_stylesheet: mnras.mplstyle
@@ -41,8 +41,6 @@ scripts:
     output_file: density_temperature_dust_to_metals.png
     section: Density-Temperature
     title: Density-Temperature (Dust / Metals)
-  - filename: scripts/density_internal_energy.py
-    caption: Density-Internal Energy diagram. If present, dashed line represents the entropy floor (equation of state).
   - filename: scripts/density_temperature_dust2metal.py
     caption: Density-temperature diagram shaded by the total fraction of metals in the dust phase.
     output_file: density_temperature_dust2metal.png
@@ -50,6 +48,8 @@ scripts:
     title: Dust-to-metal Ratio
     additional_arguments:
       quantity_type: hydro
+  - filename: scripts/density_internal_energy.py
+    caption: Density-Internal Energy diagram. If present, dashed line represents the entropy floor (equation of state).
     output_file: density_internal_energy.png
     section: Density-Temperature
     title: Density-Internal Energy
@@ -199,13 +199,6 @@ scripts:
     output_file: subgrid_density_temperature_HII.png
     section: Hydrogen Phase Density-Temperature
     title: HII
-  - filename: scripts_dev/dummy.py
-    caption: Density-temperature diagram shaded by the total fraction of metals in the dust phase.
-    output_file: density_temperature_dust2metal.png
-    section: Density-Temperature
-    title: Dust-to-metal Ratio
-    additional_arguments:
-      quantity_type: hydro
   - filename: scripts/density_temperature_dust2metal.py
     caption: Density-temperature diagram shaded by the total fraction of metals in the dust phase.
     output_file: density_temperature_dust2metal.png
@@ -221,27 +214,3 @@ scripts:
     additional_arguments:
       cooling_tables: /cosma7/data/dp004/wmfw23/colibre_dust/coolingtables/UV_dust1_CR1_G1_shield1.hdf5
       quantity_type: hydro
-  - filename: scripts/density_temperature_species.py
-    caption: Density-temperature diagram shaded by H2 mass fraction.
-    output_file: subgrid_density_temperature_H2.png
-    section: Hydrogen Phases
-    title: H2 subgrid phase diagram
-    additional_arguments:
-      hydrogen_species: H2
-      quantity_type: subgrid
-  - filename: scripts/density_temperature_species.py
-    caption: Density-temperature diagram shaded by HI mass fraction.
-    output_file: subgrid_density_temperature_HI.png
-    Section: Hydrogen Phases
-    title: HI subgrid phase diagram
-    additional_arguments:
-      hydrogen_species: HI
-      quantity_type: subgrid
-  - filename: scripts/density_temperature_species.py
-    caption: Density-temperature diagram shaded by HII mass fraction.
-    output_file: subgrid_density_temperature_HII.png
-    section: Hydrogen Phases
-    title: HII subgrid phase diagram
-    additional_arguments:
-      hydrogen_species: HII
-      quantity_type: subgrid

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -5,7 +5,7 @@
 # relation figures. Also required is the registration file
 # in the case where you have non-catalogue properties
 # used in the autoplotter.
-auto_plotter_directory: auto_plotter
+auto_plotter_directory: auto_plotter_dev
 auto_plotter_registration: registration.py
 
 # Location of the 'observational data' repository and its compiled
@@ -189,6 +189,164 @@ scripts:
       quantity_type: subgrid
   - filename: scripts/density_temperature_species.py
     caption: Density-temperature diagram shaded by HII mass fraction. The fraction is computed as the HII mass contained in each cell over the mass of gas in that cell.
+    output_file: subgrid_density_temperature_HII.png
+    section: Hydrogen Phase Density-Temperature
+    title: HII
+  - filename: scripts_dev/dummy.py
+    caption: Density-temperature diagram shaded by the total fraction of metals in the dust phase.
+    output_file: density_temperature_dust2metal.png
+    section: Density-Temperature
+    title: Dust-to-metal Ratio
+    additional_arguments:
+      quantity_type: hydro
+  - filename: scripts/density_temperature_dust2metal.py
+    caption: Density-temperature diagram shaded by the total fraction of metals in the dust phase.
+    output_file: density_temperature_dust2metal.png
+    section: Density-Temperature
+    title: Dust-to-metal Ratio
+    additional_arguments:
+      quantity_type: hydro
+  - filename: scripts/density_species_interp.py
+    caption: Co-plot of species fractions (left y-axis) and the dust-to-metal ratio (right y-axis) as a function opf gas density. If available, solid green line shows explicitly modelled dust-to-metal ratio, while dashed green is interpolated from the Ploeckinger+20 tables.
+    output_file: density_vs_species_fraction.png
+    section: Hydrogen phases
+    title: Hydrogen phases
+    additional_arguments:
+      cooling_tables: /cosma7/data/dp004/wmfw23/colibre_dust/coolingtables/UV_dust1_CR1_G1_shield1.hdf5
+      quantity_type: hydro
+  - filename: scripts/density_temperature.py
+    caption: Density-temperature diagram.
+    output_file: density_temperature.png
+    section: Density-Temperature
+    title: Density-Temperature
+  - filename: scripts/density_temperature_metals.py
+    caption: Density-temperature diagram with the pixel value weighted by the mean logrithmic metal mass fraction (absolute) in that bin. Medians are not used due to their computational complexity.
+    output_file: density_temperature_metals.png
+    section: Density-Temperature
+    title: Density-Temperature (Metals)
+  - filename: scripts/density_temperature_dust.py
+    caption: Density-temperature diagram with the pixel value weighted by the mean logrithmic dust mass fraction in that bin. Medians are not used due to their computational complexity.
+    output_file: density_temperature_dust.png
+    section: Density-Temperature
+    title: Density-Temperature (Dust)
+  - filename: scripts/density_internal_energy.py
+    caption: Density-Internal Energy diagram.
+    output_file: density_internal_energy.png
+    section: Density-Temperature
+    title: Density-Internal Energy
+  - filename: scripts/density_pressure.py
+    caption: Density-pressure diagram.
+    output_file: density_pressure.png
+    section: Density-Temperature
+    title: Density-Pressure
+  - filename: scripts/star_formation_history.py
+    caption: Star formation history plotted directly from the SFR.txt produced by SWIFT.
+    output_file: star_formation_history.png
+    section: Star Formation History
+    title: Star Formation History
+  - filename: scripts/metallicity_distribution.py
+    caption: Metal mass fraction distribution shown for each simulation; solid lines show gas metallicity and dashed lines show the same for the stars.
+    output_file: metallicity_distribution.png
+    section: Metal Mass Fractions
+    title: Metal Mass Fraction Distribution
+  - filename: scripts/birth_density_distribution.py
+    caption: Distributions of stellar birth densities, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars.
+    title: Stellar Birth Densities
+    section: Stellar Birth Densities
+    output_file: birth_density_distribution.png
+  - filename: scripts/birth_density_metallicity.py
+    caption: Stellar birth densities vs metallicity diagram. The pixel colour indicates the number of stellar particles in the pixel. At a given birth density, particles with metallicities lower than the smallest value along the Y axis are placed in the lowest-metallicity bin.
+    title: Stellar Birth Densities-Metallicity
+    section: Stellar Birth Densities
+    output_file: birth_density_metallicity.png
+  - filename: scripts/birth_density_redshift.py
+    caption: Stellar birth densities vs redshift diagram. The pixel colour indicates the number of stellar particles in the pixel.
+    title: Stellar Birth Densities-Redshift
+    section: Stellar Birth Densities
+    output_file: birth_density_redshift.png
+  - filename: scripts/metallicity_redshift.py
+    caption: Stellar metallicity vs redshift diagram. The pixel colour indicates the number of stellar particles in the pixel. At a given redshift, particles with metallicities lower than the smallest value along the X axis are placed in the lowest-metallicity bin.
+    title: Stellar Metallicity-Redshift
+    section: Stellar Birth Densities
+    output_file: metallicity_redshift.png
+  - filename: scripts/SNII_density_distribution.py
+    caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles.
+    title: Density of the gas heated by SNII
+    section: Feedback Densities
+    output_file: SNII_density_distribution.png
+  - filename: scripts/gas_metallicity_evolution.py
+    caption: Evolution of the metal mass in gas per unit co-moving volume.
+    output_file: gas_metallicity_evolution.png
+    section: Metal Evolution
+    title: Gas Phase Metal Mass Density Evolution
+  - filename: scripts/star_metallicity_evolution.py
+    caption: Evolution of the metal mass locked in stars per unit co-moving volume.
+    output_file: star_metallicity_evolution.png
+    section: Metal Evolution
+    title: Metal Mass Locked in Stars Density Evolution
+  - filename: scripts/bh_metallicity_evolution.py
+    caption: Evolution of the metal mass locked in black holes per unit co-moving volume.
+    output_file: bh_metallicity_evolution.png
+    section: Metal Evolution
+    title: Metal Mass Locked in Black Holes Density Evolution
+  - filename: scripts/bh_accretion_evolution.py
+    caption: Evolution of the accretion rate onto BHs per unit co-moving volume.
+    output_file: bh_accretion_evolution.png
+    section: Black Holes Evolution
+    title: Black Hole Accretion History
+  - filename: scripts/bh_mass_evolution.py
+    caption: Evolution of the BH mass per unit co-moving volume.
+    output_file: bh_mass_evolution.png
+    section: Black Holes Evolution
+    title: Black Hole Mass History
+  - filename: scripts/bh_masses.py
+    caption: Relation between black hole particle (dynamical) masses and subgrid masses. The vertical dashed lines shows the primordial gas particle mass and the horizontal dashed lines corresponds to the black hole seed mass.
+    output_file: bh_masses.png
+    section: Black Holes
+    title: Black Hole Dynanmical and Subgrid Masses
+  - filename: scripts/gas_masses.py
+    caption: Gas Particle Masses with the threshold for splitting indicated by the vertical dashed line.
+    output_file: gas_masses.png
+    section: Histograms
+    title: Gas Particle Masses
+  - filename: scripts/max_temperatures.py
+    caption: Maximal temperature recorded by gas particles throughout the entire simulation.
+    output_file: gas_max_temperatures.png
+    section: Histograms
+    title: Maximal Temperature reached by gas particles
+  - filename: scripts/wallclock_simulation_time.py
+    caption: The cosmic time as a function of the wall-clock time.
+    title: Cosmic time vs. wall-clock time
+    section: Run Performance
+    output_file: wallclock_simulation_time.png
+  - filename: scripts/wallclock_number_of_steps.py
+    caption: The cumulative number of the simulation time-steps as a function of the wall-clock time.
+    title: The number of steps vs. wall-clock time
+    section: Run Performance
+    output_file: wallclock_number_of_steps.png
+  - filename: scripts/simulation_time_number_of_steps.py
+    caption: The cumulative number of the simulation time-steps as a function of the cosmic time.
+    title: Number of steps vs. cosmic time
+    section: Run Performance
+    output_file: simulation_time_number_of_steps.png
+  - filename: scripts/density_temperature_species.py
+    caption: Density-temperature diagram shaded by H2 mass fraction.
+    output_file: subgrid_density_temperature_H2.png
+    section: Hydrogen Phase Density-Temperature
+    title: H2
+    additional_arguments:
+      hydrogen_species: H2
+      quantity_type: subgrid
+  - filename: scripts/density_temperature_species.py
+    caption: Density-temperature diagram shaded by HI mass fraction.
+    output_file: subgrid_density_temperature_HI.png
+    section: Hydrogen Phase Density-Temperature
+    title: HI
+    additional_arguments:
+      hydrogen_species: HI
+      quantity_type: subgrid
+  - filename: scripts/density_temperature_species.py
+    caption: Density-temperature diagram shaded by HII mass fraction.
     output_file: subgrid_density_temperature_HII.png
     section: Hydrogen Phase Density-Temperature
     title: HII

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -5,7 +5,7 @@
 # relation figures. Also required is the registration file
 # in the case where you have non-catalogue properties
 # used in the autoplotter.
-auto_plotter_directory: auto_plotter_dev
+auto_plotter_directory: auto_plotter
 auto_plotter_registration: registration.py
 
 # Location of the 'observational data' repository and its compiled
@@ -43,6 +43,13 @@ scripts:
     title: Density-Temperature (Dust / Metals)
   - filename: scripts/density_internal_energy.py
     caption: Density-Internal Energy diagram. If present, dashed line represents the entropy floor (equation of state).
+  - filename: scripts/density_temperature_dust2metal.py
+    caption: Density-temperature diagram shaded by the total fraction of metals in the dust phase.
+    output_file: density_temperature_dust2metal.png
+    section: Density-Temperature
+    title: Dust-to-metal Ratio
+    additional_arguments:
+      quantity_type: hydro
     output_file: density_internal_energy.png
     section: Density-Temperature
     title: Density-Internal Energy
@@ -209,147 +216,32 @@ scripts:
   - filename: scripts/density_species_interp.py
     caption: Co-plot of species fractions (left y-axis) and the dust-to-metal ratio (right y-axis) as a function opf gas density. If available, solid green line shows explicitly modelled dust-to-metal ratio, while dashed green is interpolated from the Ploeckinger+20 tables.
     output_file: density_vs_species_fraction.png
-    section: Hydrogen phases
-    title: Hydrogen phases
+    section: Hydrogen Phases
+    title: Hydrogen Phase Fractions
     additional_arguments:
       cooling_tables: /cosma7/data/dp004/wmfw23/colibre_dust/coolingtables/UV_dust1_CR1_G1_shield1.hdf5
       quantity_type: hydro
-  - filename: scripts/density_temperature.py
-    caption: Density-temperature diagram.
-    output_file: density_temperature.png
-    section: Density-Temperature
-    title: Density-Temperature
-  - filename: scripts/density_temperature_metals.py
-    caption: Density-temperature diagram with the pixel value weighted by the mean logrithmic metal mass fraction (absolute) in that bin. Medians are not used due to their computational complexity.
-    output_file: density_temperature_metals.png
-    section: Density-Temperature
-    title: Density-Temperature (Metals)
-  - filename: scripts/density_temperature_dust.py
-    caption: Density-temperature diagram with the pixel value weighted by the mean logrithmic dust mass fraction in that bin. Medians are not used due to their computational complexity.
-    output_file: density_temperature_dust.png
-    section: Density-Temperature
-    title: Density-Temperature (Dust)
-  - filename: scripts/density_internal_energy.py
-    caption: Density-Internal Energy diagram.
-    output_file: density_internal_energy.png
-    section: Density-Temperature
-    title: Density-Internal Energy
-  - filename: scripts/density_pressure.py
-    caption: Density-pressure diagram.
-    output_file: density_pressure.png
-    section: Density-Temperature
-    title: Density-Pressure
-  - filename: scripts/star_formation_history.py
-    caption: Star formation history plotted directly from the SFR.txt produced by SWIFT.
-    output_file: star_formation_history.png
-    section: Star Formation History
-    title: Star Formation History
-  - filename: scripts/metallicity_distribution.py
-    caption: Metal mass fraction distribution shown for each simulation; solid lines show gas metallicity and dashed lines show the same for the stars.
-    output_file: metallicity_distribution.png
-    section: Metal Mass Fractions
-    title: Metal Mass Fraction Distribution
-  - filename: scripts/birth_density_distribution.py
-    caption: Distributions of stellar birth densities, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars.
-    title: Stellar Birth Densities
-    section: Stellar Birth Densities
-    output_file: birth_density_distribution.png
-  - filename: scripts/birth_density_metallicity.py
-    caption: Stellar birth densities vs metallicity diagram. The pixel colour indicates the number of stellar particles in the pixel. At a given birth density, particles with metallicities lower than the smallest value along the Y axis are placed in the lowest-metallicity bin.
-    title: Stellar Birth Densities-Metallicity
-    section: Stellar Birth Densities
-    output_file: birth_density_metallicity.png
-  - filename: scripts/birth_density_redshift.py
-    caption: Stellar birth densities vs redshift diagram. The pixel colour indicates the number of stellar particles in the pixel.
-    title: Stellar Birth Densities-Redshift
-    section: Stellar Birth Densities
-    output_file: birth_density_redshift.png
-  - filename: scripts/metallicity_redshift.py
-    caption: Stellar metallicity vs redshift diagram. The pixel colour indicates the number of stellar particles in the pixel. At a given redshift, particles with metallicities lower than the smallest value along the X axis are placed in the lowest-metallicity bin.
-    title: Stellar Metallicity-Redshift
-    section: Stellar Birth Densities
-    output_file: metallicity_redshift.png
-  - filename: scripts/SNII_density_distribution.py
-    caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles.
-    title: Density of the gas heated by SNII
-    section: Feedback Densities
-    output_file: SNII_density_distribution.png
-  - filename: scripts/gas_metallicity_evolution.py
-    caption: Evolution of the metal mass in gas per unit co-moving volume.
-    output_file: gas_metallicity_evolution.png
-    section: Metal Evolution
-    title: Gas Phase Metal Mass Density Evolution
-  - filename: scripts/star_metallicity_evolution.py
-    caption: Evolution of the metal mass locked in stars per unit co-moving volume.
-    output_file: star_metallicity_evolution.png
-    section: Metal Evolution
-    title: Metal Mass Locked in Stars Density Evolution
-  - filename: scripts/bh_metallicity_evolution.py
-    caption: Evolution of the metal mass locked in black holes per unit co-moving volume.
-    output_file: bh_metallicity_evolution.png
-    section: Metal Evolution
-    title: Metal Mass Locked in Black Holes Density Evolution
-  - filename: scripts/bh_accretion_evolution.py
-    caption: Evolution of the accretion rate onto BHs per unit co-moving volume.
-    output_file: bh_accretion_evolution.png
-    section: Black Holes Evolution
-    title: Black Hole Accretion History
-  - filename: scripts/bh_mass_evolution.py
-    caption: Evolution of the BH mass per unit co-moving volume.
-    output_file: bh_mass_evolution.png
-    section: Black Holes Evolution
-    title: Black Hole Mass History
-  - filename: scripts/bh_masses.py
-    caption: Relation between black hole particle (dynamical) masses and subgrid masses. The vertical dashed lines shows the primordial gas particle mass and the horizontal dashed lines corresponds to the black hole seed mass.
-    output_file: bh_masses.png
-    section: Black Holes
-    title: Black Hole Dynanmical and Subgrid Masses
-  - filename: scripts/gas_masses.py
-    caption: Gas Particle Masses with the threshold for splitting indicated by the vertical dashed line.
-    output_file: gas_masses.png
-    section: Histograms
-    title: Gas Particle Masses
-  - filename: scripts/max_temperatures.py
-    caption: Maximal temperature recorded by gas particles throughout the entire simulation.
-    output_file: gas_max_temperatures.png
-    section: Histograms
-    title: Maximal Temperature reached by gas particles
-  - filename: scripts/wallclock_simulation_time.py
-    caption: The cosmic time as a function of the wall-clock time.
-    title: Cosmic time vs. wall-clock time
-    section: Run Performance
-    output_file: wallclock_simulation_time.png
-  - filename: scripts/wallclock_number_of_steps.py
-    caption: The cumulative number of the simulation time-steps as a function of the wall-clock time.
-    title: The number of steps vs. wall-clock time
-    section: Run Performance
-    output_file: wallclock_number_of_steps.png
-  - filename: scripts/simulation_time_number_of_steps.py
-    caption: The cumulative number of the simulation time-steps as a function of the cosmic time.
-    title: Number of steps vs. cosmic time
-    section: Run Performance
-    output_file: simulation_time_number_of_steps.png
   - filename: scripts/density_temperature_species.py
     caption: Density-temperature diagram shaded by H2 mass fraction.
     output_file: subgrid_density_temperature_H2.png
-    section: Hydrogen Phase Density-Temperature
-    title: H2
+    section: Hydrogen Phases
+    title: H2 subgrid phase diagram
     additional_arguments:
       hydrogen_species: H2
       quantity_type: subgrid
   - filename: scripts/density_temperature_species.py
     caption: Density-temperature diagram shaded by HI mass fraction.
     output_file: subgrid_density_temperature_HI.png
-    section: Hydrogen Phase Density-Temperature
-    title: HI
+    Section: Hydrogen Phases
+    title: HI subgrid phase diagram
     additional_arguments:
       hydrogen_species: HI
       quantity_type: subgrid
   - filename: scripts/density_temperature_species.py
     caption: Density-temperature diagram shaded by HII mass fraction.
     output_file: subgrid_density_temperature_HII.png
-    section: Hydrogen Phase Density-Temperature
-    title: HII
+    section: Hydrogen Phases
+    title: HII subgrid phase diagram
     additional_arguments:
       hydrogen_species: HII
       quantity_type: subgrid

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -145,52 +145,34 @@ except AttributeError:
 total_dust_mass = total_dust_fraction * catalogue.masses.m_gas
 name = f"$M_{{\\rm dust}}${dust_frac_error}"
 total_dust_mass.name = name
-total_dust_fraction.name = f"$\\mathcal{DTG}${dust_frac_error}"
+total_dust_fraction.name = f"$\\mathcal{{DTG}}${dust_frac_error}"
 total_dust_mass = total_dust_fraction * catalogue.masses.m_gas
-total_dust_mass.name = f"$M_{\\rm dust}${dust_frac_error}"
+total_dust_mass.name = f"$M_{{\\rm dust}}${dust_frac_error}"
 dust_to_metals = total_dust_fraction / metal_frac
-dust_to_metals.name = f"$\\mathcal{DTM}${dust_frac_error}"
+dust_to_metals.name = f"$\\mathcal{{DTM}}${dust_frac_error}"
+dust_to_stars = total_dust_mass / catalogue.apertures.mass_star_100_kpc
+dust_to_stars.name = f"$M_{{\\rm dust}}/M_*${dust_frac_error}"
 
 nonmetal_frac = 1. - catalogue.apertures.zmet_gas_sf_100_kpc
     
 setattr(self, f"total_dust_masses_100_kpc", total_dust_mass)
 setattr(self, f"dust_to_metal_ratio_100_kpc", dust_to_metals)
 setattr(self, f"dust_to_gas_ratio_100_kpc", total_dust_fraction)
+setattr(self, f"dust_to_stellar_ratio_100_kpc", dust_to_stars)
 
 # Get depletion properties
 try:
     gas_mass = catalogue.masses.m_gas
     H_frac = getattr(catalogue.element_mass_fractions, "element_0")
-    C_frac = getattr(catalogue.element_mass_fractions, "element_2")
     O_frac = getattr(catalogue.element_mass_fractions, "element_4")
-    Mg_frac = getattr(catalogue.element_mass_fractions, "element_6")
-    Si_frac = getattr(catalogue.element_mass_fractions, "element_7")
-    Fe_frac = getattr(catalogue.element_mass_fractions, "element_8")
-
-    # want [Zn/Fe], but no Zn. assume Zn undepleted (decent approx wrt Fe),
-    # and follows general Fe yield
-    zn_to_fe_abundance_estimate =  unyt.unyt_array(np.log10(
-        Fe_frac / (Fe_frac - 0.2934*catalogue.dust_mass_fractions.dust_1)),
-        "dimensionless")
-    zn_to_fe_abundance_estimate.name = "${{\\rm [Zn/Fe]}}$"
-
+    
     o_abundance = unyt.unyt_array(
         12+np.log10(O_frac/(16*H_frac)), "dimensionless")
-    o_abundance.name = "$12+\\log_10({{\\rm O/H}})$" 
-
-    setattr(self, "gas_zn_to_fe_abundance_estimate", zn_to_fe_abundance_estimate)
+    o_abundance.name = "$12+\\log_{10}({{\\rm O/H}})$" 
     setattr(self, "gas_o_abundance", o_abundance)
     
 except AttributeError:
     # We did not produce these quantities.
-    setattr(
-        self,
-        "gas_zn_to_fe_abundance_estimate",
-        unyt.unyt_array(
-            catalogue.masses.m_gas**0,
-            name="${{\\rm [Zn/Fe]}}$ not found, default to 1s"
-        ),
-    )
     setattr(
         self,
         "gas_o_abundance",
@@ -202,8 +184,7 @@ except AttributeError:
 
 
 # mask galaxies where abundances are well defined
-self.valid_abundances = np.logical_and(np.isfinite(dust_to_metals),
-                                       np.isfinite(zn_to_fe_abundance_estimate))
+self.valid_abundances = np.isfinite(dust_to_metals)
 
 # Get HI masses
 try:
@@ -237,10 +218,7 @@ except AttributeError:
 # Get HI to dust ratio
 try:
     dust_to_hi_ratio = total_dust_mass / HI_mass
-    dust_to_hi_ratio.name = "M_{{\\rm dust}}/M_{{\\rm HI}}"
-
-    grunt
-    
+    dust_to_hi_ratio.name = "M_{{\\rm dust}}/M_{{\\rm HI}}"    
     setattr(self, "gas_dust_to_hi_ratio", dust_to_hi_ratio)
     
 except AttributeError:

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -111,6 +111,8 @@ for aperture_size in aperture_sizes:
     except AttributeError:
         pass
 
+metal_frac = catalogue.apertures.zmet_gas_sf_100_kpc
+nonmetal_frac = 1.-metal_frac
 
 for aperture_size in aperture_sizes:
     stellar_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
@@ -143,9 +145,65 @@ except AttributeError:
 total_dust_mass = total_dust_fraction * catalogue.masses.m_gas
 name = f"$M_{{\\rm dust}}${dust_frac_error}"
 total_dust_mass.name = name
-nonmetal_frac = 1. - catalogue.apertures.zmet_gas_sf_100_kpc
+total_dust_fraction.name = f"$\\mathcal{DTG}${dust_frac_error}"
+total_dust_mass = total_dust_fraction * catalogue.masses.m_gas
+total_dust_mass.name = f"$M_{\\rm dust}${dust_frac_error}"
+dust_to_metals = total_dust_fraction / metal_frac
+dust_to_metals.name = f"$\\mathcal{DTM}${dust_frac_error}"
 
+nonmetal_frac = 1. - catalogue.apertures.zmet_gas_sf_100_kpc
+    
 setattr(self, f"total_dust_masses_100_kpc", total_dust_mass)
+setattr(self, f"dust_to_metal_ratio_100_kpc", dust_to_metals)
+setattr(self, f"dust_to_gas_ratio_100_kpc", total_dust_fraction)
+
+# Get depletion properties
+try:
+    gas_mass = catalogue.masses.m_gas
+    H_frac = getattr(catalogue.element_mass_fractions, "element_0")
+    C_frac = getattr(catalogue.element_mass_fractions, "element_2")
+    O_frac = getattr(catalogue.element_mass_fractions, "element_4")
+    Mg_frac = getattr(catalogue.element_mass_fractions, "element_6")
+    Si_frac = getattr(catalogue.element_mass_fractions, "element_7")
+    Fe_frac = getattr(catalogue.element_mass_fractions, "element_8")
+
+    # want [Zn/Fe], but no Zn. assume Zn undepleted (decent approx wrt Fe),
+    # and follows general Fe yield
+    zn_to_fe_abundance_estimate =  unyt.unyt_array(np.log10(
+        Fe_frac / (Fe_frac - 0.2934*catalogue.dust_mass_fractions.dust_1)),
+        "dimensionless")
+    zn_to_fe_abundance_estimate.name = "${{\\rm [Zn/Fe]}}$"
+
+    o_abundance = unyt.unyt_array(
+        12+np.log10(O_frac/(16*H_frac)), "dimensionless")
+    o_abundance.name = "$12+\\log_10({{\\rm O/H}})$" 
+
+    setattr(self, "gas_zn_to_fe_abundance_estimate", zn_to_fe_abundance_estimate)
+    setattr(self, "gas_o_abundance", o_abundance)
+    
+except AttributeError:
+    # We did not produce these quantities.
+    setattr(
+        self,
+        "gas_zn_to_fe_abundance_estimate",
+        unyt.unyt_array(
+            catalogue.masses.m_gas**0,
+            name="${{\\rm [Zn/Fe]}}$ not found, default to 1s"
+        ),
+    )
+    setattr(
+        self,
+        "gas_o_abundance",
+        unyt.unyt_array(
+            catalogue.masses.m_gas**0,
+            name="$12+\\log_10({{\\rm O/H}})$ not found, default to 1s"
+        ),
+    )
+
+
+# mask galaxies where abundances are well defined
+self.valid_abundances = np.logical_and(np.isfinite(dust_to_metals),
+                                       np.isfinite(zn_to_fe_abundance_estimate))
 
 # Get HI masses
 try:
@@ -175,6 +233,27 @@ except AttributeError:
             catalogue.masses.m_gas, name="$M{\\rm HI}$ not found, showing $M_{\\rm g}$"
         ),
     )
+
+# Get HI to dust ratio
+try:
+    dust_to_hi_ratio = total_dust_mass / HI_mass
+    dust_to_hi_ratio.name = "M_{{\\rm dust}}/M_{{\\rm HI}}"
+
+    grunt
+    
+    setattr(self, "gas_dust_to_hi_ratio", dust_to_hi_ratio)
+    
+except AttributeError:
+    # We did not produce these quantities.
+    setattr(
+        self,
+        "gas_dust_to_hi_ratio",
+        unyt.unyt_array(
+            catalogue.masses.m_gas**0,
+            name="$M_{{\\rm dust}}/M_{{\\rm HI}}$ not found, default to 1s"
+        ),
+    )
+
 
 # Get H2 masses
 try:

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -587,6 +587,9 @@ self.h2_plus_he_to_stellar_mass_100_kpc = (
 self.hi_plus_he_to_stellar_mass_100_kpc = (
     HI_mass_wHe / catalogue.apertures.mass_star_100_kpc
 )
+self.cold_gas_to_stellar_mass_100_kpc = (
+    (HI_mass_wHe + H2_mass_wHe) / catalogue.apertures.mass_star_100_kpc
+)
 
 
 self.neutral_to_stellar_mass_100_kpc = (self.hi_to_stellar_mass_100_kpc +

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -111,8 +111,8 @@ for aperture_size in aperture_sizes:
     except AttributeError:
         pass
 
-metal_frac = catalogue.apertures.zmet_gas_sf_100_kpc
-nonmetal_frac = 1.-metal_frac
+metal_frac = catalogue.apertures.zmet_gas_100_kpc
+nonmetal_frac = 1.0 - metal_frac
 
 for aperture_size in aperture_sizes:
     stellar_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
@@ -141,7 +141,7 @@ try:
 except AttributeError:
     total_dust_fraction = np.zeros(stellar_mass.size)
     dust_frac_error = " (no dust field)"
-    
+
 total_dust_mass = total_dust_fraction * catalogue.masses.m_gas
 name = f"$M_{{\\rm dust}}${dust_frac_error}"
 total_dust_mass.name = name
@@ -153,8 +153,8 @@ dust_to_metals.name = f"$\\mathcal{{DTM}}${dust_frac_error}"
 dust_to_stars = total_dust_mass / catalogue.apertures.mass_star_100_kpc
 dust_to_stars.name = f"$M_{{\\rm dust}}/M_*${dust_frac_error}"
 
-nonmetal_frac = 1. - catalogue.apertures.zmet_gas_sf_100_kpc
-    
+nonmetal_frac = 1.0 - catalogue.apertures.zmet_gas_100_kpc
+
 setattr(self, f"total_dust_masses_100_kpc", total_dust_mass)
 setattr(self, f"dust_to_metal_ratio_100_kpc", dust_to_metals)
 setattr(self, f"dust_to_gas_ratio_100_kpc", total_dust_fraction)
@@ -162,23 +162,24 @@ setattr(self, f"dust_to_stellar_ratio_100_kpc", dust_to_stars)
 
 # Get depletion properties
 try:
+    # Abundances measured over entire subhalo, using VR additional properties
     gas_mass = catalogue.masses.m_gas
     H_frac = getattr(catalogue.element_mass_fractions, "element_0")
     O_frac = getattr(catalogue.element_mass_fractions, "element_4")
-    
     o_abundance = unyt.unyt_array(
-        12+np.log10(O_frac/(16*H_frac)), "dimensionless")
-    o_abundance.name = "$12+\\log_{10}({{\\rm O/H}})$" 
+        12 + np.log10(O_frac / (16 * H_frac)), "dimensionless"
+    )
+    o_abundance.name = "Gas $12+\\log_{10}({{\\rm O/H}})$"
     setattr(self, "gas_o_abundance", o_abundance)
-    
+
 except AttributeError:
     # We did not produce these quantities.
     setattr(
         self,
         "gas_o_abundance",
         unyt.unyt_array(
-            catalogue.masses.m_gas**0,
-            name="$12+\\log_10({{\\rm O/H}})$ not found, default to 1s"
+            unyt.unyt_array(np.ones(np.size(catalogue.masses.m_gas)), "dimensionless"),
+            name="$12+\\log_10({{\\rm O/H}})$ not found, default to 1s",
         ),
     )
 
@@ -204,7 +205,7 @@ try:
 
     setattr(self, "gas_HI_mass", HI_mass)
     setattr(self, "gas_HI_plus_He_mass", HI_mass_wHe)
-    
+
 except AttributeError:
     # We did not produce these quantities.
     setattr(
@@ -218,17 +219,17 @@ except AttributeError:
 # Get HI to dust ratio
 try:
     dust_to_hi_ratio = total_dust_mass / HI_mass
-    dust_to_hi_ratio.name = "M_{{\\rm dust}}/M_{{\\rm HI}}"    
+    dust_to_hi_ratio.name = "M_{{\\rm dust}}/M_{{\\rm HI}}"
     setattr(self, "gas_dust_to_hi_ratio", dust_to_hi_ratio)
-    
+
 except AttributeError:
     # We did not produce these quantities.
     setattr(
         self,
         "gas_dust_to_hi_ratio",
         unyt.unyt_array(
-            catalogue.masses.m_gas**0,
-            name="$M_{{\\rm dust}}/M_{{\\rm HI}}$ not found, default to 1s"
+            unyt.unyt_array(np.ones(np.size(catalogue.masses.m_gas)), "dimensionless"),
+            name="$M_{{\\rm dust}}/M_{{\\rm HI}}$ not found, default to 1s",
         ),
     )
 
@@ -248,7 +249,7 @@ try:
     H2_mass = gas_mass * H_frac * H2_frac * 2.0
     H2_mass_wHe = gas_mass * nonmetal_frac * H2_frac * 2.0
     H2_mass.name = "$M_{\\rm H_2}$"
-    
+
     setattr(self, "gas_H2_mass", H2_mass)
     setattr(self, "gas_H2_plus_He_mass", H2_mass_wHe)
 
@@ -304,11 +305,12 @@ try:
         )
 
         neutral_H_to_baryonic_fraction = neutral_H_mass / (
-            neutral_H_mass + stellar_mass)
+            neutral_H_mass + stellar_mass
+        )
         neutral_H_to_baryonic_fraction.name = (
             f"$M_{{\\rm HI + H_2}}/((M_*+ M_{{\\rm HI + H_2}})$ ({aperture_size} kpc)"
         )
-        
+
         HI_to_neutral_H_fraction = HI_mass / neutral_H_mass
         HI_to_neutral_H_fraction.name = (
             f"$M_{{\\rm HI}}/M_{{\\rm HI + H_2}}$ ({aperture_size} kpc)"
@@ -318,38 +320,37 @@ try:
         H2_to_neutral_H_fraction.name = (
             f"$M_{{\\rm H_2}}/M_{{\\rm HI + H_2}}$ ({aperture_size} kpc)"
         )
-        
-        sf_to_sf_plus_stellar_fraction = sf_mass / (
-            sf_mass + stellar_mass)
+
+        sf_to_sf_plus_stellar_fraction = sf_mass / (sf_mass + stellar_mass)
         sf_to_sf_plus_stellar_fraction.name = (
             f"$M_{{\\rm SF}}/(M_{{\\rm SF}} + M_*)$ ({aperture_size} kpc)"
         )
 
         mask = sf_mass > 0.0 * sf_mass.units
 
-        neutral_H_to_sf_fraction = unyt.unyt_array(np.zeros_like(neutral_H_mass), units="dimensionless")
+        neutral_H_to_sf_fraction = unyt.unyt_array(
+            np.zeros_like(neutral_H_mass), units="dimensionless"
+        )
         neutral_H_to_sf_fraction[mask] = neutral_H_mass[mask] / sf_mass[mask]
         neutral_H_to_sf_fraction.name = (
             f"$M_{{\\rm HI + H_2}}/M_{{\\rm SF}}$ ({aperture_size} kpc)"
         )
 
-        HI_to_sf_fraction = unyt.unyt_array(np.zeros_like(HI_mass), units="dimensionless")
+        HI_to_sf_fraction = unyt.unyt_array(
+            np.zeros_like(HI_mass), units="dimensionless"
+        )
         HI_to_sf_fraction[mask] = HI_mass[mask] / sf_mass[mask]
-        HI_to_sf_fraction.name = (
-            f"$M_{{\\rm HI}}/M_{{\\rm SF}}$ ({aperture_size} kpc)"
-        )
+        HI_to_sf_fraction.name = f"$M_{{\\rm HI}}/M_{{\\rm SF}}$ ({aperture_size} kpc)"
 
-        H2_to_sf_fraction = unyt.unyt_array(np.zeros_like(H2_mass), units="dimensionless")
-        H2_to_sf_fraction[mask] = H2_mass[mask] / sf_mass[mask]
-        H2_to_sf_fraction.name = (
-            f"$M_{{\\rm H_2}}/M_{{\\rm SF}}$ ({aperture_size} kpc)"
+        H2_to_sf_fraction = unyt.unyt_array(
+            np.zeros_like(H2_mass), units="dimensionless"
         )
+        H2_to_sf_fraction[mask] = H2_mass[mask] / sf_mass[mask]
+        H2_to_sf_fraction.name = f"$M_{{\\rm H_2}}/M_{{\\rm SF}}$ ({aperture_size} kpc)"
 
         sf_to_stellar_fraction = sf_mass / stellar_mass
-        sf_to_stellar_fraction.name = (
-            f"$M_{{\\rm SF}}/M_*$ ({aperture_size} kpc)"
-        )
-        
+        sf_to_stellar_fraction.name = f"$M_{{\\rm SF}}/M_*$ ({aperture_size} kpc)"
+
         setattr(
             self,
             f"gas_neutral_H_to_stellar_fraction_{aperture_size}_kpc",
@@ -391,14 +392,10 @@ try:
             neutral_H_to_sf_fraction,
         )
         setattr(
-            self,
-            f"gas_HI_to_sf_fraction_{aperture_size}_kpc",
-            HI_to_sf_fraction,
+            self, f"gas_HI_to_sf_fraction_{aperture_size}_kpc", HI_to_sf_fraction,
         )
         setattr(
-            self,
-            f"gas_H2_to_sf_fraction_{aperture_size}_kpc",
-            H2_to_sf_fraction,
+            self, f"gas_H2_to_sf_fraction_{aperture_size}_kpc", H2_to_sf_fraction,
         )
         setattr(
             self,
@@ -406,11 +403,9 @@ try:
             sf_to_stellar_fraction,
         )
         setattr(
-            self,
-            f"has_neutral_gas_{aperture_size}_kpc",
-            neutral_H_mass > 0.,
+            self, f"has_neutral_gas_{aperture_size}_kpc", neutral_H_mass > 0.0,
         )
-        
+
 except AttributeError:
     # We did not produce these quantities.
     setattr(
@@ -453,73 +448,47 @@ except AttributeError:
         setattr(
             self,
             f"gas_neutral_H_to_baryonic_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(
-                ones,
-                name="Fraction not found, showing $1$",
-            ),
+            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
         )
         setattr(
             self,
             f"gas_HI_to_neutral_H_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(
-                ones,
-                name="Fraction not found, showing $1$",
-            ),
+            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
         )
         setattr(
             self,
             f"gas_H2_to_neutral_H_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(
-                ones,
-                name="Fraction not found, showing $1$",
-            ),
+            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
         )
         setattr(
             self,
             f"gas_sf_to_sf_plus_stellar_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(
-                ones,
-                name="Fraction not found, showing $1$",
-            ),
+            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
         )
         setattr(
             self,
             f"gas_neutral_H_to_sf_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(
-                ones,
-                name="Fraction not found, showing $1$",
-            ),
+            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
         )
         setattr(
             self,
             f"gas_HI_to_sf_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(
-                ones,
-                name="Fraction not found, showing $1$",
-            ),
+            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
         )
         setattr(
             self,
             f"gas_H2_to_sf_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(
-                ones,
-                name="Fraction not found, showing $1$",
-            ),
+            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
         )
         setattr(
             self,
             f"gas_sf_to_stellar_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(
-                ones,
-                name="Fraction not found, showing $1$",
-            ),
+            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
         )
         setattr(
-            self,
-            f"has_neutral_gas_{aperture_size}_kpc",
-            ones.astype(bool),
+            self, f"has_neutral_gas_{aperture_size}_kpc", ones.astype(bool),
         )
-        
+
 # species fraction properties
 gas_mass = catalogue.apertures.mass_gas_100_kpc
 gal_area = (
@@ -588,21 +557,28 @@ self.hi_plus_he_to_stellar_mass_100_kpc = (
     HI_mass_wHe / catalogue.apertures.mass_star_100_kpc
 )
 self.cold_gas_to_stellar_mass_100_kpc = (
-    (HI_mass_wHe + H2_mass_wHe) / catalogue.apertures.mass_star_100_kpc
+    HI_mass_wHe + H2_mass_wHe
+) / catalogue.apertures.mass_star_100_kpc
+
+
+self.neutral_to_stellar_mass_100_kpc = (
+    self.hi_to_stellar_mass_100_kpc + self.h2_to_stellar_mass_100_kpc
 )
-
-
-self.neutral_to_stellar_mass_100_kpc = (self.hi_to_stellar_mass_100_kpc +
-                                         self.h2_to_stellar_mass_100_kpc)
 
 self.neutral_hydrogen_mass_100_kpc.name = f"HI Mass (100 kpc){total_error}"
 self.hi_to_stellar_mass_100_kpc.name = f"$M_{{\\rm HI}} / M_*$ (100 kpc) {total_error}"
 self.molecular_hydrogen_mass_100_kpc.name = f"H$_2$ Mass (100 kpc){total_error}"
 self.h2_to_stellar_mass_100_kpc.name = f"$M_{{\\rm H_2}} / M_*$ (100 kpc) {total_error}"
-self.h2_plus_he_to_stellar_mass_100_kpc.name = f"$M_{{\\rm H_2}} / M_*$ (100 kpc, inc. He) {total_error}"
-self.hi_plus_he_to_stellar_mass_100_kpc.name = f"$M_{{\\rm HI}} / M_*$ (100 kpc, inc. He) {total_error}"
+self.h2_plus_he_to_stellar_mass_100_kpc.name = (
+    f"$M_{{\\rm H_2}} / M_*$ (100 kpc, inc. He) {total_error}"
+)
+self.hi_plus_he_to_stellar_mass_100_kpc.name = (
+    f"$M_{{\\rm HI}} / M_*$ (100 kpc, inc. He) {total_error}"
+)
 
-self.neutral_to_stellar_mass_100_kpc.name = f"$M_{{\\rm HI + H_2}} / M_*$ (100 kpc) {total_error}"
+self.neutral_to_stellar_mass_100_kpc.name = (
+    f"$M_{{\\rm HI + H_2}} / M_*$ (100 kpc) {total_error}"
+)
 
 # Formatting script for average of the log of stellar birth densities
 try:

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -165,6 +165,7 @@ try:
 
     setattr(self, "gas_HI_mass", HI_mass)
     setattr(self, "gas_HI_plus_He_mass", HI_mass_wHe)
+    
 except AttributeError:
     # We did not produce these quantities.
     setattr(
@@ -193,6 +194,7 @@ try:
     
     setattr(self, "gas_H2_mass", H2_mass)
     setattr(self, "gas_H2_plus_He_mass", H2_mass_wHe)
+
 except AttributeError:
     # We did not produce these quantities.
     setattr(
@@ -459,7 +461,8 @@ except AttributeError:
             self,
             f"has_neutral_gas_{aperture_size}_kpc",
             ones.astype(bool),
-        )     
+        )
+        
 # species fraction properties
 gas_mass = catalogue.apertures.mass_gas_100_kpc
 gal_area = (

--- a/colibre/scripts/density_species_interp.py
+++ b/colibre/scripts/density_species_interp.py
@@ -1,0 +1,339 @@
+"""
+Makes a rho-T plot. Uses the swiftsimio library.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import glob
+
+import swiftsimio as sw
+print(sw.__file__)
+from swiftsimio import load
+import h5py as h5
+
+from unyt import mh, cm
+from matplotlib.colors import LogNorm, ListedColormap, BoundaryNorm
+from matplotlib.animation import FuncAnimation
+from matplotlib.cm import get_cmap
+from scipy.interpolate import interpn
+
+# Set the limits of the figure.
+density_bounds = [1e-3, 1e3]  # in nh/cm^3
+temperature_bounds = [10 ** (0), 10 ** (9.5)]  # in K
+dustfracs_bounds = [-4, -1]  # In metal mass fraction
+min_dustfracs = 10 ** dustfracs_bounds[0]
+bins = 64
+elements = [
+    "Hydrogen",
+    "Helium",
+    "Carbon",
+    "Nitrogen",
+    "Oxygen",
+    "Neon",
+    "Magnesium",
+    "Silicon",
+    "Sulphur",
+    "Calcium",
+    "Iron",
+    "Oatoms",]
+
+
+def get_data(filename, tables, prefix_rho, prefix_T):
+    """
+    Grabs the data (T in Kelvin and density in mh / cm^3) and interpolates for species fractions..
+    """
+
+    data = load(filename)
+    number_density = (
+        getattr(data.gas, f"{prefix_rho}densities").to_physical() / mh
+    ).to(cm ** -3)
+    temperature = getattr(data.gas, f"{prefix_T}temperatures").to_physical().to("K")
+    masses = data.gas.masses.to_physical().to("Msun")
+    
+    # Abundance Mass Fractions 
+    X = data.gas.element_mass_fractions.hydrogen
+    Z = data.gas.metal_mass_fractions
+
+    # Species Mass Fractions
+    neutfrac = X * masses * data.gas.species_fractions.HI
+    molfrac = 2 * X * masses * data.gas.species_fractions.H2
+    ionfrac = X * masses * data.gas.species_fractions.HII
+
+    # Dust Mass Fractions
+    dfracs = np.zeros(data.gas.masses.shape)
+    for d in dir(data.gas.dust_mass_fractions):
+        if hasattr(getattr(data.gas.dust_mass_fractions, d), "units"):
+            dfracs += getattr(data.gas.dust_mass_fractions, d)
+            
+    if glob.glob(tables):
+        table_file = h5.File(tables, "r")
+        lrho = np.log10(
+            (data.gas.subgrid_physical_densities.to_physical() / mh).to(cm ** -3).value)
+        lT = np.log10((data.gas.subgrid_temperatures).to_physical().to("K").value)
+        lZ = np.log10((data.gas.metal_mass_fractions.value / 0.0127))
+        z = np.ones(lrho.size) * data.metadata.redshift
+
+        bin_z = np.array(table_file["TableBins/RedshiftBins"])
+        bin_lT = np.array(table_file["TableBins/TemperatureBins"])
+        bin_lZ = np.array(table_file["TableBins/MetallicityBins"])
+        bin_lrho = np.array(table_file["TableBins/DensityBins"])
+
+        z = np.clip(z, bin_z.min(), bin_z.max())
+        lZ = np.clip(lZ, bin_lZ.min(), bin_lZ.max())
+        lT = np.clip(lT, bin_lT.min(), bin_lT.max())
+        lrho = np.clip(lrho, bin_lrho.min(), bin_lrho.max())
+
+        bins = (bin_z, bin_lT, bin_lZ, bin_lrho)
+        vecs = np.column_stack([z, lT, lZ, lrho])
+
+        df = pow(10, np.array(table_file["Tdep/Depletion"]))
+        difracs = np.zeros(z.shape)
+        for i in range(df.shape[-1]):
+            elname = elements[i].lower()
+            if hasattr(data.gas.element_mass_fractions, elname):
+                elfrac = getattr(data.gas.element_mass_fractions, elname)
+                interp_elfdust = interpn(
+                    bins, df[:, :, :, :, i], vecs, bounds_error=False
+                )
+                indvdust = elfrac * interp_elfdust
+                difracs += indvdust
+            else:
+                continue
+        table_file.close()
+    else:
+        difracs = np.zeros(masses.size)
+        print("Cooling Tables not found. continuing without tables")
+
+    out_tuple = (number_density.value,
+                 temperature.value,
+                 difracs,
+                 dfracs,
+                 masses.value,
+                 molfrac.value,
+                 neutfrac.value,
+                 ionfrac.value,
+                 X.value,
+                 Z.value)
+        
+    return out_tuple
+
+
+def make_hist(
+    filename,
+    density_bounds,
+    temperature_bounds,
+    bins,
+    tables,
+    prefix_rho="",
+    prefix_T="",
+):
+    """
+    Makes the histogram for filename with bounds as lower, higher
+    for the bins and "bins" the number of bins along each dimension.
+
+    Also returns the edges for pcolormesh to use.
+    """
+
+    density_bins = np.logspace(
+        np.log10(density_bounds[0]), np.log10(density_bounds[1]), bins
+    )
+    temperature_bins = np.logspace(
+        np.log10(temperature_bounds[0]), np.log10(temperature_bounds[1]), bins
+    )
+
+    ret_tuple = get_data(filename, tables, prefix_rho, prefix_T)
+    nH, T, Di, D, Mg, mol, neut, ion, X, Z = ret_tuple
+    
+    Hd, density_edges = np.histogram(
+        nH, bins=density_bins, weights=D * Mg
+    )
+
+    Hdi, density_edges = np.histogram(
+        nH, bins=density_bins, weights=Di * Mg
+    )
+
+    H_Z, _ = np.histogram(
+        nH, bins=density_bins, weights= Z * Mg
+    )
+
+    Hh2, _ = np.histogram(
+        nH, bins=density_bins, weights=mol
+    )
+
+    Hhi, _ = np.histogram(
+        nH, bins=density_bins, weights=neut
+    )
+
+    Hhii, _ = np.histogram(
+        nH, bins=density_bins, weights=ion
+    )
+    
+    H_norm, _ = np.histogram(
+        nH, bins=density_bins, weights=Mg
+    )
+
+    H_h, _ = np.histogram(
+        nH, bins=density_bins, weights=X*Mg
+    )
+
+
+    # Avoid div/0
+    mask = H_norm == 0.0
+    Hd[mask] = None
+    Hdi[mask] = None
+    Hh2[mask] = None
+    Hhi[mask] = None
+    Hhii[mask] = None
+    H_h[mask] = 1.0
+    H_Z[mask] = 1.0
+    H_norm[mask] = 1.0
+
+    out_tuple = (np.ma.array((Hh2 / H_h).T, mask=mask.T),
+                 np.ma.array((Hhi / H_h).T, mask=mask.T),
+                 np.ma.array((Hhii / H_h).T, mask=mask.T),
+                 np.ma.array((Hd / H_Z).T, mask=mask.T),
+                 np.ma.array((Hdi / H_Z).T, mask=mask.T),
+                 density_edges)
+
+    return out_tuple
+
+
+def setup_axes(number_of_simulations: int, prop_type="hydro"):
+    """
+    Creates the figure and axis object. Creates a grid of a x b subplots
+    that add up to at least number_of_simulations.
+    """
+
+    sqrt_number_of_simulations = np.sqrt(number_of_simulations)
+    horizontal_number = int(np.ceil(sqrt_number_of_simulations))
+    # Ensure >= number_of_simulations plots in a grid
+    vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
+
+    fig, ax = plt.subplots(
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+    )
+
+    ax = np.array([ax]) if number_of_simulations == 1 else ax
+
+    if horizontal_number * vertical_number > number_of_simulations:
+        for axis in ax.flat[number_of_simulations:]:
+            axis.axis("off")
+
+    # Set all valid on bottom row to have the horizontal axis label.
+    for axis in np.atleast_2d(ax)[:][-1]:
+        if prop_type == "hydro":
+            axis.set_xlabel(r"Log Density [$\log_{10}(n_H /\; {\rm cm}^{-3})$]")
+        elif prop_type == "subgrid":
+            axis.set_xlabel(r"Log Subgrid Density [$\log_{10}(n_H /\; {\rm cm}^{-3})$]")
+        else:
+            raise Exception("Unrecognised property type.")
+    for axis in np.atleast_2d(ax).T[:][0]:
+            axis.set_ylabel("Species Mass Fraction")
+            axis2 = axis.twinx()
+            axis2.set_ylabel("\n\n\n Fraction of Dust in Metals")
+            axis2.set_yticks([])
+    return fig, ax
+
+
+def make_single_image(
+    filenames,
+    names,
+    number_of_simulations,
+    density_bounds,
+    temperature_bounds,
+    bins,
+    output_path,
+    prop_type,
+    tables,
+):
+    """
+    Makes a single plot of rho-T
+    """
+
+    if prop_type == "subgrid":
+        prefix_rho = "subgrid_physical_"
+        prefix_T = "subgrid_"
+    else:
+        prefix_rho = ""
+        prefix_T = ""
+
+    fig, ax = setup_axes(
+        number_of_simulations=number_of_simulations, prop_type=prop_type
+    )
+
+    hist_h2 = []
+    hist_hi = []
+    hist_hii = []
+    hist_d2z = []
+    hist_di2z = []
+
+    for filename in filenames:
+        hh2, hhi, hhii, hd2z, hdi2z, d = make_hist(
+            filename,
+            density_bounds,
+            temperature_bounds,
+            bins,
+            tables,
+            prefix_rho,
+            prefix_T
+        )
+        hist_h2.append(hh2)
+        hist_hi.append(hhi)
+        hist_hii.append(hhii)
+        hist_d2z.append(hd2z)
+        hist_di2z.append(hdi2z)
+        
+    smap = get_cmap("plasma")
+    ncols = 20
+    collist = []
+    binmids = np.log10(d)[:-1] + 0.5*np.diff(np.log10(d))
+    
+    for hist_h2, hist_hi, hist_hii, hist_d2z, hist_di2z, name, axis in zip(hist_h2, hist_hi, hist_hii, hist_d2z, hist_di2z, names, ax.flat):
+        # mappable = axis.pcolormesh(d, T, np.log10(hist), cmap=cmap, norm=norm)
+        axis.plot(binmids, np.clip(hist_h2, 0, 1), label='molecular')
+        axis.plot(binmids, np.clip(hist_hi, 0, 1), label='neutral')
+        axis.plot(binmids, np.clip(hist_hii, 0, 1), label='ionised')
+        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.legend(frameon=False, loc=6)
+        axis.set_ylim(0,1.1)
+        axis2 = axis.twinx()
+        axis2.plot(binmids, hist_d2z, c='C5', label='Model dust')
+        axis2.plot(binmids, hist_di2z, c='C5', ls="--", label='Table dust')
+        axis2.legend(frameon=False, loc=(0.02, 0.7))
+        axis2.set_ylim(0,axis2.get_ylim()[1])
+        
+    fig.savefig(f"{output_path}/{prefix_T}density_vs_species_fraction.png")
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(
+        description="Basic density-temperature figure.",
+        additional_arguments={
+            "quantity_type": "hydro",
+            "cooling_tables": "UV_dust1_CR1_G1_shield1.hdf5",
+        },
+    )
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        number_of_simulations=arguments.number_of_inputs,
+        density_bounds=density_bounds,
+        temperature_bounds=temperature_bounds,
+        bins=bins,
+        output_path=arguments.output_directory,
+        prop_type=arguments.quantity_type,
+        tables=arguments.cooling_tables,
+    )

--- a/colibre/scripts/density_temperature_dust2metal.py
+++ b/colibre/scripts/density_temperature_dust2metal.py
@@ -1,0 +1,196 @@
+"""
+Makes a rho-T plot. Uses the swiftsimio library.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.stats import binned_statistic_2d as bs2d
+
+from swiftsimio import load
+
+from unyt import mh, cm, Gyr
+from matplotlib.colors import LogNorm
+from matplotlib.animation import FuncAnimation
+
+# Set the limits of the figure.
+density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+temperature_bounds = [10 ** (0), 10 ** (9.5)]  # in K
+DTMs_bounds = [2e-2, 1]  # In metal mass fraction
+min_DTMs = DTMs_bounds[0]
+bins = 256
+
+
+def get_data(filename, prefix_rho, prefix_T):
+    """
+    Grabs the data (T in Kelvin and density in mh / cm^3).
+    """
+
+    data = load(filename)
+
+    number_density = (
+        getattr(data.gas, f"{prefix_rho}densities").to_physical() / mh
+    ).to(cm ** -3)
+    temperature = getattr(data.gas, f"{prefix_T}temperatures").to_physical().to("K")
+    masses = data.gas.masses.to_physical().to("Msun")
+    Z = data.gas.metal_mass_fractions
+
+    dfracs = np.zeros(data.gas.masses.shape)
+
+    for d in dir(data.gas.dust_mass_fractions):
+        if hasattr(getattr(data.gas.dust_mass_fractions, d), "units"):
+            dfracs += getattr(data.gas.dust_mass_fractions, d)
+
+    # dfracs[dfracs < min_DTMs] = min_DTMs
+
+    return number_density.value, temperature.value, dfracs.value, Z.value, masses.value
+
+
+def make_hist(
+    filename, density_bounds, temperature_bounds, bins, prefix_rho="", prefix_T=""
+):
+    """
+    Makes the histogram for filename with bounds as lower, higher
+    for the bins and "bins" the number of bins along each dimension.
+
+    Also returns the edges for pcolormesh to use.
+    """
+
+    density_bins = np.logspace(
+        np.log10(density_bounds[0]), np.log10(density_bounds[1]), bins
+    )
+    temperature_bins = np.logspace(
+        np.log10(temperature_bounds[0]), np.log10(temperature_bounds[1]), bins
+    )
+
+    nH, T, D, Z, Mg = get_data(filename, prefix_rho, prefix_T)
+
+    H, density_edges, temperature_edges = np.histogram2d(
+        nH, T, bins=[density_bins, temperature_bins], weights=D * Mg
+    )
+    H_norm, _, _ = np.histogram2d(
+        nH, T, bins=[density_bins, temperature_bins], weights=Z * Mg
+    )
+
+    # Avoid div/0
+    mask = H_norm == 0.0
+    H[mask] = -50
+    H_norm[mask] = 1.0
+
+    return np.ma.array((H / H_norm).T, mask=mask.T), density_edges, temperature_edges
+
+
+def setup_axes(number_of_simulations: int, prop_type="hydro"):
+    """
+    Creates the figure and axis object. Creates a grid of a x b subplots
+    that add up to at least number_of_simulations.
+    """
+
+    sqrt_number_of_simulations = np.sqrt(number_of_simulations)
+    horizontal_number = int(np.ceil(sqrt_number_of_simulations))
+    # Ensure >= number_of_simulations plots in a grid
+    vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
+
+    fig, ax = plt.subplots(
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+    )
+
+    ax = np.array([ax]) if number_of_simulations == 1 else ax
+
+    if horizontal_number * vertical_number > number_of_simulations:
+        for axis in ax.flat[number_of_simulations:]:
+            axis.axis("off")
+
+    # Set all valid on bottom row to have the horizontal axis label.
+    for axis in np.atleast_2d(ax)[:][-1]:
+        if prop_type == "hydro":
+            axis.set_xlabel("Density [$n_H$ cm$^{-3}$]")
+        elif prop_type == "subgrid":
+            axis.set_xlabel("Subgrid Physical Density [$n_H$ cm$^{-3}$]")
+        else:
+            raise Exception("Unrecognised property type.")
+    for axis in np.atleast_2d(ax).T[:][0]:
+        if prop_type == "hydro":
+            axis.set_ylabel("Temperature [K]")
+        elif prop_type == "subgrid":
+            axis.set_xlabel("Subgrid Temperature [K]")
+
+    ax.flat[0].loglog()
+
+    return fig, ax
+
+
+def make_single_image(
+    filenames,
+    names,
+    number_of_simulations,
+    density_bounds,
+    temperature_bounds,
+    bins,
+    output_path,
+    prop_type,
+):
+    """
+    Makes a single plot of rho-T
+    """
+
+    if prop_type == "subgrid":
+        prefix_rho = "subgrid_physical_"
+        prefix_T = "subgrid_"
+    else:
+        prefix_rho = ""
+        prefix_T = ""
+
+    fig, ax = setup_axes(
+        number_of_simulations=number_of_simulations, prop_type=prop_type
+    )
+
+    hists = []
+
+    for filename in filenames:
+        hist, d, T = make_hist(
+            filename, density_bounds, temperature_bounds, bins, prefix_rho, prefix_T
+        )
+        hists.append(hist)
+
+    vmax = np.max([np.max(hist) for hist in hists])
+
+    for hist, name, axis in zip(hists, names, ax.flat):
+        mappable = axis.pcolormesh(
+            d, T, hist, norm=LogNorm(vmin=DTMs_bounds[0], vmax=DTMs_bounds[1])
+        )
+        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+
+    fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Dust to Metal Ratio")
+
+    fig.savefig(f"{output_path}/{prefix_T}density_temperature_dust2metal.png")
+
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(
+        description="Basic density-temperature figure.",
+        additional_arguments={"quantity_type": "hydro"},
+    )
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        number_of_simulations=arguments.number_of_inputs,
+        density_bounds=density_bounds,
+        temperature_bounds=temperature_bounds,
+        bins=bins,
+        output_path=arguments.output_directory,
+        prop_type=arguments.quantity_type,
+    )

--- a/colibre/vrconfig_example.cfg
+++ b/colibre/vrconfig_example.cfg
@@ -182,9 +182,9 @@ Spherical_overdensity_halo_particle_list_output=1
 #ALTER THIS as part of a script to get temporally unique ids
 Snapshot_value=SNAP
 
-Gas_internal_property_names=SpeciesFractions,SpeciesFractions,SpeciesFractions,ElementMassFractions,
-Gas_internal_property_index_in_file=1,2,7,0,
-Gas_internal_property_calculation_type =averagemassweighted,averagemassweighted,averagemassweighted,averagemassweighted,
+Gas_internal_property_names=SpeciesFractions,SpeciesFractions,SpeciesFractions,ElementMassFractions,ElementMassFractions,
+Gas_internal_property_index_in_file=1,2,7,0,4,
+Gas_internal_property_calculation_type =averagemassweighted,averagemassweighted,averagemassweighted,averagemassweighted,averagemassweighted,
 
 
 ################################


### PR DESCRIPTION
Collection of new dust related plots:

- Dust-to-metal shaded phase diagram
- Hydrogen species fractions as a function of density, co-plotted with dust-to-metal ratio as a function of density
- Dust scaling relation plots fro data comparison collected from DeLooze et al (2020) data
- Dust to gas ratio as a function of oxygen abundance, to compare with Rémi-Ruyer et al (2014) data

NB. registration of some new quantities, change to VR file to add reading of mass-weighted Oxygen abundances. species fraction plot uses interpolated Ploeckinger et al (2020) tables for dust comparison. Added config arg points to an instance of this, but if unavailable will not plot. Also want to investigate selection function for DeLooze plots 