### PR TITLE
Include Read2017 

### DIFF
--- a/colibre/auto_plotter/stellar_mass_halo_mass.yml
+++ b/colibre/auto_plotter/stellar_mass_halo_mass.yml
@@ -31,6 +31,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_100:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013Ratio.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Reed2017_Ratio.hdf5
 
 stellar_mass_halo_mass_MBN98_centrals_ratio_100:
   type: "scatter"
@@ -99,6 +100,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_100:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013RatioStellar.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Reed2017_RatioStellar.hdf5
       
 stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
   type: "scatter"
@@ -165,6 +167,7 @@ stellar_mass_halo_mass_M200_all_100:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200.hdf5
+    - filename: GalaxyStellarMassHaloMass/Reed2017.hdf5
 
 stellar_mass_halo_mass_MBN98_all_100:
   type: "scatter"
@@ -232,6 +235,7 @@ stellar_mass_halo_mass_M200_centrals_100:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200.hdf5
+    - filename: GalaxyStellarMassHaloMass/Reed2017.hdf5
 
 stellar_mass_halo_mass_MBN98_centrals_100:
   type: "scatter"
@@ -302,6 +306,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_30:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013Ratio.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Reed2017_Ratio.hdf5
 
 stellar_mass_halo_mass_M200_centrals_ratio_stellar_30:
   type: "scatter"
@@ -337,6 +342,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_30:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013RatioStellar.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Reed2017_RatioStellar.hdf5
 
 stellar_mass_halo_mass_M200_all_30:
   type: "scatter"
@@ -370,6 +376,7 @@ stellar_mass_halo_mass_M200_all_30:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200.hdf5
+    - filename: GalaxyStellarMassHaloMass/Reed2017.hdf5
 
 stellar_mass_halo_mass_M200_centrals_30:
   type: "scatter"
@@ -405,3 +412,4 @@ stellar_mass_halo_mass_M200_centrals_30:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200.hdf5
+    - filename: GalaxyStellarMassHaloMass/Reed2017.hdf5

--- a/colibre/auto_plotter/stellar_mass_halo_mass.yml
+++ b/colibre/auto_plotter/stellar_mass_halo_mass.yml
@@ -31,7 +31,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_100:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013Ratio.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_Ratio.hdf5
-    - filename: GalaxyStellarMassHaloMass/Reed2017_Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Read2017_Ratio.hdf5
 
 stellar_mass_halo_mass_MBN98_centrals_ratio_100:
   type: "scatter"
@@ -100,7 +100,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_100:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013RatioStellar.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_RatioStellar.hdf5
-    - filename: GalaxyStellarMassHaloMass/Reed2017_RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Read2017_RatioStellar.hdf5
       
 stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
   type: "scatter"
@@ -167,7 +167,7 @@ stellar_mass_halo_mass_M200_all_100:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200.hdf5
-    - filename: GalaxyStellarMassHaloMass/Reed2017.hdf5
+    - filename: GalaxyStellarMassHaloMass/Read2017.hdf5
 
 stellar_mass_halo_mass_MBN98_all_100:
   type: "scatter"
@@ -235,7 +235,7 @@ stellar_mass_halo_mass_M200_centrals_100:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200.hdf5
-    - filename: GalaxyStellarMassHaloMass/Reed2017.hdf5
+    - filename: GalaxyStellarMassHaloMass/Read2017.hdf5
 
 stellar_mass_halo_mass_MBN98_centrals_100:
   type: "scatter"
@@ -306,7 +306,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_30:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013Ratio.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_Ratio.hdf5
-    - filename: GalaxyStellarMassHaloMass/Reed2017_Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Read2017_Ratio.hdf5
 
 stellar_mass_halo_mass_M200_centrals_ratio_stellar_30:
   type: "scatter"
@@ -342,7 +342,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_stellar_30:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013RatioStellar.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200_RatioStellar.hdf5
-    - filename: GalaxyStellarMassHaloMass/Reed2017_RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Read2017_RatioStellar.hdf5
 
 stellar_mass_halo_mass_M200_all_30:
   type: "scatter"
@@ -376,7 +376,7 @@ stellar_mass_halo_mass_M200_all_30:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200.hdf5
-    - filename: GalaxyStellarMassHaloMass/Reed2017.hdf5
+    - filename: GalaxyStellarMassHaloMass/Read2017.hdf5
 
 stellar_mass_halo_mass_M200_centrals_30:
   type: "scatter"
@@ -412,4 +412,4 @@ stellar_mass_halo_mass_M200_centrals_30:
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Moster2013.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_M200.hdf5
-    - filename: GalaxyStellarMassHaloMass/Reed2017.hdf5
+    - filename: GalaxyStellarMassHaloMass/Read2017.hdf5


### PR DESCRIPTION
- Include Read2017 data
- Update hash of the comparison-data submodule

[Example of how the webpage will look like](http://swift.dur.ac.uk/COLIBREPlots/chaikin/individual_runs/HAWK/L006N188/z2.1_01_REFERENCE/) following this update

Note that I first made the above plots and only then found a typo in _Reed_. I did correct for that typo in this PR. Below is the new version of SMHM plots with the correct spelling of Read

![Read2017](https://user-images.githubusercontent.com/20153933/107036068-52c22d00-67b9-11eb-81a7-afb378c158ca.png)
