### PR TITLE
Add SNII feedback density plots to colibre config

### DIFF
--- a/colibre/auto_plotter/feedback_densities.yml
+++ b/colibre/auto_plotter/feedback_densities.yml
@@ -1,0 +1,86 @@
+snii_thermal_feedback_density_halo_mass_max_all:
+  type: "scatter"
+  legend_loc: "upper left"
+  x:
+    quantity: "masses.mass_200crit"
+    units: Solar_Mass
+    start: 1e8
+    end: 1e13
+  y:
+    quantity: "snii_thermal_feedback_densities.max"
+    units: "mh/cm**3"
+    start: 1e-4
+    end: 5e6
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 25
+    start:
+      value: 1e8
+      units: Solar_Mass
+    end:
+      value: 1e13
+      units: Solar_Mass
+  metadata:
+    title: Maximal SNII thermal feedback Density-Halo Mass relation
+    caption: Includes all haloes, including subhaloes.
+    section: Feedback Densities
+
+snii_thermal_feedback_density_stellar_mass_max_all_100:
+  type: "scatter"
+  legend_loc: "upper left"
+  x:
+    quantity: "apertures.mass_star_100_kpc"
+    units: Solar_Mass
+    start: 1e4
+    end: 1e12
+  y:
+    quantity: "snii_thermal_feedback_densities.max"
+    units: "mh/cm**3"
+    start: 1e-4
+    end: 5e6
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 25
+    start:
+      value: 1e4
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Maximal SNII thermal feedback Density-Stellar Mass relation
+    caption: Includes all haloes, including subhaloes.
+    section: Feedback Densities
+
+snii_thermal_feedback_density_stellar_birth_density_max_all:
+  type: "scatter"
+  legend_loc: "upper left"
+  x:
+    quantity: "stellar_birth_densities.max"
+    units: "mh/cm**3"
+    start: 1e-4
+    end: 5e6
+  y:
+    quantity: "snii_thermal_feedback_densities.max"
+    units: "mh/cm**3"
+    start: 1e-4
+    end: 5e6
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 25
+    start:
+      value: 1e-4
+      units: "mh/cm**3"
+    end:
+      value: 5e6
+      units: "mh/cm**3"
+  metadata:
+    title: Maximal SNII thermal feedback Density-Maximal Stellar Birth Density relation
+    caption: Includes all haloes, including subhaloes.
+    section: Feedback Densities

--- a/colibre/auto_plotter/feedback_densities.yml
+++ b/colibre/auto_plotter/feedback_densities.yml
@@ -9,7 +9,7 @@ snii_thermal_feedback_density_halo_mass_max_all:
   y:
     quantity: "snii_thermal_feedback_densities.max"
     units: "mh/cm**3"
-    start: 1e-4
+    start: 5e-2
     end: 5e6
   median:
     plot: true
@@ -38,7 +38,7 @@ snii_thermal_feedback_density_stellar_mass_max_all_100:
   y:
     quantity: "snii_thermal_feedback_densities.max"
     units: "mh/cm**3"
-    start: 1e-4
+    start: 5e-2
     end: 5e6
   median:
     plot: true
@@ -62,12 +62,12 @@ snii_thermal_feedback_density_stellar_birth_density_max_all:
   x:
     quantity: "stellar_birth_densities.max"
     units: "mh/cm**3"
-    start: 1e-4
+    start: 5e-2
     end: 5e6
   y:
     quantity: "snii_thermal_feedback_densities.max"
     units: "mh/cm**3"
-    start: 1e-4
+    start: 5e-2
     end: 5e6
   median:
     plot: true
@@ -75,7 +75,7 @@ snii_thermal_feedback_density_stellar_birth_density_max_all:
     adaptive: true
     number_of_bins: 25
     start:
-      value: 1e-4
+      value: 5e-2
       units: "mh/cm**3"
     end:
       value: 5e6

--- a/colibre/auto_plotter/feedback_densities.yml
+++ b/colibre/auto_plotter/feedback_densities.yml
@@ -73,7 +73,7 @@ snii_thermal_feedback_density_stellar_birth_density_max_all:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 25
+    number_of_bins: 40
     start:
       value: 5e-2
       units: "mh/cm**3"

--- a/colibre/auto_plotter/feedback_densities.yml
+++ b/colibre/auto_plotter/feedback_densities.yml
@@ -44,7 +44,7 @@ snii_thermal_feedback_density_stellar_mass_max_all_100:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 25
+    number_of_bins: 40
     start:
       value: 1e4
       units: Solar_Mass

--- a/colibre/auto_plotter/stellar_birth_densities.yml
+++ b/colibre/auto_plotter/stellar_birth_densities.yml
@@ -10,7 +10,7 @@ stellar_birth_density_halo_mass_average_of_log_all:
     quantity: "derived_quantities.average_of_log_stellar_birth_density"
     units: "mh/cm**3"
     start: 5e-2
-    end: 5e5
+    end: 5e6
   median:
     plot: true
     log: true
@@ -39,7 +39,7 @@ stellar_birth_density_halo_mass_max_all:
     quantity: "stellar_birth_densities.max"
     units: "mh/cm**3"
     start: 5e-2
-    end: 5e5
+    end: 5e6
   median:
     plot: true
     log: true
@@ -68,7 +68,7 @@ stellar_birth_density_stellar_mass_average_of_log_all_100:
     quantity: "derived_quantities.average_of_log_stellar_birth_density"
     units: "mh/cm**3"
     start: 5e-2
-    end: 5e5
+    end: 5e6
   median:
     plot: true
     log: true
@@ -97,7 +97,7 @@ stellar_birth_density_stellar_mass_max_all_100:
     quantity: "stellar_birth_densities.max"
     units: "mh/cm**3"
     start: 5e-2
-    end: 5e5
+    end: 5e6
   median:
     plot: true
     log: true


### PR DESCRIPTION
- [EXAMPLE](http://swift.dur.ac.uk/COLIBREPlots/chaikin/individual_runs/HAWK/L006N188/z1.0_01_REFERENCE/) (three new plots in the **Feedback Densities** section)

- I also extended the upper limits in the stellar birth density plots from `5e5` to `5e6` because in the lastest runs we often had data above the Y-axis range.