### PR TITLE
Add two plots with SNII kick velocities

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -103,7 +103,7 @@ scripts:
     title: Stellar Metallicity-Birth Redshift
     section: Stellar Birth Densities
     output_file: metallicity_redshift.png
-  - filename: scripts/SNII_density_distribution.py
+  - filename: scripts/last_SNII_density_distribution.py
     caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles. The dashed vertical lines show the median SNII gas-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for $f_t=10$.
     title: Density of the gas heated by SNII
     section: Feedback Densities
@@ -207,3 +207,13 @@ scripts:
     additional_arguments:
       cooling_tables: /cosma7/data/dp004/wmfw23/colibre_dust/coolingtables/UV_dust1_CR1_G1_shield1.hdf5
       quantity_type: hydro
+  - filename: scripts/last_SNII_kick_velocity_distribution.py
+    caption: Distributions of SNII kick velocities experienced by the gas recorded when the gas was last kicked by SNII, split by redshift. The y axis shows the number of SNII-kicked gas particles per bin divided by the bin width and by the total of SNII-kicked gas particles. The dashed vertical lines show the median kick velocitites, while the dotted lines indicade the target kick velocity.
+    output_file: SNII_last_kick_velocity_distribution.png
+    section: Feedback kick velocities
+    title: Kick velocity distribution at last SNII
+  - filename: scripts/max_SNII_kick_velocities.py
+    caption: Maximal SNII kick velocities by experienced by particles in SNII kinetic feedback throughout the entire simulation.
+    output_file: SNII_maximal_kick_velocities.png
+    section: Feedback kick velocities
+    title: Maximal SNII kick velocity

--- a/colibre/scripts/last_SNII_density_distribution.py
+++ b/colibre/scripts/last_SNII_density_distribution.py
@@ -1,5 +1,5 @@
 """
-Plots the SNII density distribution.
+Plots the SNII density distribution (at last SNII thermal injections).
 """
 
 import matplotlib.pyplot as plt
@@ -115,12 +115,28 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
     stars_SNII_densities = (snapshot.stars.densities_at_last_supernova_event / mh).to(
         SNII_density_bins.units
     )
-    stars_SNII_redshifts = 1 / snapshot.stars.last_sniifeedback_scale_factors.value - 1
+
+    # swift-colibre master branch as of Feb 26 2021
+    try:
+        stars_SNII_redshifts = (
+            1 / snapshot.stars.last_sniithermal_feedback_scale_factors.value - 1
+        )
+    # swift-colibre master prior to Feb 26 2021
+    except AttributeError:
+        stars_SNII_redshifts = (
+            1 / snapshot.stars.last_sniifeedback_scale_factors.value - 1
+        )
 
     gas_SNII_densities = (snapshot.gas.densities_at_last_supernova_event / mh).to(
         SNII_density_bins.units
     )
-    gas_SNII_redshifts = 1 / snapshot.gas.last_sniifeedback_scale_factors.value - 1
+
+    try:
+        gas_SNII_redshifts = (
+            1 / snapshot.gas.last_sniithermal_feedback_scale_factors.value - 1
+        )
+    except AttributeError:
+        gas_SNII_redshifts = 1 / snapshot.gas.last_sniifeedback_scale_factors.value - 1
 
     # Limit only to those gas/stellar particles that were in fact heated by SNII
     stars_SNII_heated = stars_SNII_densities > 0.0
@@ -181,7 +197,10 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
             y_points = np.zeros_like(H)
 
         ax.plot(
-            SNII_density_centers, y_points, label=name, color=f"C{color}",
+            SNII_density_centers,
+            y_points,
+            label=name,
+            color=f"C{color}",
         )
         ax.axvline(
             np.median(data),
@@ -193,7 +212,11 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
 
         # Add the DV&S2012 line
         ax.axvline(
-            n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5,
+            n_crit,
+            color=f"C{color}",
+            linestyle="dotted",
+            zorder=-10,
+            alpha=0.5,
         )
 
 axes[0].legend(loc="upper right", markerfirst=False)

--- a/colibre/scripts/last_SNII_kick_velocity_distribution.py
+++ b/colibre/scripts/last_SNII_kick_velocity_distribution.py
@@ -1,0 +1,148 @@
+"""
+Plots the SNII kick velocity distribution (at last SNII kinetic-feedback events).
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import unyt
+
+from swiftsimio import load
+from swiftpipeline.argumentparser import ScriptArgumentParser
+
+arguments = ScriptArgumentParser(
+    description="Creates a plot showing the distribution of SNII kick velocities "
+    "recorded when the gas was last kicked by SNII, split by redshift"
+)
+
+snapshot_filenames = [
+    f"{directory}/{snapshot}"
+    for directory, snapshot in zip(arguments.directory_list, arguments.snapshot_list)
+]
+
+names = arguments.name_list
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
+number_of_bins = 256
+
+SNII_v_kick_bins = unyt.unyt_array(np.logspace(-1, 4, number_of_bins), units="km/s")
+log_SNII_v_kick_bin_width = np.log10(SNII_v_kick_bins[1].value) - np.log10(
+    SNII_v_kick_bins[0].value
+)
+SNII_v_kick_centres = 0.5 * (SNII_v_kick_bins[1:] + SNII_v_kick_bins[:-1])
+
+# Begin plotting
+fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
+axes = axes.flat
+
+ax_dict = {
+    "$z < 1$": axes[0],
+    "$1 < z < 3$": axes[1],
+    "$z > 3$": axes[2],
+}
+
+for label, ax in ax_dict.items():
+    ax.loglog()
+    ax.text(0.025, 1.0 - 0.025 * 3, label, transform=ax.transAxes, ha="left", va="top")
+
+for color, (snapshot, name) in enumerate(zip(data, names)):
+
+    stars_SNII_v_kick_last = (snapshot.stars.last_sniikinetic_feedbackvkick).to(
+        SNII_v_kick_bins.units
+    )
+
+    stars_SNII_redshifts = (
+        1 / snapshot.stars.last_sniikinetic_feedback_scale_factors.value - 1
+    )
+
+    gas_SNII_v_kick_last = (snapshot.gas.last_sniikinetic_feedbackvkick).to(
+        SNII_v_kick_bins.units
+    )
+
+    gas_SNII_redshifts = (
+        1 / snapshot.gas.last_sniikinetic_feedback_scale_factors.value - 1
+    )
+
+    # Limit only to those gas / stellar particles that were in fact kicked by SNII
+    stars_SNII_kicked = stars_SNII_v_kick_last > 0.0
+    gas_SNII_kicked = gas_SNII_v_kick_last > 0.0
+
+    # Select only those parts that were kicked by SNII in the past
+    stars_SNII_v_kick_last = stars_SNII_v_kick_last[stars_SNII_kicked]
+    stars_SNII_redshifts = stars_SNII_redshifts[stars_SNII_kicked]
+    gas_SNII_v_kick_last = gas_SNII_v_kick_last[gas_SNII_kicked]
+    gas_SNII_redshifts = gas_SNII_redshifts[gas_SNII_kicked]
+
+    # Segment SNII kick velocities into redshift bins
+    stars_SNII_v_kick_by_redshift = {
+        "$z < 1$": stars_SNII_v_kick_last[stars_SNII_redshifts < 1],
+        "$1 < z < 3$": stars_SNII_v_kick_last[
+            np.logical_and(stars_SNII_redshifts > 1, stars_SNII_redshifts < 3)
+        ],
+        "$z > 3$": stars_SNII_v_kick_last[stars_SNII_redshifts > 3],
+    }
+
+    gas_SNII_v_kick_by_redshift = {
+        "$z < 1$": gas_SNII_v_kick_last[gas_SNII_redshifts < 1],
+        "$1 < z < 3$": gas_SNII_v_kick_last[
+            np.logical_and(gas_SNII_redshifts > 1, gas_SNII_redshifts < 3)
+        ],
+        "$z > 3$": gas_SNII_v_kick_last[gas_SNII_redshifts > 3],
+    }
+
+    # Fetch target kick velocity
+    SNII_target_kick_velocity_km_p_s = float(
+        snapshot.metadata.parameters["COLIBREFeedback:SNII_delta_v_km_p_s"].decode(
+            "utf-8"
+        )
+    )  # in km/s
+
+    for redshift, ax in ax_dict.items():
+        data = np.concatenate(
+            [
+                stars_SNII_v_kick_by_redshift[redshift],
+                gas_SNII_v_kick_by_redshift[redshift],
+            ]
+        )
+
+        H, _ = np.histogram(data, bins=SNII_v_kick_bins)
+
+        # Total number of particles kicked by SNIIe
+        Num_of_obj = np.sum(H)
+
+        # Check to avoid division by zero
+        if Num_of_obj:
+            y_points = H / log_SNII_v_kick_bin_width / Num_of_obj
+        else:
+            y_points = np.zeros_like(H)
+
+        ax.plot(
+            SNII_v_kick_centres,
+            y_points,
+            label=name,
+            color=f"C{color}",
+        )
+        ax.axvline(
+            np.median(data),
+            color=f"C{color}",
+            linestyle="dashed",
+            zorder=-10,
+            alpha=0.5,
+        )
+
+        # Add the line indicating the target kick velocity
+        ax.axvline(
+            SNII_target_kick_velocity_km_p_s,
+            color=f"C{color}",
+            linestyle="dotted",
+            zorder=-10,
+            alpha=0.5,
+        )
+
+axes[0].legend(loc="upper right", markerfirst=False)
+axes[2].set_xlabel("Kick velocity at last SNII $v_{\\rm kick}$ [km s$^{-1}$]")
+axes[1].set_ylabel("$N_{\\rm bin}$ / d$\\log v_{\\rm kick}$ / $N_{\\rm total}$")
+
+fig.savefig(f"{arguments.output_directory}/SNII_last_kick_velocity_distribution.png")

--- a/colibre/scripts/max_SNII_kick_velocities.py
+++ b/colibre/scripts/max_SNII_kick_velocities.py
@@ -1,0 +1,97 @@
+"""
+Makes a histogram of maximal kicked velocities experienced by the gas particles in SNII
+kinetic feedback. Uses the swiftsimio library.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+
+v_kick_bounds = [0.1, 1e5]  # in km/s
+
+
+def get_data(filename):
+    """
+    Grabs the data
+    """
+
+    data = load(filename)
+
+    # We need to select only only gas but also stars because sparts were gas at some
+    # point in the past and hence could be kicked.
+    stars_SNII_v_kick_max = (data.stars.maximal_sniikinetic_feedbackvkick).to("km/s")
+    gas_SNII_v_kick_max = (data.gas.maximal_sniikinetic_feedbackvkick).to("km/s")
+
+    # Limit only to those gas/stellar particles that were in fact kicked by SNII
+    stars_SNII_kicked = stars_SNII_v_kick_max > 0.0
+    gas_SNII_kicked = gas_SNII_v_kick_max > 0.0
+
+    # Select only those parts that were kicked by SNII in the past
+    stars_SNII_v_kick_max = stars_SNII_v_kick_max[stars_SNII_kicked]
+    gas_SNII_v_kick_max = gas_SNII_v_kick_max[gas_SNII_kicked]
+
+    # All kicks (contained in gas + stars info)
+    v_kick_max_all = np.concatenate(
+        [
+            stars_SNII_v_kick_max,
+            gas_SNII_v_kick_max,
+        ]
+    )
+
+    return v_kick_max_all
+
+
+def make_single_image(
+    filenames, names, v_kick_bounds, number_of_simulations, output_path
+):
+    """
+    Makes a single histogram of the maximal SNII kick velocities.
+    """
+
+    fig, ax = plt.subplots()
+
+    ax.set_xlabel("Maximal SNII kick velocity $v_{\\rm kick,max}$ [km s$^{-1}$]")
+    ax.set_ylabel("PDF [-]")
+    ax.loglog()
+
+    for filename, name in zip(filenames, names):
+        v_kick_max = get_data(filename)
+        h, bin_edges = np.histogram(
+            np.log10(v_kick_max), range=np.log10(v_kick_bounds), bins=250, density=True
+        )
+        bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
+        bins = 10 ** bins
+        ax.plot(bins, h, label=name)
+
+    ax.legend()
+    ax.set_xlim(*v_kick_bounds)
+
+    fig.savefig(f"{output_path}/SNII_maximal_kick_velocities.png")
+
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(
+        description="Basic max SNII kick velocity histogram."
+    )
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        v_kick_bounds=v_kick_bounds,
+        number_of_simulations=arguments.number_of_inputs,
+        output_path=arguments.output_directory,
+    )

--- a/colibre/scripts/max_temperatures.py
+++ b/colibre/scripts/max_temperatures.py
@@ -7,11 +7,7 @@ import numpy as np
 
 from swiftsimio import load
 
-from unyt import unyt_quantity
-from matplotlib.colors import LogNorm
-from matplotlib.animation import FuncAnimation
-
-T_bounds = [1e5, 3e10]
+T_bounds = [1e5, 3e10]  # in K
 
 
 def get_data(filename):


### PR DESCRIPTION
Hi @JBorrow 

I am adding two new plots showing the distribution of kick velocities from SNII feedback. 

This is the first-ever diagnostics of SNII kinetic feedback in the pipeline.

Here is an example of a webpage including this update: [LINK](http://swift.dur.ac.uk/COLIBREPlots/chaikin/individual_runs/HAWK/L006N188/z2.0_39_only_UVB_L006N0188/)