### PR TITLE
Add temperature-density plot colour-coded by mass fraction of SF gas

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -26,6 +26,11 @@ scripts:
     output_file: density_temperature.png
     section: Density-Temperature
     title: Density-Temperature
+  - filename: scripts/density_temperature_sf_fraction.py
+    caption: Density-temperature diagram shaded by the mass fraction of the gas whose instantaneous star formation rate is greater than zero.
+    output_file: density_temperature_sf_fraction.png
+    section: Density-Temperature
+    title: Density-Temperature (Star Forming Gas)
   - filename: scripts/density_temperature_metals.py
     caption: Density-temperature diagram with the pixel value weighted by the mean logarithmic metal mass fraction (absolute) in that bin. Medians are not used due to their computational complexity. If present, dashed line represents the entropy floor (equation of state).
     output_file: density_temperature_metals.png
@@ -98,7 +103,7 @@ scripts:
     title: Stellar Birth Densities-Birth Redshift
     section: Stellar Birth Densities
     output_file: birth_density_redshift.png
-  - filename: scripts/metallicity_redshift.py
+  - filename: scripts/birth_metallicity_redshift.py
     caption: Stellar metallicity vs birth redshift diagram. The pixel colour indicates the number of stellar particles in the pixel. At a given birth redshift, particles with metallicities lower than the smallest value along the X axis are placed in the lowest-metallicity bin.
     title: Stellar Metallicity-Birth Redshift
     section: Stellar Birth Densities

--- a/colibre/scripts/birth_density_distribution.py
+++ b/colibre/scripts/birth_density_distribution.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import unyt
 
-from unyt import mh, cm
+from unyt import mh
 
 from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
@@ -86,7 +86,7 @@ data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
 number_of_bins = 256
 
 birth_density_bins = unyt.unyt_array(
-    np.logspace(-3, 5, number_of_bins), units=1 / cm ** 3
+    np.logspace(-2, 6.5, number_of_bins), units="1/cm**3"
 )
 log_birth_density_bin_width = np.log10(birth_density_bins[1].value) - np.log10(
     birth_density_bins[0].value
@@ -110,7 +110,7 @@ for label, ax in ax_dict.items():
 
 for color, (snapshot, name) in enumerate(zip(data, names)):
 
-    birth_densities = (snapshot.stars.birth_densities / mh).to(birth_density_bins.units)
+    birth_densities = snapshot.stars.birth_densities.to("g/cm**3") / mh.to("g")
     birth_redshifts = 1 / snapshot.stars.birth_scale_factors.value - 1
 
     # Segment birth densities into redshift bins
@@ -149,7 +149,10 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
             y_points = np.zeros_like(H)
 
         ax.plot(
-            birth_density_centers, y_points, label=name, color=f"C{color}",
+            birth_density_centers,
+            y_points,
+            label=name,
+            color=f"C{color}",
         )
 
         # Add the median stellar birth-density line
@@ -163,7 +166,11 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
 
         # Add the DV&S2012 line
         ax.axvline(
-            n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5,
+            n_crit,
+            color=f"C{color}",
+            linestyle="dotted",
+            zorder=-10,
+            alpha=0.5,
         )
 
 axes[0].legend(loc="upper right", markerfirst=False)

--- a/colibre/scripts/birth_density_metallicity.py
+++ b/colibre/scripts/birth_density_metallicity.py
@@ -7,11 +7,11 @@ import numpy as np
 
 from swiftsimio import load
 
-from unyt import mh, cm
+from unyt import mh
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-density_bounds = [0.01, 1e5]  # in nh/cm^3
+density_bounds = [0.01, 10 ** 6.5]  # in nh/cm^3
 metal_mass_fraction_bounds = [1e-4, 0.5]  # dimensionless
 bins = 128
 
@@ -23,7 +23,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    birth_densities = (data.stars.birth_densities / mh).to(cm ** -3)
+    birth_densities = data.stars.birth_densities.to("g/cm**3") / mh.to("g")
     try:
         metal_mass_fractions = data.stars.smoothed_metal_mass_fractions.value
     except AttributeError:
@@ -32,7 +32,9 @@ def get_data(filename):
     below_Z_min = np.where(metal_mass_fractions < metal_mass_fraction_bounds[0])
 
     # Stars with Z < lowest Z in the figure should be added to the lowest-Z bin
-    metal_mass_fractions[below_Z_min] = metal_mass_fraction_bounds[0] * (1. + 1e-3/bins)
+    metal_mass_fractions[below_Z_min] = metal_mass_fraction_bounds[0] * (
+        1.0 + 1e-3 / bins
+    )
 
     return birth_densities.value, metal_mass_fractions
 
@@ -73,7 +75,11 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/birth_density_redshift.py
+++ b/colibre/scripts/birth_density_redshift.py
@@ -7,11 +7,11 @@ import numpy as np
 
 from swiftsimio import load
 
-from unyt import mh, cm
+from unyt import mh
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-density_bounds = [0.01, 1e5]  # in nh/cm^3
+density_bounds = [0.01, 10 ** 6.5]  # in nh/cm^3
 redshift_bounds = [-1.5, 12]  # dimensionless
 bins = 128
 
@@ -23,7 +23,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    birth_densities = (data.stars.birth_densities / mh).to(cm ** -3)
+    birth_densities = data.stars.birth_densities.to("g/cm**3") / mh.to("g")
     birth_redshifts = 1 / data.stars.birth_scale_factors.value - 1
 
     return birth_densities.value, birth_redshifts
@@ -61,7 +61,11 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/birth_metallicity_redshift.py
+++ b/colibre/scripts/birth_metallicity_redshift.py
@@ -1,5 +1,5 @@
 """
-Makes a stellar metallicity vs. redshift 2D plot. Uses the swiftsimio library.
+Makes a stellar birth metallicity vs. redshift 2D plot. Uses the swiftsimio library.
 """
 
 import matplotlib.pyplot as plt
@@ -73,7 +73,11 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_sf_fraction.py
+++ b/colibre/scripts/density_temperature_sf_fraction.py
@@ -1,0 +1,233 @@
+"""
+Makes a rho-T plot colour-coded by mass fraction of star-forming gas.
+Uses the swiftsimio library.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+
+from unyt import mh, cm, unyt_array
+from matplotlib.colors import Normalize
+
+# Constants; these could be put in the parameter file but are rarely changed.
+density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
+sf_mass_fraction_bounds = [-2.5, 0]  # log mass fraction of star-forming gas
+min_sf_mass_fraction = 1e-6  # Minimal mass fraction of star-forming gas
+bins = 256
+
+
+def get_data(filename):
+    """
+    Grabs the data (T in Kelvin, density in mh / cm^3, mass in Msun, mask with gas
+    particles whose SFR > 0).
+    """
+
+    data = load(filename)
+
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
+    temperature = data.gas.temperatures.to_physical().to("K")
+    mass = data.gas.masses.to("Msun")
+    sfr = data.gas.star_formation_rates.to("Msun/yr")
+
+    # Select only star-forming gas
+    only_star_forming_gas = sfr > 0.0 * sfr.units
+
+    return number_density.value, temperature.value, mass, only_star_forming_gas
+
+
+def make_hist(filename, density_bounds, temperature_bounds, bins):
+    """
+    Makes the histogram for filename with bounds as lower, higher
+    for the bins and "bins" the number of bins along each dimension.
+    Also returns the edges for pcolormesh to use.
+    """
+
+    density_bins = np.logspace(
+        np.log10(density_bounds[0]), np.log10(density_bounds[1]), bins
+    )
+    temperature_bins = np.logspace(
+        np.log10(temperature_bounds[0]), np.log10(temperature_bounds[1]), bins
+    )
+
+    dens, temps, mass, star_forming_gas = get_data(filename)
+
+    H, density_edges, temperature_edges = np.histogram2d(
+        dens[star_forming_gas],
+        temps[star_forming_gas],
+        bins=[density_bins, temperature_bins],
+        weights=mass[star_forming_gas],
+    )
+
+    H_norm, _, _ = np.histogram2d(
+        dens, temps, bins=[density_bins, temperature_bins], weights=mass
+    )
+
+    # Avoid bins with 0 and 1/0 values
+    mask = H == 0.0
+    H[mask] = min_sf_mass_fraction
+    H_norm[mask] = 1.0
+
+    return (
+        np.log10(np.ma.array((H / H_norm).T, mask=mask.T)),
+        density_edges,
+        temperature_edges,
+    )
+
+
+def setup_axes(number_of_simulations: int):
+    """
+    Creates the figure and axis object. Creates a grid of a x b subplots
+    that add up to at least number_of_simulations.
+    """
+
+    sqrt_number_of_simulations = np.sqrt(number_of_simulations)
+    horizontal_number = int(np.ceil(sqrt_number_of_simulations))
+    # Ensure >= number_of_simulations plots in a grid
+    vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
+
+    fig, ax = plt.subplots(
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+    )
+
+    ax = np.array([ax]) if number_of_simulations == 1 else ax
+
+    if horizontal_number * vertical_number > number_of_simulations:
+        for axis in ax.flat[number_of_simulations:]:
+            axis.axis("off")
+
+    # Set all valid on bottom row to have the horizontal axis label.
+    for axis in np.atleast_2d(ax)[:][-1]:
+        axis.set_xlabel("Density [$n_H$ cm$^{-3}$]")
+
+    for axis in np.atleast_2d(ax).T[:][0]:
+        axis.set_ylabel("Temperature [K]")
+
+    ax.flat[0].loglog()
+
+    return fig, ax
+
+
+def plot_eos(metadata, ax):
+    """
+    Plots the Equation of State (Entropy Floor) and +0.3 dex in Temperature,
+    which should generally enclose particles with divergent subgrid
+    properties.
+    """
+
+    parameters = metadata.parameters
+
+    for name in ["Cool", "Jeans"]:
+        try:
+            norm_H = float(
+                parameters[f"COLIBREEntropyFloor:{name}_density_norm_H_p_cm3"]
+            )
+            gamma_eff = float(parameters[f"COLIBREEntropyFloor:{name}_gamma_effective"])
+            norm_T = float(parameters[f"COLIBREEntropyFloor:{name}_temperature_norm_K"])
+        except:
+            continue
+
+        first_point_H = 1e-10 * norm_H
+        second_point_H = 1e10 * norm_H
+        temp_first_point = norm_T * (first_point_H / norm_H) ** (gamma_eff - 1)
+        temp_second_point = norm_T * (second_point_H / norm_H) ** (gamma_eff - 1)
+
+        ax.plot(
+            unyt_array([first_point_H, second_point_H], "cm**-3"),
+            unyt_array([temp_first_point, temp_second_point], "K"),
+            linestyle="dashed",
+            alpha=0.5,
+            color="k",
+            lw=0.5,
+        )
+
+        ax.plot(
+            unyt_array([first_point_H, second_point_H], "cm**-3"),
+            unyt_array([temp_first_point, temp_second_point], "K") * pow(10, 0.3),
+            linestyle="dotted",
+            alpha=0.5,
+            color="k",
+            lw=0.5,
+        )
+
+    return
+
+
+def make_single_image(
+    filenames,
+    names,
+    number_of_simulations,
+    density_bounds,
+    temperature_bounds,
+    sf_mass_fraction_bounds,
+    bins,
+    output_path,
+):
+    """
+    Makes a single plot of rho-T
+    """
+
+    fig, ax = setup_axes(number_of_simulations=number_of_simulations)
+
+    hists = []
+
+    for filename in filenames:
+        hist, d, T = make_hist(filename, density_bounds, temperature_bounds, bins)
+        hists.append(hist)
+
+    for filename, hist, name, axis in zip(filenames, hists, names, ax.flat):
+        mappable = axis.pcolormesh(
+            d,
+            T,
+            hist,
+            norm=Normalize(
+                vmin=sf_mass_fraction_bounds[0], vmax=sf_mass_fraction_bounds[1]
+            ),
+        )
+        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        metadata = load(filename).metadata
+        plot_eos(metadata, axis)
+        axis.set_xlim(*density_bounds)
+        axis.set_ylim(*temperature_bounds)
+
+    fig.colorbar(
+        mappable,
+        ax=ax.ravel().tolist(),
+        label="log Mass Fraction of Star-Forming Gas",
+    )
+
+    fig.savefig(f"{output_path}/density_temperature_sf_fraction.png")
+
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(description="Basic density-temperature figure.")
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        number_of_simulations=arguments.number_of_inputs,
+        density_bounds=density_bounds,
+        temperature_bounds=temperature_bounds,
+        sf_mass_fraction_bounds=sf_mass_fraction_bounds,
+        bins=bins,
+        output_path=arguments.output_directory,
+    )

--- a/colibre/scripts/gas_smoothing_lengths.py
+++ b/colibre/scripts/gas_smoothing_lengths.py
@@ -8,7 +8,7 @@ import numpy as np
 from swiftsimio import load
 from unyt import unyt_quantity, dimensionless, Mpc
 
-h_bounds = [1e-2, 5e2]  # comoving kpc
+h_bounds = [1e-3, 5e2]  # comoving kpc
 
 
 def get_data(filename):

--- a/colibre/scripts/last_SNII_density_distribution.py
+++ b/colibre/scripts/last_SNII_density_distribution.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import unyt
 
-from unyt import mh, cm
+from unyt import mh
 
 from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
@@ -87,7 +87,7 @@ data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
 number_of_bins = 256
 
 SNII_density_bins = unyt.unyt_array(
-    np.logspace(-5, 5, number_of_bins), units=1 / cm ** 3
+    np.logspace(-5, 6.5, number_of_bins), units="1/cm**3"
 )
 log_SNII_density_bin_width = np.log10(SNII_density_bins[1].value) - np.log10(
     SNII_density_bins[0].value
@@ -112,9 +112,9 @@ for label, ax in ax_dict.items():
 
 for color, (snapshot, name) in enumerate(zip(data, names)):
 
-    stars_SNII_densities = (snapshot.stars.densities_at_last_supernova_event / mh).to(
-        SNII_density_bins.units
-    )
+    stars_SNII_densities = snapshot.stars.densities_at_last_supernova_event.to(
+        "g/cm**3"
+    ) / mh.to("g")
 
     # swift-colibre master branch as of Feb 26 2021
     try:

--- a/colibre/scripts/max_temperatures.py
+++ b/colibre/scripts/max_temperatures.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from swiftsimio import load
 
-T_bounds = [1e5, 3e10]  # in K
+T_bounds = [1e5, 1e11]  # in K
 
 
 def get_data(filename):


### PR DESCRIPTION
**Big change**
- Add Temperature-Density plot colour-coded by the mass fraction of SF gas

**Minor changes**
- Extend axes ranges in several scripts (stellar birth densities, max temperatures, sph smoothing lengths)
- Fix the bug with infinite densities 
- Rename the `metallicity_redshift` script to `birth_metallicity_redshift`
