### PR TITLE
Fix two small bugs with additional data points

### DIFF
--- a/colibre/auto_plotter/star_formation_rates.yml
+++ b/colibre/auto_plotter/star_formation_rates.yml
@@ -86,9 +86,6 @@ stellar_mass_specific_sfr_all_100:
     end:
       value: 1e12
       units: solar_mass
-    lower:
-      value: 1.01e-11
-      units: 1 / year
   metadata:
     title: Specific Star Formation Rate - Stellar Mass (100 kpc aperture)
     caption: All galaxies, including those deemed to be passive (below 0.01 / Gyr sSFR), are included in the median line.
@@ -121,9 +118,6 @@ stellar_mass_specific_sfr_all_30:
     end:
       value: 1e12
       units: solar_mass
-    lower:
-      value: 1.01e-11
-      units: 1 / year
   metadata:
     title: Specific Star Formation Rate - Stellar Mass (30 kpc aperture)
     caption: All galaxies, including those deemed to be passive (below 0.01 / Gyr sSFR), are included in the median line.
@@ -160,9 +154,6 @@ stellar_mass_specific_sfr_active_100:
     end:
       value: 1e12
       units: solar_mass
-    lower:
-      value: 1.01e-11
-      units: 1 / year
   metadata:
     title: Specific Star Formation Rate - Stellar Mass (100 kpc aperture, active only)
     caption: Only active galaxies (threshold is above 0.01 / Gyr sSFR) are included in the median line.
@@ -198,9 +189,6 @@ stellar_mass_specific_sfr_active_30:
     end:
       value: 1e12
       units: solar_mass
-    lower:
-      value: 1.01e-11
-      units: 1 / year
   metadata:
     title: Specific Star Formation Rate - Stellar Mass (30 kpc aperture, active only)
     caption: Only active galaxies (threshold is above 0.01 / Gyr sSFR) are included in the median line.
@@ -237,9 +225,6 @@ halo_mass_specific_sfr_30:
     end:
       value: 1e13
       units: solar_mass
-    lower:
-      value: 1.01e-11
-      units: 1 / year
   metadata:
     title: Specific Star Formation Rate (30 kpc aperture) - Halo Mass
     caption: Only active galaxies (threshold is above 0.01 / Gyr sSFR) are included in the median line.
@@ -273,9 +258,6 @@ halo_mass_specific_sfr_100:
     end:
       value: 1e13
       units: solar_mass
-    lower:
-      value: 1.01e-11
-      units: 1 / year
   metadata:
     title: Specific Star Formation Rate (100 kpc aperture) - Halo Mass
     caption: Only active galaxies (threshold is above 0.01 / Gyr sSFR) are included in the median line.

--- a/colibre/auto_plotter/stellar_mass_halo_mass.yml
+++ b/colibre/auto_plotter/stellar_mass_halo_mass.yml
@@ -120,7 +120,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
   median:
     plot: true
     log: true
-    adapive: true
+    adaptive: true
     number_of_bins: 30
     start:
       value: 9e3


### PR DESCRIPTION
Finally fixing this

![bug1](https://user-images.githubusercontent.com/20153933/111044060-9528fa80-8446-11eb-9c1c-04b98f2ceef4.png)

and this

![bug2](https://user-images.githubusercontent.com/20153933/111044063-99551800-8446-11eb-8d18-1da467c4de2a.png)

The former bug is the result of applying a mask associated with the plot's `upper` and `lower` attributes to the data points **after** the adaptive bins have been generated. In the sSFR plots, the mask `sSFR > lower = 10^{-11} 1/yr` is unnecessary. If the plot is for active-only objects, we don't have data points with `sSFR < 10^{-11} 1/yr` to begin with. The latter is because we apply `get_quantity_from_catalogue_with_mask()`, which already includes the mask with  `sSFR < 10^{-11} 1/yr`, to the raw data points before `add_median_line()` is called.

The latter bug is caused by a typo in the config file.
 
