### PR TITLE
Reduce the number of plots in Colibre 

### DIFF
--- a/colibre/auto_plotter/cold_gas_relations.yml
+++ b/colibre/auto_plotter/cold_gas_relations.yml
@@ -88,6 +88,7 @@ stellar_mass_neutral_to_stellar_fraction_100:
     title: Stellar Mass-Neutral To Stellar Gas Fraction (100 kpc Stellar Mass)
     caption: All galaxies are included in the median line. Gas fraction is HI + H$_2$ mass divided by stellar mass in a 100 kpc aperture.
     section: Cold Gas Relations (Stellar Mass)
+    show_on_webpage: false
 
 stellar_mass_molecular_to_stellar_plus_molecular_fraction_30:
   type: "scatter"
@@ -147,6 +148,7 @@ stellar_mass_molecular_to_stellar_plus_molecular_fraction_100:
     title: Stellar Mass-Molecular Gas To Molecular Plus Stellar Fraction (100 kpc Stellar Mass)
     caption: All galaxies are included in the median line. Gas fraction is H$_2$ mass divided by H$_2$ mass + stellar mass in a 100 kpc aperture.
     section: Cold Gas Relations (Stellar Mass)
+    show_on_webpage: false
 
 stellar_mass_H2_mass_30:
   type: "scatter"
@@ -207,6 +209,7 @@ stellar_mass_H2_mass_100:
     title: Stellar Mass-H$_2$ Gas Mass (100 kpc Stellar Mass)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
+    show_on_webpage: false
 
 stellar_mass_HI_mass_30:
   type: "scatter"
@@ -268,6 +271,7 @@ stellar_mass_HI_mass_100:
     title: Stellar Mass-HI Gas Mass (100 kpc Stellar Mass)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
+    show_on_webpage: false
 
 H2_mass_star_formation_rate_30:
   type: "scatter"
@@ -329,6 +333,7 @@ H2_mass_star_formation_rate_100:
     title: H$_2$ Gas Mass - Star Formation Rate
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Gas Mass)
+    show_on_webpage: false
 
 stellar_mass_neutral_H_to_baryonic_fraction_100:
   type: "scatter"
@@ -453,6 +458,7 @@ stellar_mass_sf_to_sf_plus_stellar_fraction_100:
     title: Stellar Mass-SF gas to SF Gas + Stellar Fraction (100 kpc Stellar Mass)
     caption: All galaxies are included in the median line. Fraction is star-forming gas mass over SF gas + stellar mass in a 100 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
+    show_on_webpage: false
 
 stellar_mass_neutral_H_to_sf_fraction_100:
   type: "scatter"
@@ -483,6 +489,7 @@ stellar_mass_neutral_H_to_sf_fraction_100:
     title: Stellar Mass-Neutral to SF Gas Fraction (100 kpc Stellar Mass)
     caption: All galaxies are included in the median line. Fraction is HI + H$_2$ gas mass over SF gas in a 100 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
+    show_on_webpage: false
 
 stellar_mass_HI_to_sf_fraction_100:
   type: "scatter"
@@ -513,6 +520,7 @@ stellar_mass_HI_to_sf_fraction_100:
     title: Stellar Mass-HI to SF Gas Fraction (100 kpc Stellar Mass)
     caption: All galaxies are included in the median line. Fraction is HI gas mass over SF gas in a 100 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
+    show_on_webpage: false
 
 stellar_mass_H2_to_sf_fraction_100:
   type: "scatter"
@@ -664,6 +672,7 @@ sfr_sf_to_stellar_fraction_kpc_100:
     title: sSFR-SF Gas to Stellar Fraction (100 kpc Stellar Mass)
     caption: All galaxies are included in the median line. Fraction is SF gas mass over stellar mass in a 100 kpc aperture.
     section: Cold Gas Fractions (sSFR)
+    show_on_webpage: false
 
 sigma_neutral_H_to_baryonic_fraction_100:
   type: "scatter"
@@ -693,6 +702,8 @@ sigma_neutral_H_to_baryonic_fraction_100:
     title: Surface Density-Neutral Gas to Baryonic Fraction (100 kpc Stellar Mass)
     caption: All galaxies are included in the median line. Fraction is neutral gas mass over baryonic mass in a 100 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
+    show_on_webpage: false
+
 
 sigma_hi_to_neutral_H_fraction_100:
   type: "scatter"
@@ -723,6 +734,7 @@ sigma_hi_to_neutral_H_fraction_100:
     title: Surface Density-HI Gas to Neutral Fraction (100 kpc Stellar Mass)
     caption: All galaxies are included in the median line. Fraction is HI gas mass over neutral gas mass in a 100 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
+    show_on_webpage: false
 
 sigma_h2_to_neutral_H_fraction_100:
   type: "scatter"
@@ -753,6 +765,7 @@ sigma_h2_to_neutral_H_fraction_100:
     title: Surface Density-H$_2$ Gas to Neutral Fraction (100 kpc Stellar Mass)
     caption: All galaxies are included in the median line. Fraction is H$_2$ gas mass over neutral gas mass in a 100 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
+    show_on_webpage: false
 
 sigma_sf_to_sf_plus_stellar_fraction_100:
   type: "scatter"
@@ -782,3 +795,4 @@ sigma_sf_to_sf_plus_stellar_fraction_100:
     title: Surface Density-SF Gas to SF Gas + Stellar Fraction (100 kpc Stellar Mass)
     caption: All galaxies are included in the median line. Fraction is SF gas mass over SF gas mass + Stellar mass in a 100 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
+    show_on_webpage: false

--- a/colibre/auto_plotter/gas_mass_functions.yml
+++ b/colibre/auto_plotter/gas_mass_functions.yml
@@ -77,7 +77,7 @@ adaptive_gas_H2_mass_function:
     end: 0.316 # (1e-0.5)
   metadata:
     title: H$_2$ Mass Function
-    caption: H$_2$ MF, showing all galaxies with a fixed bin-width of 0.2 dex. H$_2$ mass corrected for Helium (uses H$_2$ masses from the whole FOF halo).
+    caption: H$_2$ MF, showing all galaxies with an adaptive bin-width. H$_2$ mass corrected for Helium (uses H$_2$ masses from the whole FOF halo).
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyH2MassFunction/Fletcher2020.hdf5

--- a/colibre/auto_plotter/star_formation_rates.yml
+++ b/colibre/auto_plotter/star_formation_rates.yml
@@ -262,6 +262,7 @@ halo_mass_specific_sfr_100:
     title: Specific Star Formation Rate (100 kpc aperture) - Halo Mass
     caption: Only active galaxies (threshold is above 0.01 / Gyr sSFR) are included in the median line.
     section: Star Formation Rates
+    show_on_webpage: false
 
 halo_mass_sfr_30_halo_mass:
   type: "scatter"
@@ -333,6 +334,7 @@ stellar_mass_passive_fraction_30:
   type: "scatter"
   legend_loc: "lower left"
   redshift_loc: "upper center"
+  min_num_points_highlight: 0
   x:
     quantity: "apertures.mass_star_30_kpc"
     units: solar_mass
@@ -370,6 +372,7 @@ stellar_mass_passive_fraction_100:
   type: "scatter"
   legend_loc: "lower left"
   redshift_loc: "upper center"
+  min_num_points_highlight: 0
   x:
     quantity: "apertures.mass_star_100_kpc"
     units: solar_mass

--- a/colibre/auto_plotter/stellar_birth_densities.yml
+++ b/colibre/auto_plotter/stellar_birth_densities.yml
@@ -26,6 +26,7 @@ stellar_birth_density_halo_mass_average_of_log_all:
     title: Average of log Stellar Birth Density-Halo Mass relation
     caption: Includes all haloes, including subhaloes.
     section: Stellar Birth Densities
+    show_on_webpage: false
 
 stellar_birth_density_halo_mass_max_all:
   type: "scatter"
@@ -55,6 +56,7 @@ stellar_birth_density_halo_mass_max_all:
     title: Maximal Stellar Birth Density-Halo Mass relation
     caption: Includes all haloes, including subhaloes.
     section: Stellar Birth Densities
+    show_on_webpage: false
 
 stellar_birth_density_stellar_mass_average_of_log_all_100:
   type: "scatter"


### PR DESCRIPTION
We currently have too many plots (especially cold-gas-related plots)

Also,

- set the minimum number of additional points in the passive-fractions plots to **zero**
- Fix caption of the gas-mass function figure with adaptive binning 