### PR TITLE
Rearrange Colibre registration file

### DIFF
--- a/colibre/auto_plotter/cold_gas_fractions.yml
+++ b/colibre/auto_plotter/cold_gas_fractions.yml
@@ -95,7 +95,7 @@ cold_gas_frac_func_ssfr:
   metadata:
     title: sSFR-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy neutral gas mass mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy neutral gas mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyColdGasFractions/Catinella2018_abcissa_sSFR.hdf5
 

--- a/colibre/auto_plotter/cold_gas_fractions.yml
+++ b/colibre/auto_plotter/cold_gas_fractions.yml
@@ -25,7 +25,7 @@ h2_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. Grossi+16 use a Herschel (FIR) detected (by >5$\sigma$ in 4 bands) sample of Virgo Cluster star-forming dwarf galaxies, with CO detection. This biases towards higher SFR and metallicity systems. conversion uses a radio H-band luminosity estimate. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XCOLDGASS (Saintonge+17) is a uniform subsample of XGASS (see Stellar Mass-HI Fraction caption) plotting those above the CO detection limit ($M_{\rm H2}/M_*$ > $1.5\%$).    
+    caption: Galaxy H$_2$ mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
     - filename: GalaxyH2Fractions/Hunt2020_Data.hdf5
@@ -95,7 +95,7 @@ cold_gas_frac_func_ssfr:
   metadata:
     title: sSFR-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyColdGasFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -127,7 +127,7 @@ h2_to_neutral_gas_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over neutral gas (HI+H$_2$) mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS and XCOLDGASS samples are uniform in mass in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$ and $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$ and plotting those above the CO detection limit ($M_{\rm H2}/M_*$ > $1.5\%$).
+    caption: Galaxy H$_2$ mass over neutral gas (HI+H$_2$) mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS and XCOLDGASS samples are uniform in mass in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$ and $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$ and plotting those above the CO detection limit ($M_{\rm H2}/M_*$ > $1.5\%$).
   observational_data:
     - filename: GalaxyColdGasFractions/CatinellaSaintongeComposite_abcissa_M_star.hdf5
     - filename: GalaxyColdGasFractions/Hunt2020_Data.hdf5
@@ -162,7 +162,7 @@ h2_to_neutral_gas_frac_func_ssfr:
   metadata:
     title: sSFR-H2 Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over neutral gas mass (HI+H$_2$) as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass over neutral gas mass (HI+H$_2$) as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyColdGasFractions/CatinellaSaintongeComposite_abcissa_sSFR.hdf5
 

--- a/colibre/auto_plotter/cold_gas_fractions.yml
+++ b/colibre/auto_plotter/cold_gas_fractions.yml
@@ -25,7 +25,7 @@ h2_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy neutral gas mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
     - filename: GalaxyH2Fractions/Hunt2020_Data.hdf5
@@ -95,14 +95,13 @@ cold_gas_frac_func_ssfr:
   metadata:
     title: sSFR-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy neutral gas mass mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyColdGasFractions/Catinella2018_abcissa_sSFR.hdf5
 
 h2_to_neutral_gas_frac_func_stellar_mass:
   type: "scatter"
   legend_loc: "lower left"
-  comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
@@ -137,7 +136,6 @@ h2_to_neutral_gas_frac_func_stellar_mass:
 h2_to_neutral_gas_frac_func_ssfr:
   type: "scatter"
   legend_loc: "upper right"
-  comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
     quantity: "derived_quantities.specific_sfr_gas_100_kpc"
     units: "1 / Gigayear"

--- a/colibre/auto_plotter/cold_gas_relations.yml
+++ b/colibre/auto_plotter/cold_gas_relations.yml
@@ -24,7 +24,7 @@ stellar_mass_molecular_to_neutral_fraction_30:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Molecular to Neutral Gas Fraction (30 kpc Stellar Mass)
+    title: Stellar Mass-Molecular to Neutral Gas Fraction (30 kpc aperture)
     caption: All galaxies are included in the median line. Gas fraction is H$_2$ mass over HI + H$_2$ mass in a 30 kpc aperture.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -55,7 +55,7 @@ stellar_mass_neutral_to_stellar_fraction_30:
       units: Solar_Mass
 
   metadata:
-    title: Stellar Mass-Neutral To Stellar Gas Fraction (30 kpc Stellar Mass)
+    title: Stellar Mass-Neutral To Stellar Gas Fraction (30 kpc aperture)
     caption: All galaxies are included in the median line. Gas fraction is HI + H$_2$ mass divided by stellar mass in a 30 kpc aperture.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -85,7 +85,7 @@ stellar_mass_neutral_to_stellar_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Neutral To Stellar Gas Fraction (100 kpc Stellar Mass)
+    title: Stellar Mass-Neutral To Stellar Gas Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Gas fraction is HI + H$_2$ mass divided by stellar mass in a 100 kpc aperture.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -115,7 +115,7 @@ stellar_mass_molecular_to_stellar_plus_molecular_fraction_30:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Molecular Gas To Molecular Plus Stellar Fraction (30 kpc Stellar Mass)
+    title: Stellar Mass-Molecular Gas To Molecular Plus Stellar Fraction (30 kpc aperture)
     caption: All galaxies are included in the median line. Gas fraction is H$_2$ mass divided by H$_2$ mass + stellar mass in a 30 kpc aperture.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -145,7 +145,7 @@ stellar_mass_molecular_to_stellar_plus_molecular_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Molecular Gas To Molecular Plus Stellar Fraction (100 kpc Stellar Mass)
+    title: Stellar Mass-Molecular Gas To Molecular Plus Stellar Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Gas fraction is H$_2$ mass divided by H$_2$ mass + stellar mass in a 100 kpc aperture.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -175,7 +175,7 @@ stellar_mass_H2_mass_30:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-H$_2$ Gas Mass (30 kpc)
+    title: Stellar Mass-H$_2$ Gas Mass (30 kpc aperture)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -206,7 +206,7 @@ stellar_mass_H2_mass_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-H$_2$ Gas Mass (100 kpc)
+    title: Stellar Mass-H$_2$ Gas Mass (100 kpc aperture)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -237,7 +237,7 @@ stellar_mass_HI_mass_30:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-HI Gas Mass (30 kpc)
+    title: Stellar Mass-HI Gas Mass (30 kpc aperture)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -268,7 +268,7 @@ stellar_mass_HI_mass_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-HI Gas Mass (100 kpc)
+    title: Stellar Mass-HI Gas Mass (100 kpc aperture)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -299,7 +299,7 @@ H2_mass_star_formation_rate_30:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: H$_2$ Gas Mass - Star Formation Rate (30 kpc)
+    title: H$_2$ Gas Mass - Star Formation Rate (30 kpc aperture)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Gas Mass)
     show_on_webpage: false
@@ -366,7 +366,7 @@ stellar_mass_neutral_H_to_baryonic_fraction_100:
       value: 1e99
       units: "dimensionless"
   metadata:
-    title: Stellar Mass-Neutral Gas to Baryonic Fraction (100 kpc Stellar Mass)
+    title: Stellar Mass-Neutral Gas to Baryonic Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is HI + H$_2$ mass over total baryonic mass in a 100 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
 
@@ -396,7 +396,7 @@ stellar_mass_HI_to_neutral_H_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-HI to Neutral Gas Fraction (100 kpc Stellar Mass)
+    title: Stellar Mass-HI to Neutral Gas Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is HI mass over HI + H$_2$ mass in a 100 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
 
@@ -426,7 +426,7 @@ stellar_mass_H2_to_neutral_H_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-H$_2$ to Neutral Gas Fraction (100 kpc Stellar Mass)
+    title: Stellar Mass-H$_2$ to Neutral Gas Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is H$_2$ mass over HI + H$_2$ mass in a 100 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
 
@@ -455,7 +455,7 @@ stellar_mass_sf_to_sf_plus_stellar_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-SF gas to SF Gas + Stellar Fraction (100 kpc Stellar Mass)
+    title: Stellar Mass-SF gas to SF Gas + Stellar Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is star-forming gas mass over SF gas + stellar mass in a 100 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
     show_on_webpage: false
@@ -486,7 +486,7 @@ stellar_mass_neutral_H_to_sf_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Neutral to SF Gas Fraction (100 kpc Stellar Mass)
+    title: Stellar Mass-Neutral to SF Gas Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is HI + H$_2$ gas mass over SF gas in a 100 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
     show_on_webpage: false
@@ -517,7 +517,7 @@ stellar_mass_HI_to_sf_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-HI to SF Gas Fraction (100 kpc Stellar Mass)
+    title: Stellar Mass-HI to SF Gas Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is HI gas mass over SF gas in a 100 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
     show_on_webpage: false
@@ -548,7 +548,7 @@ stellar_mass_H2_to_sf_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-H$_2$ to SF Gas Fraction (100 kpc Stellar Mass)
+    title: Stellar Mass-H$_2$ to SF Gas Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is H$_2$ gas mass over SF gas in a 100 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
 
@@ -578,7 +578,7 @@ sfr_neutral_to_stellar_mass_100_kpc_100:
       value: 10
       units: "1 / Gyr"
   metadata:
-    title: sSFR-Neutral Gas to SF Gas Fraction (100 kpc Stellar Mass)
+    title: sSFR-Neutral Gas to SF Gas Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is HI + H$_2$ mass over stellar mass in a 100 kpc aperture.
     section: Cold Gas Fractions (sSFR)
 
@@ -608,7 +608,7 @@ sfr_hi_to_stellar_mass_100_kpc_100:
       value: 10
       units: "1 / Gyr"
   metadata:
-    title: sSFR-HI Gas to SF Gas Fraction (100 kpc Stellar Mass)
+    title: sSFR-HI Gas to SF Gas Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is HI mass over stellar mass in a 100 kpc aperture.
     section: Cold Gas Fractions (sSFR)
 
@@ -638,7 +638,7 @@ sfr_h2_to_stellar_mass_100_kpc_100:
       value: 10
       units: "1 / Gyr"
   metadata:
-    title: sSFR-H$_2$ Gas to SF Gas Fraction (100 kpc Stellar Mass)
+    title: sSFR-H$_2$ Gas to SF Gas Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is H$_2$ mass over stellar mass in a 100 kpc aperture.
     section: Cold Gas Fractions (sSFR)
 
@@ -669,7 +669,7 @@ sfr_sf_to_stellar_fraction_kpc_100:
       value: 10
       units: "1 / Gyr"
   metadata:
-    title: sSFR-SF Gas to Stellar Fraction (100 kpc Stellar Mass)
+    title: sSFR-SF Gas to Stellar Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is SF gas mass over stellar mass in a 100 kpc aperture.
     section: Cold Gas Fractions (sSFR)
     show_on_webpage: false
@@ -699,7 +699,7 @@ sigma_neutral_H_to_baryonic_fraction_100:
       value: 1e10
       units: "Solar_Mass / kpc**2"
   metadata:
-    title: Surface Density-Neutral Gas to Baryonic Fraction (100 kpc Stellar Mass)
+    title: Surface Density-Neutral Gas to Baryonic Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is neutral gas mass over baryonic mass in a 100 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
     show_on_webpage: false
@@ -731,7 +731,7 @@ sigma_hi_to_neutral_H_fraction_100:
       value: 1e10
       units: "Solar_Mass / kpc**2"
   metadata:
-    title: Surface Density-HI Gas to Neutral Fraction (100 kpc Stellar Mass)
+    title: Surface Density-HI Gas to Neutral Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is HI gas mass over neutral gas mass in a 100 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
     show_on_webpage: false
@@ -762,7 +762,7 @@ sigma_h2_to_neutral_H_fraction_100:
       value: 1e10
       units: "Solar_Mass / kpc**2"
   metadata:
-    title: Surface Density-H$_2$ Gas to Neutral Fraction (100 kpc Stellar Mass)
+    title: Surface Density-H$_2$ Gas to Neutral Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is H$_2$ gas mass over neutral gas mass in a 100 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
     show_on_webpage: false
@@ -792,7 +792,7 @@ sigma_sf_to_sf_plus_stellar_fraction_100:
       value: 1e10
       units: "Solar_Mass / kpc**2"
   metadata:
-    title: Surface Density-SF Gas to SF Gas + Stellar Fraction (100 kpc Stellar Mass)
+    title: Surface Density-SF Gas to SF Gas + Stellar Fraction (100 kpc aperture)
     caption: All galaxies are included in the median line. Fraction is SF gas mass over SF gas mass + Stellar mass in a 100 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
     show_on_webpage: false

--- a/colibre/auto_plotter/cold_gas_relations.yml
+++ b/colibre/auto_plotter/cold_gas_relations.yml
@@ -159,7 +159,7 @@ stellar_mass_H2_mass_30:
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_H2_mass"
+    quantity: "derived_quantities.gas_H2_mass_30_kpc"
     units: "Solar_Mass"
     start: 1e5
     end: 1e11
@@ -175,7 +175,7 @@ stellar_mass_H2_mass_30:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-H$_2$ Gas Mass (30 kpc Stellar Mass)
+    title: Stellar Mass-H$_2$ Gas Mass (30 kpc)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -190,7 +190,7 @@ stellar_mass_H2_mass_100:
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_H2_mass"
+    quantity: "derived_quantities.gas_H2_mass_100_kpc"
     units: "Solar_Mass"
     start: 1e5
     end: 1e11
@@ -206,7 +206,7 @@ stellar_mass_H2_mass_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-H$_2$ Gas Mass (100 kpc Stellar Mass)
+    title: Stellar Mass-H$_2$ Gas Mass (100 kpc)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -221,7 +221,7 @@ stellar_mass_HI_mass_30:
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_HI_mass"
+    quantity: "derived_quantities.gas_HI_mass_30_kpc"
     units: "Solar_Mass"
     start: 1e5
     end: 1e11
@@ -237,7 +237,7 @@ stellar_mass_HI_mass_30:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-HI Gas Mass (30 kpc Stellar Mass)
+    title: Stellar Mass-HI Gas Mass (30 kpc)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -252,7 +252,7 @@ stellar_mass_HI_mass_100:
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_HI_mass"
+    quantity: "derived_quantities.gas_HI_mass_100_kpc"
     units: "Solar_Mass"
     start: 1e5
     end: 1e11
@@ -268,7 +268,7 @@ stellar_mass_HI_mass_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-HI Gas Mass (100 kpc Stellar Mass)
+    title: Stellar Mass-HI Gas Mass (100 kpc)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -278,7 +278,7 @@ H2_mass_star_formation_rate_30:
   legend_loc: "lower right"
   selection_mask: "derived_quantities.is_active_100_kpc"
   x:
-    quantity: "derived_quantities.gas_H2_mass"
+    quantity: "derived_quantities.gas_H2_mass_30_kpc"
     units: "Solar_Mass"
     start: 1e5
     end: 1e11
@@ -299,7 +299,7 @@ H2_mass_star_formation_rate_30:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: H$_2$ Gas Mass - Star Formation Rate
+    title: H$_2$ Gas Mass - Star Formation Rate (30 kpc)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Gas Mass)
     show_on_webpage: false
@@ -309,7 +309,7 @@ H2_mass_star_formation_rate_100:
   legend_loc: "lower right"
   selection_mask: "derived_quantities.is_active_100_kpc"
   x:
-    quantity: "derived_quantities.gas_H2_mass"
+    quantity: "derived_quantities.gas_H2_mass_100_kpc"
     units: "Solar_Mass"
     start: 1e5
     end: 1e11
@@ -330,7 +330,7 @@ H2_mass_star_formation_rate_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: H$_2$ Gas Mass - Star Formation Rate
+    title: H$_2$ Gas Mass - Star Formation Rate (100 kpc)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Gas Mass)
     show_on_webpage: false

--- a/colibre/auto_plotter/depletion_relations.yml
+++ b/colibre/auto_plotter/depletion_relations.yml
@@ -31,7 +31,7 @@ oxygen_abundance_v_dust_to_gas:
       value: 1
       units: "dimensionless"
   metadata:
-    title:  Oxygen abundance vs dust-to-gas ratio (100 kpc)
+    title:  Oxygen abundance vs dust-to-gas ratio (100 kpc aperture)
     caption: Dust-to-gas mass ratio as a function of oxygen number density abundance.
     section: Dust Depletion Relations
     show_on_webpage: true

--- a/colibre/auto_plotter/depletion_relations.yml
+++ b/colibre/auto_plotter/depletion_relations.yml
@@ -1,9 +1,9 @@
 oxygen_abundance_v_dust_to_gas:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.valid_abundances"
+  selection_mask: "derived_quantities.dust_valid_abundances_100_kpc"
   x:
-    quantity: "derived_quantities.gas_o_abundance"
+    quantity: "derived_quantities.gas_o_abundance_100_kpc"
     units: "dimensionless"
     start: 6.8
     end: 9.2

--- a/colibre/auto_plotter/dust_scaling_relations.yml
+++ b/colibre/auto_plotter/dust_scaling_relations.yml
@@ -73,7 +73,7 @@ hi_stellar_fraction_o_abundance:
   legend_loc: "upper right"
   selection_mask: "derived_quantities.is_active_100_kpc"
   x:
-    quantity: "derived_quantities.gas_o_abundance"
+    quantity: "derived_quantities.gas_o_abundance_100_kpc"
     units: "dimensionless"
     start: 6.8
     end: 9.2
@@ -97,7 +97,7 @@ hi_stellar_fraction_o_abundance:
       units: "dimensionless"
   metadata:
     title: HI-to-stellar mass ratio vs Oxygen abundance
-    caption: HI to stellar mass ratio as a function of the gas-phase Oxygen abundance measured in 100kpc apertures
+    caption: HI to stellar mass ratio as a function of the gas-phase Oxygen abundance measured in 100 kpc apertures
     section: Dust Scaling Relations
     show_on_webpage: true
   observational_data:

--- a/colibre/auto_plotter/gas_fraction_plots.yml
+++ b/colibre/auto_plotter/gas_fraction_plots.yml
@@ -9,7 +9,7 @@ h2_frac_func_stellar_mass:
     start: 1e9
     end: 1e12
   y:
-    quantity: "derived_quantities.h2_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -27,7 +27,7 @@ h2_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H_$2$ mass (100 kpc) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
 
@@ -42,7 +42,7 @@ h2_frac_func_ssfr:
     start: 1e-4
     end: 1e4
   y:
-    quantity: "derived_quantities.h2_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -60,7 +60,7 @@ h2_frac_func_ssfr:
   metadata:
     title: sSFR-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H_$2$ mass (100 kpc) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_sSFR.hdf5
 
@@ -75,7 +75,7 @@ h2_frac_func_stellar_surface_density:
     start: 1e7
     end: 1e11
   y:
-    quantity: "derived_quantities.h2_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -93,7 +93,7 @@ h2_frac_func_stellar_surface_density:
   metadata:
     title: Stellar Mass Surface Density-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H_$2$ mass (100 kpc) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_mu_star.hdf5
 

--- a/colibre/auto_plotter/gas_fraction_plots.yml
+++ b/colibre/auto_plotter/gas_fraction_plots.yml
@@ -9,7 +9,7 @@ h2_frac_func_stellar_mass:
     start: 1e9
     end: 1e12
   y:
-    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_to_stellar_mass_100_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -27,7 +27,7 @@ h2_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H_$2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H_$2$ mass (100 kpc) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
 
@@ -42,7 +42,7 @@ h2_frac_func_ssfr:
     start: 1e-4
     end: 1e4
   y:
-    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_to_stellar_mass_100_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -60,7 +60,7 @@ h2_frac_func_ssfr:
   metadata:
     title: sSFR-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H_$2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H_$2$ mass (100 kpc) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_sSFR.hdf5
 
@@ -75,7 +75,7 @@ h2_frac_func_stellar_surface_density:
     start: 1e7
     end: 1e11
   y:
-    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_to_stellar_mass_100_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -93,7 +93,7 @@ h2_frac_func_stellar_surface_density:
   metadata:
     title: Stellar Mass Surface Density-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H_$2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H_$2$ mass (100 kpc) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_mu_star.hdf5
 

--- a/colibre/auto_plotter/gas_mass_functions.yml
+++ b/colibre/auto_plotter/gas_mass_functions.yml
@@ -47,7 +47,7 @@ gas_H2_mass_function:
   legend_loc: "lower left"
   number_of_bins: 25
   x:
-    quantity: "derived_quantities.gas_H2_mass_100_kpc"
+    quantity: "derived_quantities.gas_H2_plus_He_mass_100_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e11
@@ -57,7 +57,7 @@ gas_H2_mass_function:
     end: 0.316 # (1e-0.5)
   metadata:
     title: H$_2$ Mass Function
-    caption: H$_2$ MF, showing all galaxies with a fixed bin-width of 0.2 dex (H2 masses 100 kpc).
+    caption: H$_2$ MF, showing all galaxies with a fixed bin-width of 0.2 dex. H$_2$ mass corrected for Helium (uses H$_2$ masses in 100 kpc apertures)
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyH2MassFunction/Fletcher2020.hdf5
@@ -67,7 +67,7 @@ adaptive_gas_H2_mass_function:
   legend_loc: "lower left"
   number_of_bins: 25
   x:
-    quantity: "derived_quantities.gas_H2_mass_100_kpc"
+    quantity: "derived_quantities.gas_H2_plus_He_mass_100_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e11
@@ -77,7 +77,7 @@ adaptive_gas_H2_mass_function:
     end: 0.316 # (1e-0.5)
   metadata:
     title: H$_2$ Mass Function
-    caption: H$_2$ MF, showing all galaxies with an adaptive bin-width (H2 masses 100 kpc).
+    caption: H$_2$ MF, showing all galaxies with an adaptive bin-width. H$_2$ mass corrected for Helium (uses H$_2$ masses in 100 kpc apertures)
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyH2MassFunction/Fletcher2020.hdf5

--- a/colibre/auto_plotter/gas_mass_functions.yml
+++ b/colibre/auto_plotter/gas_mass_functions.yml
@@ -3,7 +3,7 @@ gas_HI_mass_function:
   legend_loc: "lower left"
   number_of_bins: 25
   x:
-    quantity: "derived_quantities.gas_HI_mass"
+    quantity: "derived_quantities.gas_HI_mass_100_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e11
@@ -13,7 +13,7 @@ gas_HI_mass_function:
     end: 0.316 # (1e-0.5)
   metadata:
     title: HI Mass Function
-    caption: HIMF, showing all galaxies with a fixed bin-width of 0.2 dex (uses HI masses from the whole FOF halo).
+    caption: HIMF, showing all galaxies with a fixed bin-width of 0.2 dex (HI masses 100 kpc).
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyHIMassFunction/Zwaan2003.hdf5
@@ -25,7 +25,7 @@ adaptive_gas_HI_mass_function:
   legend_loc: "lower left"
   number_of_bins: 25
   x:
-    quantity: "derived_quantities.gas_HI_mass"
+    quantity: "derived_quantities.gas_HI_mass_100_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e11
@@ -35,7 +35,7 @@ adaptive_gas_HI_mass_function:
     end: 0.316 # (1e-0.5)
   metadata:
     title: HI Mass Function
-    caption: HIMF, showing all galaxies with an adaptive bin-width (uses HI masses from the whole FOF halo).
+    caption: HIMF, showing all galaxies with an adaptive bin-width (HI masses 100 kpc).
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyHIMassFunction/Zwaan2003.hdf5
@@ -47,7 +47,7 @@ gas_H2_mass_function:
   legend_loc: "lower left"
   number_of_bins: 25
   x:
-    quantity: "derived_quantities.gas_H2_plus_He_mass"
+    quantity: "derived_quantities.gas_H2_mass_100_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e11
@@ -57,7 +57,7 @@ gas_H2_mass_function:
     end: 0.316 # (1e-0.5)
   metadata:
     title: H$_2$ Mass Function
-    caption: H$_2$ MF, showing all galaxies with a fixed bin-width of 0.2 dex. H$_2$ mass corrected for Helium (uses H$_2$ masses from the whole FOF halo).
+    caption: H$_2$ MF, showing all galaxies with a fixed bin-width of 0.2 dex (H2 masses 100 kpc).
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyH2MassFunction/Fletcher2020.hdf5
@@ -67,7 +67,7 @@ adaptive_gas_H2_mass_function:
   legend_loc: "lower left"
   number_of_bins: 25
   x:
-    quantity: "derived_quantities.gas_H2_plus_He_mass"
+    quantity: "derived_quantities.gas_H2_mass_100_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e11
@@ -77,7 +77,7 @@ adaptive_gas_H2_mass_function:
     end: 0.316 # (1e-0.5)
   metadata:
     title: H$_2$ Mass Function
-    caption: H$_2$ MF, showing all galaxies with an adaptive bin-width. H$_2$ mass corrected for Helium (uses H$_2$ masses from the whole FOF halo).
+    caption: H$_2$ MF, showing all galaxies with an adaptive bin-width (H2 masses 100 kpc).
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyH2MassFunction/Fletcher2020.hdf5

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -211,8 +211,7 @@ def register_dust(self, catalogue):
     # If the catalogue has no dust fields
     except AttributeError:
         total_dust_fraction = unyt.unyt_array(
-            np.zeros(metal_frac.size),
-            units="dimensionless",
+            np.zeros(metal_frac.size), units="dimensionless"
         )
         dust_frac_error = " (no dust field)"
 
@@ -553,26 +552,14 @@ def register_cold_gas_mass_ratios(self, catalogue):
             f"gas_neutral_H_to_sf_fraction_{aperture_size}_kpc",
             neutral_H_to_sf_fraction,
         )
-        setattr(
-            self,
-            f"gas_HI_to_sf_fraction_{aperture_size}_kpc",
-            HI_to_sf_fraction,
-        )
-        setattr(
-            self,
-            f"gas_H2_to_sf_fraction_{aperture_size}_kpc",
-            H2_to_sf_fraction,
-        )
+        setattr(self, f"gas_HI_to_sf_fraction_{aperture_size}_kpc", HI_to_sf_fraction)
+        setattr(self, f"gas_H2_to_sf_fraction_{aperture_size}_kpc", H2_to_sf_fraction)
         setattr(
             self,
             f"gas_sf_to_stellar_fraction_{aperture_size}_kpc",
             sf_to_stellar_fraction,
         )
-        setattr(
-            self,
-            f"has_neutral_gas_{aperture_size}_kpc",
-            neutral_H_mass > 0.0,
-        )
+        setattr(self, f"has_neutral_gas_{aperture_size}_kpc", neutral_H_mass > 0.0)
 
     return
 

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -24,177 +24,259 @@ This file calculates:
         velociraptor outputs the log of the quantity we need, so we take exp(...) of it
 """
 
-# Aperture sizes in kpc in which stellar mass is computed
-aperture_sizes = [30, 100]
 
-# Specific star formation rate in apertures below which a galaxy is identified as
-# passive
-marginal_ssfr = unyt.unyt_quantity(1e-11, units=1 / unyt.year)
+def register_spesific_star_formation_rates(self, catalogue):
 
-for aperture_size in aperture_sizes:
-    halo_mass = catalogue.masses.mass_200crit
+    # Define aperture size in kpc
+    aperture_sizes = [30, 100]
 
-    stellar_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
-    # Need to mask out zeros, otherwise we get RuntimeWarnings
-    good_stellar_mass = stellar_mass > unyt.unyt_quantity(0.0, stellar_mass.units)
+    # Lowest sSFR below which the galaxy is considered passive
+    marginal_ssfr = unyt.unyt_quantity(1e-11, units=1 / unyt.year)
 
-    star_formation_rate = getattr(catalogue.apertures, f"sfr_gas_{aperture_size}_kpc")
+    for aperture_size in aperture_sizes:
 
-    ssfr = unyt.unyt_array(np.zeros(len(star_formation_rate)), units=1 / unyt.year)
-    ssfr[good_stellar_mass] = (
-        star_formation_rate[good_stellar_mass] / stellar_mass[good_stellar_mass]
-    )
-    ssfr.name = f"Specific SFR ({aperture_size} kpc)"
+        # Get the halo mass
+        halo_mass = catalogue.masses.mass_200crit
 
-    is_passive = unyt.unyt_array(
-        (ssfr < 1.01 * marginal_ssfr).astype(float), units="dimensionless"
-    )
-    is_passive.name = "Passive Fraction"
+        # Get stellar mass
+        stellar_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
+        # Need to mask out zeros, otherwise we get RuntimeWarnings
+        good_stellar_mass = stellar_mass > unyt.unyt_quantity(0.0, stellar_mass.units)
 
-    is_active = unyt.unyt_array(
-        (ssfr > 1.01 * marginal_ssfr).astype(float), units="dimensionless"
-    )
-    is_active.name = "Active Fraction"
+        # Get star formation rate
+        star_formation_rate = getattr(
+            catalogue.apertures, f"sfr_gas_{aperture_size}_kpc"
+        )
 
-    sfr_M200 = star_formation_rate / halo_mass
-    sfr_M200.name = "Star formation rate divided by halo mass"
+        # Compute specific star formation rate using the "good" stellar mass
+        ssfr = unyt.unyt_array(np.zeros(len(star_formation_rate)), units=1 / unyt.year)
+        ssfr[good_stellar_mass] = (
+            star_formation_rate[good_stellar_mass] / stellar_mass[good_stellar_mass]
+        )
 
-    setattr(self, f"specific_sfr_gas_{aperture_size}_kpc", ssfr)
-    setattr(self, f"is_passive_{aperture_size}_kpc", is_passive)
-    setattr(self, f"is_active_{aperture_size}_kpc", is_active)
-    setattr(self, f"sfr_halo_mass_{aperture_size}_kpc", sfr_M200)
+        # Name of the field
+        ssfr.name = f"Specific SFR ({aperture_size} kpc)"
 
-# Now metallicities relative to different units
-solar_metal_mass_fraction = 0.0126
-twelve_plus_log_OH_solar = 8.69
-minimal_twelve_plus_log_OH = 7.5
+        # Mask for the passive objects
+        is_passive = unyt.unyt_array(
+            (ssfr < 1.01 * marginal_ssfr).astype(float), units="dimensionless"
+        )
+        is_passive.name = "Passive Fraction"
 
-for aperture_size in aperture_sizes:
+        # Mask for the active objects
+        is_active = unyt.unyt_array(
+            (ssfr > 1.01 * marginal_ssfr).astype(float), units="dimensionless"
+        )
+        is_active.name = "Active Fraction"
+
+        # Get the specific star formation rate (per halo mass instead of stellar mass)
+        sfr_M200 = star_formation_rate / halo_mass
+        sfr_M200.name = "Star formation rate divided by halo mass"
+
+        # Register derived fields with specific star formation rates
+        setattr(self, f"specific_sfr_gas_{aperture_size}_kpc", ssfr)
+        setattr(self, f"is_passive_{aperture_size}_kpc", is_passive)
+        setattr(self, f"is_active_{aperture_size}_kpc", is_active)
+        setattr(self, f"sfr_halo_mass_{aperture_size}_kpc", sfr_M200)
+
+    return
+
+
+def register_star_metallicities(self, catalogue):
+
+    # Define aperture size in kpc
+    aperture_sizes = [30, 100]
+
+    # Solar metallicity
+    solar_metal_mass_fraction = 0.0126
+
+    for aperture_size in aperture_sizes:
+
+        try:
+            metal_mass_fraction_star = (
+                getattr(catalogue.apertures, f"zmet_star_{aperture_size}_kpc")
+                / solar_metal_mass_fraction
+            )
+            metal_mass_fraction_star.name = (
+                f"Star Metallicity $Z_*$ rel. to "
+                f"$Z_\\odot={solar_metal_mass_fraction}$ ({aperture_size} kpc)"
+            )
+            setattr(
+                self,
+                f"star_metallicity_in_solar_{aperture_size}_kpc",
+                metal_mass_fraction_star,
+            )
+        except AttributeError:
+            pass
+
+    return
+
+
+def register_gas_phase_metallicities(self, catalogue):
+
+    # Define aperture size in kpc
+    aperture_sizes = [30, 100]
+
+    # Metallicities relative to different units
+    solar_metal_mass_fraction = 0.0126
+    twelve_plus_log_OH_solar = 8.69
+    minimal_twelve_plus_log_OH = 7.5
+
+    for aperture_size in aperture_sizes:
+
+        try:
+
+            # Metallicity of star forming gas in units of solar metallicity
+            metal_mass_fraction_gas = (
+                getattr(catalogue.apertures, f"zmet_gas_sf_{aperture_size}_kpc")
+                / solar_metal_mass_fraction
+            )
+
+            # Handle scenario where metallicity is zero, as we are bounded
+            # by approx 1e-2 metal mass fraction anyway:
+            metal_mass_fraction_gas[metal_mass_fraction_gas < 1e-5] = 1e-5
+
+            # Get the log of the metallicity
+            log_metal_mass_fraction_gas = np.log10(metal_mass_fraction_gas.value)
+
+            # Get the O/H ratio
+            twelve_plus_log_OH = unyt.unyt_array(
+                twelve_plus_log_OH_solar + log_metal_mass_fraction_gas,
+                units="dimensionless",
+            )
+            twelve_plus_log_OH.name = (
+                f"Gas (SF) $12+\\log_{{10}}$O/H from "
+                f"$Z$ (Solar={twelve_plus_log_OH_solar}) ({aperture_size} kpc)"
+            )
+
+            # Gas metallicity cannot be lower than the minimal value
+            twelve_plus_log_OH[
+                twelve_plus_log_OH < minimal_twelve_plus_log_OH
+            ] = minimal_twelve_plus_log_OH
+
+            setattr(
+                self,
+                f"gas_sf_twelve_plus_log_OH_{aperture_size}_kpc",
+                twelve_plus_log_OH,
+            )
+        except AttributeError:
+            pass
+
+    return
+
+
+def register_stellar_to_halo_mass_ratios_bn98(self, catalogue):
+
+    # Define aperture size in kpc
+    aperture_sizes = [30, 100]
+
+    # Loop over apertures
+    for aperture_size in aperture_sizes:
+
+        # Get the stellar mass in the aperture of a given size
+        stellar_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
+
+        halo_M200crit = catalogue.masses.mass_200crit
+        smhm = stellar_mass / halo_M200crit
+        name = f"$M_* / M_{{\\rm 200crit}}$ ({aperture_size} kpc)"
+        smhm.name = name
+        setattr(self, f"stellar_mass_to_halo_mass_200crit_{aperture_size}_kpc", smhm)
+
+        halo_MBN98 = catalogue.masses.mass_bn98
+        smhm = stellar_mass / halo_MBN98
+        name = f"$M_* / M_{{\\rm BN98}}$ ({aperture_size} kpc)"
+        smhm.name = name
+        setattr(self, f"stellar_mass_to_halo_mass_bn98_{aperture_size}_kpc", smhm)
+
+    return
+
+
+def register_dust(self, catalogue):
+
+    # Metal mass fractions of the gas
+    metal_frac = catalogue.apertures.zmet_gas_100_kpc
+
+    # Get total dust mass fractions by iterating through available dust types
     try:
-        metal_mass_fraction_star = (
-            getattr(catalogue.apertures, f"zmet_star_{aperture_size}_kpc")
-            / solar_metal_mass_fraction
-        )
-        metal_mass_fraction_star.name = f"Star Metallicity $Z_*$ rel. to $Z_\\odot={solar_metal_mass_fraction}$ ({aperture_size} kpc)"
-        setattr(
-            self,
-            f"star_metallicity_in_solar_{aperture_size}_kpc",
-            metal_mass_fraction_star,
-        )
+        dust_fields = []
+        for sub_path in dir(catalogue.dust_mass_fractions):
+            if sub_path.startswith("dust_"):
+                dust_fields.append(getattr(catalogue.dust_mass_fractions, sub_path))
+        total_dust_fraction = sum(dust_fields)
+        dust_frac_error = ""
+
     except AttributeError:
-        pass
+        total_dust_fraction = np.zeros(metal_frac.size)
+        dust_frac_error = " (no dust field)"
 
-    try:
-        metal_mass_fraction_gas = (
-            getattr(catalogue.apertures, f"zmet_gas_sf_{aperture_size}_kpc")
-            / solar_metal_mass_fraction
-        )
+    total_dust_fraction.name = f"$\\mathcal{{DTG}}${dust_frac_error}"
 
-        # Handle scenario where metallicity is zero, as we are bounded
-        # by approx 1e-2 metal mass fraction anyway:
-        metal_mass_fraction_gas[metal_mass_fraction_gas < 1e-5] = 1e-5
+    # Compute total dust mass
+    total_dust_mass = total_dust_fraction * catalogue.masses.m_gas
+    total_dust_mass.name = f"$M_{{\\rm dust}}${dust_frac_error}"
 
-        log_metal_mass_fraction_gas = np.log10(metal_mass_fraction_gas.value)
-        twelve_plus_log_OH = unyt.unyt_array(
-            twelve_plus_log_OH_solar + log_metal_mass_fraction_gas,
-            units="dimensionless",
-        )
-        twelve_plus_log_OH.name = f"Gas (SF) $12+\\log_{{10}}$O/H from $Z$ (Solar={twelve_plus_log_OH_solar}) ({aperture_size} kpc)"
+    # Compute to metal ratio
+    dust_to_metals = total_dust_fraction / metal_frac
+    dust_to_metals.name = f"$\\mathcal{{DTM}}${dust_frac_error}"
 
-        twelve_plus_log_OH[
-            twelve_plus_log_OH < minimal_twelve_plus_log_OH
-        ] = minimal_twelve_plus_log_OH
+    # Compute dust to stellar ratio
+    dust_to_stars = total_dust_mass / catalogue.apertures.mass_star_100_kpc
+    dust_to_stars.name = f"$M_{{\\rm dust}}/M_*${dust_frac_error}"
 
-        setattr(
-            self, f"gas_sf_twelve_plus_log_OH_{aperture_size}_kpc", twelve_plus_log_OH
-        )
-    except AttributeError:
-        pass
+    # Mask galaxies where abundances are well defined
+    self.valid_abundances = np.isfinite(dust_to_metals)
 
-metal_frac = catalogue.apertures.zmet_gas_100_kpc
-nonmetal_frac = 1.0 - metal_frac
+    # Register derived fields with dust
+    setattr(self, f"total_dust_masses_100_kpc", total_dust_mass)
+    setattr(self, f"dust_to_metal_ratio_100_kpc", dust_to_metals)
+    setattr(self, f"dust_to_gas_ratio_100_kpc", total_dust_fraction)
+    setattr(self, f"dust_to_stellar_ratio_100_kpc", dust_to_stars)
 
-for aperture_size in aperture_sizes:
-    stellar_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
+    return
 
-    halo_M200crit = catalogue.masses.mass_200crit
-    smhm = stellar_mass / halo_mass
-    name = f"$M_* / M_{{\\rm 200crit}}$ ({aperture_size} kpc)"
-    smhm.name = name
-    setattr(self, f"stellar_mass_to_halo_mass_200crit_{aperture_size}_kpc", smhm)
-
-    halo_MBN98 = catalogue.masses.mass_bn98
-    smhm = stellar_mass / halo_MBN98
-    name = f"$M_* / M_{{\\rm BN98}}$ ({aperture_size} kpc)"
-    smhm.name = name
-    setattr(self, f"stellar_mass_to_halo_mass_bn98_{aperture_size}_kpc", smhm)
-
-
-# If present, iterate through available dust types
-try:
-    dust_fields = []
-    for sub_path in dir(catalogue.dust_mass_fractions):
-        if sub_path.startswith("dust_"):
-            dust_fields.append(getattr(catalogue.dust_mass_fractions, sub_path))
-    total_dust_fraction = sum(dust_fields)
-    dust_frac_error = ""
-except AttributeError:
-    total_dust_fraction = np.zeros(stellar_mass.size)
-    dust_frac_error = " (no dust field)"
-
-total_dust_mass = total_dust_fraction * catalogue.masses.m_gas
-name = f"$M_{{\\rm dust}}${dust_frac_error}"
-total_dust_mass.name = name
-total_dust_fraction.name = f"$\\mathcal{{DTG}}${dust_frac_error}"
-total_dust_mass = total_dust_fraction * catalogue.masses.m_gas
-total_dust_mass.name = f"$M_{{\\rm dust}}${dust_frac_error}"
-dust_to_metals = total_dust_fraction / metal_frac
-dust_to_metals.name = f"$\\mathcal{{DTM}}${dust_frac_error}"
-dust_to_stars = total_dust_mass / catalogue.apertures.mass_star_100_kpc
-dust_to_stars.name = f"$M_{{\\rm dust}}/M_*${dust_frac_error}"
-
-nonmetal_frac = 1.0 - catalogue.apertures.zmet_gas_100_kpc
-
-setattr(self, f"total_dust_masses_100_kpc", total_dust_mass)
-setattr(self, f"dust_to_metal_ratio_100_kpc", dust_to_metals)
-setattr(self, f"dust_to_gas_ratio_100_kpc", total_dust_fraction)
-setattr(self, f"dust_to_stellar_ratio_100_kpc", dust_to_stars)
 
 # Get depletion properties
-try:
-    # Abundances measured over entire subhalo, using VR additional properties
-    gas_mass = catalogue.masses.m_gas
-    H_frac = getattr(catalogue.element_mass_fractions, "element_0")
-    O_frac = getattr(catalogue.element_mass_fractions, "element_4")
-    o_abundance = unyt.unyt_array(
-        12 + np.log10(O_frac / (16 * H_frac)), "dimensionless"
-    )
-    o_abundance.name = "Gas $12+\\log_{10}({{\\rm O/H}})$"
-    setattr(self, "gas_o_abundance", o_abundance)
+def register_oxygen_to_hydrogen(self, catalogue):
 
-except AttributeError:
-    # We did not produce these quantities.
-    setattr(
-        self,
-        "gas_o_abundance",
-        unyt.unyt_array(
-            unyt.unyt_array(np.ones(np.size(catalogue.masses.m_gas)), "dimensionless"),
-            name="$12+\\log_10({{\\rm O/H}})$ not found, default to 1s",
-        ),
-    )
+    try:
+        # Abundances measured over entire subhalo, using VR additional properties
+        H_frac = getattr(catalogue.element_mass_fractions, "element_0")
+        O_frac = getattr(catalogue.element_mass_fractions, "element_4")
+        o_abundance = unyt.unyt_array(
+            12 + np.log10(O_frac / (16 * H_frac)), "dimensionless"
+        )
+        o_abundance.name = "Gas $12+\\log_{10}({{\\rm O/H}})$"
+        setattr(self, "gas_o_abundance", o_abundance)
+
+    except AttributeError:
+        # We did not produce these quantities.
+        setattr(
+            self,
+            "gas_o_abundance",
+            unyt.unyt_array(
+                unyt.unyt_array(
+                    np.ones(np.size(catalogue.masses.m_gas)), "dimensionless"
+                ),
+                name="$12+\\log_10({{\\rm O/H}})$ not found, default to 1",
+            ),
+        )
+
+    return
 
 
-# mask galaxies where abundances are well defined
-self.valid_abundances = np.isfinite(dust_to_metals)
+def register_hi_masses_and_dust_to_hi_ratio(self, catalogue):
 
-# Get HI masses
-try:
+    # Mass fraction of X + Y in the gas
+    nonmetal_frac = 1.0 - catalogue.apertures.zmet_gas_100_kpc
+
+    # Get HI masses
     gas_mass = catalogue.masses.m_gas
     H_frac = getattr(catalogue.element_mass_fractions, "element_0")
 
     # Try CHIMES arrays
     if hasattr(catalogue.species_fractions, "species_7"):
         HI_frac = getattr(catalogue.species_fractions, "species_1")
+
     # If species_7 doesn't exist, switch to the (default) Table-cooling case
     else:
         HI_frac = getattr(catalogue.species_fractions, "species_0")
@@ -206,37 +288,50 @@ try:
     setattr(self, "gas_HI_mass", HI_mass)
     setattr(self, "gas_HI_plus_He_mass", HI_mass_wHe)
 
-except AttributeError:
-    # We did not produce these quantities.
-    setattr(
-        self,
-        "gas_HI_mass",
-        unyt.unyt_array(
-            catalogue.masses.m_gas, name="$M{\\rm HI}$ not found, showing $M_{\\rm g}$"
-        ),
-    )
+    # Get HI to dust ratio
+    try:
 
-# Get HI to dust ratio
-try:
-    dust_to_hi_ratio = total_dust_mass / HI_mass
-    dust_to_hi_ratio.name = "M_{{\\rm dust}}/M_{{\\rm HI}}"
-    setattr(self, "gas_dust_to_hi_ratio", dust_to_hi_ratio)
+        # Compute total dust mass
+        dust_fields = []
+        for sub_path in dir(catalogue.dust_mass_fractions):
+            if sub_path.startswith("dust_"):
+                dust_fields.append(getattr(catalogue.dust_mass_fractions, sub_path))
+        total_dust_fraction = sum(dust_fields)
+        total_dust_mass = total_dust_fraction * catalogue.masses.m_gas
 
-except AttributeError:
-    # We did not produce these quantities.
-    setattr(
-        self,
-        "gas_dust_to_hi_ratio",
-        unyt.unyt_array(
-            unyt.unyt_array(np.ones(np.size(catalogue.masses.m_gas)), "dimensionless"),
-            name="$M_{{\\rm dust}}/M_{{\\rm HI}}$ not found, default to 1s",
-        ),
-    )
+        # Compute dust-to-HI mass ratios
+        dust_to_hi_ratio = total_dust_mass / HI_mass
+
+        # Register the field
+        dust_to_hi_ratio.name = "M_{{\\rm dust}}/M_{{\\rm HI}}"
+        setattr(self, "gas_dust_to_hi_ratio", dust_to_hi_ratio)
+
+    # Dust might not be present
+    except AttributeError:
+
+        # We did not produce these quantities.
+        setattr(
+            self,
+            "gas_dust_to_hi_ratio",
+            unyt.unyt_array(
+                unyt.unyt_array(
+                    np.ones(np.size(catalogue.masses.m_gas)), "dimensionless"
+                ),
+                name="$M_{{\\rm dust}}/M_{{\\rm HI}}$ not found, default to 1s",
+            ),
+        )
+
+    return
 
 
-# Get H2 masses
-try:
+def register_h2_masses(self, catalogue):
+
+    # Mass fraction of X + Y in the gas
+    nonmetal_frac = 1.0 - catalogue.apertures.zmet_gas_100_kpc
+
+    # Fetch gas mass
     gas_mass = catalogue.masses.m_gas
+    # Fetch hydrogen mass fraction
     H_frac = getattr(catalogue.element_mass_fractions, "element_0")
 
     # Try CHIMES arrays
@@ -246,25 +341,25 @@ try:
     else:
         H2_frac = getattr(catalogue.species_fractions, "species_2")
 
+    # Compute H2 mass
     H2_mass = gas_mass * H_frac * H2_frac * 2.0
+    # With He
     H2_mass_wHe = gas_mass * nonmetal_frac * H2_frac * 2.0
-    H2_mass.name = "$M_{\\rm H_2}$"
 
+    # Register fields
+    H2_mass.name = "$M_{\\rm H_2}$"
     setattr(self, "gas_H2_mass", H2_mass)
     setattr(self, "gas_H2_plus_He_mass", H2_mass_wHe)
 
-except AttributeError:
-    # We did not produce these quantities.
-    setattr(
-        self,
-        "gas_H2_mass",
-        unyt.unyt_array(
-            catalogue.masses.m_gas, name="$M{\\rm H_2}$ not found, showing $M_{\\rm g}$"
-        ),
-    )
+    return
 
-# Get neutral H masses and fractions
-try:
+
+def register_cold_gas_mass_ratios(self, catalogue):
+
+    # Define aperture size in kpc
+    aperture_sizes = [30, 100]
+
+    # Get neutral H masses and fractions
     gas_mass = catalogue.masses.m_gas
     H_frac = getattr(catalogue.element_mass_fractions, "element_0")
 
@@ -277,21 +372,32 @@ try:
         HI_frac = getattr(catalogue.species_fractions, "species_0")
         H2_frac = getattr(catalogue.species_fractions, "species_2")
 
+    # Compute HI and H2 mass
     HI_mass = gas_mass * H_frac * HI_frac
-    H2_mass = gas_mass * H_frac * H2_frac * 2
-    neutral_H_mass = HI_mass + H2_mass
-    neutral_H_mass.name = "$M_{\\rm HI + H_2}$"
+    H2_mass = gas_mass * H_frac * H2_frac * 2.0
 
+    # Compute neutral H mass
+    neutral_H_mass = HI_mass + H2_mass
+
+    # Register H neutral field
+    neutral_H_mass.name = "$M_{\\rm HI + H_2}$"
     setattr(self, "gas_neutral_H_mass", neutral_H_mass)
 
+    # Loop over aperture sizes
     for aperture_size in aperture_sizes:
+
+        # Fetch total stellar mass
         stellar_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
+        # Fetch mass of star-forming gas
         sf_mass = getattr(catalogue.apertures, f"mass_gas_sf_{aperture_size}_kpc")
+
+        # Compute neutral to stellar ratio
         neutral_H_to_stellar_fraction = neutral_H_mass / stellar_mass
         neutral_H_to_stellar_fraction.name = (
             f"$M_{{\\rm HI + H_2}} / M_*$ ({aperture_size} kpc)"
         )
 
+        # Compute molecular H to molecular plus stellar fraction
         molecular_H_to_molecular_plus_stellar_fraction = H2_mass / (
             H2_mass + stellar_mass
         )
@@ -299,11 +405,13 @@ try:
             f"$M_{{\\rm H_2}} / (M_* + M_{{\\rm H_2}})$ ({aperture_size} kpc)"
         )
 
+        # Compute molecular to neutral ratio
         molecular_H_to_neutral_fraction = H2_mass / neutral_H_mass
         molecular_H_to_neutral_fraction.name = (
             f"$M_{{\\rm H_2}} / M_{{\\rm HI + H_2}}$ ({aperture_size} kpc)"
         )
 
+        # Compute neutral to baryonic fraction
         neutral_H_to_baryonic_fraction = neutral_H_mass / (
             neutral_H_mass + stellar_mass
         )
@@ -311,26 +419,28 @@ try:
             f"$M_{{\\rm HI + H_2}}/((M_*+ M_{{\\rm HI + H_2}})$ ({aperture_size} kpc)"
         )
 
+        # HI mass to neutral H ratio
         HI_to_neutral_H_fraction = HI_mass / neutral_H_mass
-        HI_to_neutral_H_fraction[np.isnan(HI_to_neutral_H_fraction)] = 0. * unyt.dimensionless
         HI_to_neutral_H_fraction.name = (
             f"$M_{{\\rm HI}}/M_{{\\rm HI + H_2}}$ ({aperture_size} kpc)"
         )
 
+        # H2 mass to neutral H ratio
         H2_to_neutral_H_fraction = H2_mass / neutral_H_mass
-        H2_to_neutral_H_fraction[np.isnan(H2_to_neutral_H_fraction)] = 0. * unyt.dimensionless
         H2_to_neutral_H_fraction.name = (
             f"$M_{{\\rm H_2}}/M_{{\\rm HI + H_2}}$ ({aperture_size} kpc)"
         )
-        
-        sf_to_sf_plus_stellar_fraction = sf_mass / (
-            sf_mass + stellar_mass)
+
+        # SF mass to SF mass plus stellar mass ratio
+        sf_to_sf_plus_stellar_fraction = sf_mass / (sf_mass + stellar_mass)
         sf_to_sf_plus_stellar_fraction.name = (
             f"$M_{{\\rm SF}}/(M_{{\\rm SF}} + M_*)$ ({aperture_size} kpc)"
         )
 
+        # Select only the star-forming gas mass that is greater than zero
         mask = sf_mass > 0.0 * sf_mass.units
 
+        # Compute neutral H to SF gas mass ratio
         neutral_H_to_sf_fraction = unyt.unyt_array(
             np.zeros_like(neutral_H_mass), units="dimensionless"
         )
@@ -339,21 +449,25 @@ try:
             f"$M_{{\\rm HI + H_2}}/M_{{\\rm SF}}$ ({aperture_size} kpc)"
         )
 
+        # Compute HI to SF gas mass ratio
         HI_to_sf_fraction = unyt.unyt_array(
             np.zeros_like(HI_mass), units="dimensionless"
         )
         HI_to_sf_fraction[mask] = HI_mass[mask] / sf_mass[mask]
         HI_to_sf_fraction.name = f"$M_{{\\rm HI}}/M_{{\\rm SF}}$ ({aperture_size} kpc)"
 
+        # Compute H2 to SF gas mass ratio
         H2_to_sf_fraction = unyt.unyt_array(
             np.zeros_like(H2_mass), units="dimensionless"
         )
         H2_to_sf_fraction[mask] = H2_mass[mask] / sf_mass[mask]
         H2_to_sf_fraction.name = f"$M_{{\\rm H_2}}/M_{{\\rm SF}}$ ({aperture_size} kpc)"
 
+        # Compute SF gas mss to stellar mass ratio
         sf_to_stellar_fraction = sf_mass / stellar_mass
         sf_to_stellar_fraction.name = f"$M_{{\\rm SF}}/M_*$ ({aperture_size} kpc)"
 
+        # Finally, register all the above fields
         setattr(
             self,
             f"gas_neutral_H_to_stellar_fraction_{aperture_size}_kpc",
@@ -394,212 +508,156 @@ try:
             f"gas_neutral_H_to_sf_fraction_{aperture_size}_kpc",
             neutral_H_to_sf_fraction,
         )
-        setattr(
-            self, f"gas_HI_to_sf_fraction_{aperture_size}_kpc", HI_to_sf_fraction,
-        )
-        setattr(
-            self, f"gas_H2_to_sf_fraction_{aperture_size}_kpc", H2_to_sf_fraction,
-        )
+        setattr(self, f"gas_HI_to_sf_fraction_{aperture_size}_kpc", HI_to_sf_fraction)
+        setattr(self, f"gas_H2_to_sf_fraction_{aperture_size}_kpc", H2_to_sf_fraction)
         setattr(
             self,
             f"gas_sf_to_stellar_fraction_{aperture_size}_kpc",
             sf_to_stellar_fraction,
         )
-        setattr(
-            self, f"has_neutral_gas_{aperture_size}_kpc", neutral_H_mass > 0.0,
-        )
+        setattr(self, f"has_neutral_gas_{aperture_size}_kpc", neutral_H_mass > 0.0)
 
-except AttributeError:
-    # We did not produce these quantities.
-    setattr(
-        self,
-        "gas_neutral_H_mass",
-        unyt.unyt_array(
-            catalogue.masses.m_gas,
-            name="$M_{\\rm HI + H_2}$ not found, showing $M_{\\rm g}$",
-        ),
+    return
+
+
+def register_species_fractions(self, catalogue):
+
+    # Mass fraction of X + Y in the gas
+    nonmetal_frac = 1.0 - catalogue.apertures.zmet_gas_100_kpc
+
+    # species fraction properties
+    gas_mass = catalogue.apertures.mass_gas_100_kpc
+
+    # Compute gas area
+    gal_area = (
+        2
+        * np.pi
+        * catalogue.projected_apertures.projected_1_rhalfmass_star_100_kpc ** 2
     )
-    # We did not produce these fractions, let's make an arrays of ones.
-    ones = unyt.unyt_array(
-        np.ones(np.size(catalogue.masses.mass_200crit)), "dimensionless"
+
+    # Mass in the projected apertures
+    mstar_100 = catalogue.projected_apertures.projected_1_mass_star_100_kpc
+
+    # Selection functions for the xGASS and xCOLDGASS surveys, used for the H species
+    # fraction comparison. Note these are identical mass selections, but are separated
+    # to keep survey selections explicit and to allow more detailed selection criteria
+    # to be added for each.
+
+    self.xgass_galaxy_selection = np.logical_and(
+        catalogue.apertures.mass_star_100_kpc
+        > unyt.unyt_quantity(10 ** 9, "Solar_Mass"),
+        catalogue.apertures.mass_star_100_kpc
+        < unyt.unyt_quantity(10 ** (11.5), "Solar_Mass"),
     )
-    for aperture_size in aperture_sizes:
-        setattr(
-            self,
-            f"gas_neutral_H_to_stellar_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(
-                ones,
-                name="$M_{{\\rm HI + H_2}} / M_*$ ({aperture_size} kpc) not found, showing $1$",
-            ),
-        )
-        setattr(
-            self,
-            f"gas_molecular_H_to_molecular_plus_stellar_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(
-                ones,
-                name=f"$M_{{\\rm H_2}} / (M_* + M_{{\\rm H_2}})$ ({aperture_size} kpc) not found, showing $1$",
-            ),
-        )
-        setattr(
-            self,
-            f"gas_molecular_H_to_neutral_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(
-                ones,
-                name=f"$M_{{\\rm H_2}} / M_{{\\rm HI + H_2}}$ ({aperture_size} kpc) not found, showing $1$",
-            ),
-        )
-        setattr(
-            self,
-            f"gas_neutral_H_to_baryonic_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
-        )
-        setattr(
-            self,
-            f"gas_HI_to_neutral_H_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
-        )
-        setattr(
-            self,
-            f"gas_H2_to_neutral_H_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
-        )
-        setattr(
-            self,
-            f"gas_sf_to_sf_plus_stellar_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
-        )
-        setattr(
-            self,
-            f"gas_neutral_H_to_sf_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
-        )
-        setattr(
-            self,
-            f"gas_HI_to_sf_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
-        )
-        setattr(
-            self,
-            f"gas_H2_to_sf_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
-        )
-        setattr(
-            self,
-            f"gas_sf_to_stellar_fraction_{aperture_size}_kpc",
-            unyt.unyt_array(ones, name="Fraction not found, showing $1$",),
-        )
-        setattr(
-            self, f"has_neutral_gas_{aperture_size}_kpc", ones.astype(bool),
-        )
+    self.xcoldgass_galaxy_selection = np.logical_and(
+        catalogue.apertures.mass_star_100_kpc
+        > unyt.unyt_quantity(10 ** 9, "Solar_Mass"),
+        catalogue.apertures.mass_star_100_kpc
+        < unyt.unyt_quantity(10 ** (11.5), "Solar_Mass"),
+    )
 
-# species fraction properties
-gas_mass = catalogue.apertures.mass_gas_100_kpc
-gal_area = (
-    2 * np.pi * catalogue.projected_apertures.projected_1_rhalfmass_star_100_kpc ** 2
-)
-mstar_100 = catalogue.projected_apertures.projected_1_mass_star_100_kpc
+    # Register stellar mass density
+    self.mu_star_100_kpc = mstar_100 / gal_area
+    self.mu_star_100_kpc.name = "$M_{*, 100 {\\rm kpc}} / \\pi R_{*, 100 {\\rm kpc}}^2$"
 
-# Selection functions for the xGASS and xCOLDGASS surveys, used for the H species fraction comparison.
-# Note these are identical mass selections, but are separated to keep survey selections explicit
-# and to allow more detailed selection criteria to be added for each.
+    # Fetch hydrogen mass fraction
+    H_frac = getattr(catalogue.element_mass_fractions, "element_0")
 
-self.xgass_galaxy_selection = np.logical_and(
-    catalogue.apertures.mass_star_100_kpc > unyt.unyt_quantity(10 ** 9, "Solar_Mass"),
-    catalogue.apertures.mass_star_100_kpc
-    < unyt.unyt_quantity(10 ** (11.5), "Solar_Mass"),
-)
+    # Try CHIMES arrays
+    if hasattr(catalogue.species_fractions, "species_7"):
+        HI_frac = getattr(catalogue.species_fractions, "species_1")
+        H2_frac = getattr(catalogue.species_fractions, "species_7")
+    # Default to Table-cooling arrays
+    else:
+        HI_frac = getattr(catalogue.species_fractions, "species_0")
+        H2_frac = getattr(catalogue.species_fractions, "species_2")
 
-self.xcoldgass_galaxy_selection = np.logical_and(
-    catalogue.apertures.mass_star_100_kpc > unyt.unyt_quantity(10 ** 9, "Solar_Mass"),
-    catalogue.apertures.mass_star_100_kpc
-    < unyt.unyt_quantity(10 ** (11.5), "Solar_Mass"),
-)
+    # H2 and HI with He
+    H2_mass_wHe = gas_mass * nonmetal_frac * H2_frac * 2.0
+    HI_mass_wHe = gas_mass * nonmetal_frac * HI_frac
 
-self.mu_star_100_kpc = mstar_100 / gal_area
-self.mu_star_100_kpc.name = "$\\pi R_{*, 100 {\\rm kpc}}^2 / M_{*, 100 {\\rm kpc}}$"
+    # Neutral hydrogen mass in the 100-kpc aperture
+    self.neutral_hydrogen_mass_100_kpc = gas_mass * H_frac * HI_frac
+    self.neutral_hydrogen_mass_100_kpc.name = "HI Mass (100 kpc)"
 
-try:
-    H_frac = catalogue.element_mass_fractions.element_0
-    hydrogen_frac_error = ""
-except:
+    # Neutral hydrogen to stellar mass in the 100 kpc aperture
+    self.hi_to_stellar_mass_100_kpc = (
+        self.neutral_hydrogen_mass_100_kpc / catalogue.apertures.mass_star_100_kpc
+    )
+    self.hi_to_stellar_mass_100_kpc.name = "$M_{{\\rm HI}} / M_*$ (100 kpc)"
 
-    H_frac = 0.0
-    hydrogen_frac_error = "(no H abundance)"
+    # Molecular hydrogen mass in the 100-kpc aperture
+    # (species_H2 already contains a factor of 2.0)
+    self.molecular_hydrogen_mass_100_kpc = gas_mass * H_frac * H2_frac * 2.0
+    self.molecular_hydrogen_mass_100_kpc.name = "H$_2$ Mass (100 kpc)"
 
-try:
-    # Test for CHIMES arrays
-    species_HI = catalogue.species_fractions.species_1
-    species_H2 = 2.0 * catalogue.species_fractions.species_7
-    species_frac_error = ""
-except:
+    # Molecular hydrogen to stellar mass in the 100 kpc aperture
+    self.h2_to_stellar_mass_100_kpc = (
+        self.molecular_hydrogen_mass_100_kpc / catalogue.apertures.mass_star_100_kpc
+    )
+    self.h2_to_stellar_mass_100_kpc.name = "$M_{{\\rm H_2}} / M_*$ (100 kpc)"
+
+    # H2 with He / stellar mass
+    self.h2_plus_he_to_stellar_mass_100_kpc = (
+        H2_mass_wHe / catalogue.apertures.mass_star_100_kpc
+    )
+    self.h2_plus_he_to_stellar_mass_100_kpc.name = (
+        "$M_{{\\rm H_2}} / M_*$ (100 kpc, inc. He)"
+    )
+
+    # HI with He / stellar mass
+    self.hi_plus_he_to_stellar_mass_100_kpc = (
+        HI_mass_wHe / catalogue.apertures.mass_star_100_kpc
+    )
+    self.hi_plus_he_to_stellar_mass_100_kpc.name = (
+        f"$M_{{\\rm HI}} / M_*$ (100 kpc, inc. He)"
+    )
+
+    # Neutral H / stellar mass
+    self.neutral_to_stellar_mass_100_kpc = (
+        self.hi_to_stellar_mass_100_kpc + self.h2_to_stellar_mass_100_kpc
+    )
+
+    self.neutral_to_stellar_mass_100_kpc.name = f"$M_{{\\rm HI + H_2}} / M_*$ (100 kpc)"
+
+    return
+
+
+def register_stellar_birth_densities(self, catalogue):
+
     try:
-        # Test for COLIBRE arrays
-        species_HI = catalogue.species_fractions.species_0
-        species_H2 = 2.0 * catalogue.species_fractions.species_2
-        species_frac_error = ""
+        average_log_n_b = catalogue.stellar_birth_densities.logaverage
+        stellar_mass = catalogue.apertures.mass_star_100_kpc
+
+        exp_average_log_n_b = unyt.unyt_array(
+            np.exp(average_log_n_b), units=average_log_n_b.units
+        )
+
+        # Ensure haloes with zero stellar mass have zero stellar birth densities
+        no_stellar_mass = stellar_mass <= unyt.unyt_quantity(0.0, stellar_mass.units)
+        exp_average_log_n_b[no_stellar_mass] = unyt.unyt_quantity(
+            0.0, average_log_n_b.units
+        )
+
+        name = "Stellar Birth Density (average of log)"
+        exp_average_log_n_b.name = name
+        setattr(self, "average_of_log_stellar_birth_density", exp_average_log_n_b)
+
     except:
-        species_HI = 0.0
-        species_H2 = 0.0
-        species_frac_error = "(no species field)"
+        pass
 
-total_error = f" {species_frac_error}{hydrogen_frac_error}"
-
-self.neutral_hydrogen_mass_100_kpc = gas_mass * H_frac * species_HI
-self.hi_to_stellar_mass_100_kpc = (
-    self.neutral_hydrogen_mass_100_kpc / catalogue.apertures.mass_star_100_kpc
-)
-self.molecular_hydrogen_mass_100_kpc = gas_mass * H_frac * species_H2
-self.h2_to_stellar_mass_100_kpc = (
-    self.molecular_hydrogen_mass_100_kpc / catalogue.apertures.mass_star_100_kpc
-)
-
-self.h2_plus_he_to_stellar_mass_100_kpc = (
-    H2_mass_wHe / catalogue.apertures.mass_star_100_kpc
-)
-self.hi_plus_he_to_stellar_mass_100_kpc = (
-    HI_mass_wHe / catalogue.apertures.mass_star_100_kpc
-)
-self.cold_gas_to_stellar_mass_100_kpc = (
-    HI_mass_wHe + H2_mass_wHe
-) / catalogue.apertures.mass_star_100_kpc
+    return
 
 
-self.neutral_to_stellar_mass_100_kpc = (
-    self.hi_to_stellar_mass_100_kpc + self.h2_to_stellar_mass_100_kpc
-)
-
-self.neutral_hydrogen_mass_100_kpc.name = f"HI Mass (100 kpc){total_error}"
-self.hi_to_stellar_mass_100_kpc.name = f"$M_{{\\rm HI}} / M_*$ (100 kpc) {total_error}"
-self.molecular_hydrogen_mass_100_kpc.name = f"H$_2$ Mass (100 kpc){total_error}"
-self.h2_to_stellar_mass_100_kpc.name = f"$M_{{\\rm H_2}} / M_*$ (100 kpc) {total_error}"
-self.h2_plus_he_to_stellar_mass_100_kpc.name = (
-    f"$M_{{\\rm H_2}} / M_*$ (100 kpc, inc. He) {total_error}"
-)
-self.hi_plus_he_to_stellar_mass_100_kpc.name = (
-    f"$M_{{\\rm HI}} / M_*$ (100 kpc, inc. He) {total_error}"
-)
-
-self.neutral_to_stellar_mass_100_kpc.name = (
-    f"$M_{{\\rm HI + H_2}} / M_*$ (100 kpc) {total_error}"
-)
-
-# Formatting script for average of the log of stellar birth densities
-try:
-    average_log_n_b = catalogue.stellar_birth_densities.logaverage
-    stellar_mass = catalogue.apertures.mass_star_100_kpc
-
-    exp_average_log_n_b = unyt.unyt_array(
-        np.exp(average_log_n_b), units=average_log_n_b.units
-    )
-
-    # Ensure haloes with zero stellar mass have zero stellar birth densities
-    no_stellar_mass = stellar_mass <= unyt.unyt_quantity(0.0, stellar_mass.units)
-    exp_average_log_n_b[no_stellar_mass] = unyt.unyt_quantity(
-        0.0, average_log_n_b.units
-    )
-
-    name = "Stellar Birth Density (average of log)"
-    exp_average_log_n_b.name = name
-    setattr(self, "average_of_log_stellar_birth_density", exp_average_log_n_b)
-except AttributeError:
-    pass
+# Register derived fields
+register_spesific_star_formation_rates(self, catalogue)
+register_star_metallicities(self, catalogue)
+register_gas_phase_metallicities(self, catalogue)
+register_stellar_to_halo_mass_ratios_bn98(self, catalogue)
+register_dust(self, catalogue)
+register_oxygen_to_hydrogen(self, catalogue)
+register_hi_masses_and_dust_to_hi_ratio(self, catalogue)
+register_h2_masses(self, catalogue)
+register_cold_gas_mass_ratios(self, catalogue)
+register_species_fractions(self, catalogue)
+register_stellar_birth_densities(self, catalogue)

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -348,7 +348,7 @@ def register_h2_masses(self, catalogue, aperture_sizes):
 
         # Compute H2 mass with correction due to He
         He_mass = getattr(catalogue.gas_H_and_He_masses, f"He_mass_{aperture_size}_kpc")
-        H_mass = getattr(catalogue.gas_H_and_He_masses, f"He_mass_{aperture_size}_kpc")
+        H_mass = getattr(catalogue.gas_H_and_He_masses, f"H_mass_{aperture_size}_kpc")
 
         H2_mass_with_He = H2_mass * (1.0 + He_mass / H_mass)
 
@@ -588,7 +588,7 @@ def register_species_fractions(self, catalogue, aperture_sizes):
 
         # Compute H2 mass with correction due to He
         He_mass = getattr(catalogue.gas_H_and_He_masses, f"He_mass_{aperture_size}_kpc")
-        H_mass = getattr(catalogue.gas_H_and_He_masses, f"He_mass_{aperture_size}_kpc")
+        H_mass = getattr(catalogue.gas_H_and_He_masses, f"H_mass_{aperture_size}_kpc")
 
         H2_mass_with_He = H2_mass * (1.0 + He_mass / H_mass)
         H2_mass_with_He.name = f"$M_{{\\rm H_2}}$ (incl. He, {aperture_size} kpc)"

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -225,7 +225,7 @@ def register_dust(self, catalogue):
     total_dust_fraction.name = f"$\\mathcal{{DTG}}${dust_frac_error}"
 
     # Compute total dust mass
-    total_dust_mass = total_dust_fraction * catalogue.masses.m_gas
+    total_dust_mass = total_dust_fraction * catalogue.masses.mass_gas
     total_dust_mass.name = f"$M_{{\\rm dust}}${dust_frac_error}"
 
     # Compute to metal ratio
@@ -268,7 +268,7 @@ def register_oxygen_to_hydrogen(self, catalogue):
             "gas_o_abundance",
             unyt.unyt_array(
                 unyt.unyt_array(
-                    np.ones(np.size(catalogue.masses.m_gas)), "dimensionless"
+                    np.ones(np.size(catalogue.masses.mass_gas)), "dimensionless"
                 ),
                 name="$12+\\log_10({{\\rm O/H}})$ not found, default to 1",
             ),
@@ -283,7 +283,7 @@ def register_hi_masses(self, catalogue):
     nonmetal_frac = 1.0 - catalogue.apertures.zmet_gas_100_kpc
 
     # Fetch gas mass
-    gas_mass = catalogue.masses.m_gas
+    gas_mass = catalogue.masses.mass_gas
 
     # Fetch the mass fraction of Hydrogen
     H_frac = getattr(catalogue.element_mass_fractions, "element_0")
@@ -314,7 +314,7 @@ def register_hi_masses(self, catalogue):
 def register_dust_to_hi_ratio(self, catalogue):
 
     # Fetch gas masses
-    gas_mass = catalogue.masses.m_gas
+    gas_mass = catalogue.masses.mass_gas
 
     # Fetch the fraction of H in HI (try CHIMES arrays first)
     if hasattr(catalogue.species_fractions, "species_7"):
@@ -338,7 +338,7 @@ def register_dust_to_hi_ratio(self, catalogue):
             if sub_path.startswith("dust_"):
                 dust_fields.append(getattr(catalogue.dust_mass_fractions, sub_path))
         total_dust_fraction = sum(dust_fields)
-        total_dust_mass = total_dust_fraction * catalogue.masses.m_gas
+        total_dust_mass = total_dust_fraction * catalogue.masses.mass_gas
 
         # Compute dust-to-HI mass ratios
         dust_to_hi_ratio = total_dust_mass / HI_mass
@@ -356,7 +356,7 @@ def register_dust_to_hi_ratio(self, catalogue):
             "gas_dust_to_hi_ratio",
             unyt.unyt_array(
                 unyt.unyt_array(
-                    np.ones(np.size(catalogue.masses.m_gas)), "dimensionless"
+                    np.ones(np.size(catalogue.masses.mass_gas)), "dimensionless"
                 ),
                 name="$M_{\\rm dust}/M_{\\rm HI}$ not found, default to 1s",
             ),
@@ -371,7 +371,7 @@ def register_h2_masses(self, catalogue):
     nonmetal_frac = 1.0 - catalogue.apertures.zmet_gas_100_kpc
 
     # Fetch gas mass
-    gas_mass = catalogue.masses.m_gas
+    gas_mass = catalogue.masses.mass_gas
     # Fetch hydrogen mass fraction
     H_frac = getattr(catalogue.element_mass_fractions, "element_0")
 
@@ -403,7 +403,7 @@ def register_cold_gas_mass_ratios(self, catalogue):
     aperture_sizes = [30, 100]
 
     # Fetch gas mass
-    gas_mass = catalogue.masses.m_gas
+    gas_mass = catalogue.masses.mass_gas
 
     # Fetch hydrogen mass fraction
     H_frac = getattr(catalogue.element_mass_fractions, "element_0")
@@ -579,7 +579,7 @@ def register_species_fractions(self, catalogue):
     gas_mass_100kpc = catalogue.apertures.mass_gas_100_kpc
 
     # Fetch all gas mass
-    gas_mass = catalogue.masses.m_gas
+    gas_mass = catalogue.masses.mass_gas
 
     # Compute galaxy area (pi r^2)
     gal_area = (

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -252,7 +252,7 @@ def register_oxygen_to_hydrogen(self, catalogue, aperture_sizes):
         # Fetch O over H times gas mass computed in apertures
         O_over_H_times_gas_mass = getattr(
             catalogue.gas_element_ratios_times_masses,
-            f"O_over_H_times_mass_{aperture_size}_kpc",
+            f"O_over_H_times_gas_mass_{aperture_size}_kpc",
         )
         # Fetch gas mass in apertures
         gas_mass = getattr(catalogue.apertures, f"mass_gas_{aperture_size}_kpc")

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -208,6 +208,12 @@ def register_dust(self, catalogue):
         total_dust_fraction = sum(dust_fields)
         dust_frac_error = ""
 
+        if total_dust_fraction == 0:
+            total_dust_fraction = unyt.unyt_array(
+                np.zeros(metal_frac.size), units="dimensionless"
+            )
+            dust_frac_error = " (no dust field)"
+
     # If the catalogue has no dust fields
     except AttributeError:
         total_dust_fraction = unyt.unyt_array(


### PR DESCRIPTION
Hi @JBorrow,

Yesterday I was going to add a new code to `registration.py` to have a new derived field. However, after looking at `registration.py` I decided to first rearrange it - otherwise, I find it too large, difficult to maintain, and bug-prone; and I don't want to make it even larger. This PR should help improve the file.

I verified that the new version works correctly by feeding the pipeline with the hawk reference run's z=0 snapshot for this branch and master branch, and then running
`diff data_master_branch.yml data_this_branch.yml`

The result is

```
3438c3438
<   x_label: $\pi R_{*, 100 {\rm kpc}}^2 / M_{*, 100 {\rm kpc}}$ $\left[\frac{\rm{M}_\odot}{\rm{kpc}^{2}}\right]$
---
>   x_label: $M_{*, 100 {\rm kpc}} / \pi R_{*, 100 {\rm kpc}}^2$ $\left[\frac{\rm{M}_\odot}{\rm{kpc}^{2}}\right]$
3497c3497
<   x_label: $\pi R_{*, 100 {\rm kpc}}^2 / M_{*, 100 {\rm kpc}}$ $\left[\frac{\rm{M}_\odot}{\rm{kpc}^{2}}\right]$
---
>   x_label: $M_{*, 100 {\rm kpc}} / \pi R_{*, 100 {\rm kpc}}^2$ $\left[\frac{\rm{M}_\odot}{\rm{kpc}^{2}}\right]$
15049c15049
<   x_label: $\pi R_{*, 100 {\rm kpc}}^2 / M_{*, 100 {\rm kpc}}$ $\left[\frac{\rm{M}_\odot}{\rm{kpc}^{2}}\right]$
---
>   x_label: $M_{*, 100 {\rm kpc}} / \pi R_{*, 100 {\rm kpc}}^2$ $\left[\frac{\rm{M}_\odot}{\rm{kpc}^{2}}\right]$
26601c26601
<   x_label: $\pi R_{*, 100 {\rm kpc}}^2 / M_{*, 100 {\rm kpc}}$ $\left[\frac{\rm{M}_\odot}{\rm{kpc}^{2}}\right]$
---
>   x_label: $M_{*, 100 {\rm kpc}} / \pi R_{*, 100 {\rm kpc}}^2$ $\left[\frac{\rm{M}_\odot}{\rm{kpc}^{2}}\right]$
```

the difference is because I fixed a typo in the caption of one field.

Also, @MatthieuSchaller if you have any comments, let me know
