### PR TITLE
Add AGN feedback density distribution plot

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -113,6 +113,11 @@ scripts:
     title: Density of the gas heated by SNII
     section: Feedback Densities
     output_file: SNII_density_distribution.png
+  - filename: scripts/last_AGN_density_distribution.py
+    caption: Distributions of the gas densities recorded when the gas was last heated by AGN, split by redshift. The y axis shows the number of AGN-heated gas particles per bin divided by the bin width and by the total of AGN-heated gas particles. The dashed vertical lines show the median AGN gas-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for $f_t=10$.
+    title: Density of the gas heated by AGN
+    section: Feedback Densities
+    output_file: AGN_density_distribution.png
   - filename: scripts/gas_metallicity_evolution.py
     caption: Evolution of the metal mass in gas per unit co-moving volume.
     output_file: gas_metallicity_evolution.png

--- a/colibre/scripts/last_AGN_density_distribution.py
+++ b/colibre/scripts/last_AGN_density_distribution.py
@@ -1,5 +1,5 @@
 """
-Plots the SNII density distribution (at last SNII thermal injections).
+Plots the AGN density distribution (at last AGN thermal injections).
 """
 
 import matplotlib.pyplot as plt
@@ -70,7 +70,7 @@ def critical_density_DVS2012(
 
 arguments = ScriptArgumentParser(
     description="Creates a plot showing the distribution of the gas densities recorded "
-    "when the gas was last heated by SNII, split by redshift"
+    "when the gas was last heated by AGN, split by redshift"
 )
 
 snapshot_filenames = [
@@ -86,13 +86,13 @@ plt.style.use(arguments.stylesheet_location)
 data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
 number_of_bins = 256
 
-SNII_density_bins = unyt.unyt_array(
+AGN_density_bins = unyt.unyt_array(
     np.logspace(-5, 6.5, number_of_bins), units="1/cm**3"
 )
-log_SNII_density_bin_width = np.log10(SNII_density_bins[1].value) - np.log10(
-    SNII_density_bins[0].value
+log_AGN_density_bin_width = np.log10(AGN_density_bins[1].value) - np.log10(
+    AGN_density_bins[0].value
 )
-SNII_density_centers = 0.5 * (SNII_density_bins[1:] + SNII_density_bins[:-1])
+AGN_density_centers = 0.5 * (AGN_density_bins[1:] + AGN_density_bins[:-1])
 
 
 # Begin plotting
@@ -112,92 +112,79 @@ for label, ax in ax_dict.items():
 
 for color, (snapshot, name) in enumerate(zip(data, names)):
 
-    stars_SNII_densities = snapshot.stars.densities_at_last_supernova_event.to(
+    stars_AGN_densities = snapshot.stars.densities_at_last_agnevent.to(
         "g/cm**3"
     ) / mh.to("g")
 
     # swift-colibre master branch as of Feb 26 2021
-    try:
-        stars_SNII_redshifts = (
-            1 / snapshot.stars.last_sniithermal_feedback_scale_factors.value - 1
-        )
-    # swift-colibre master prior to Feb 26 2021
-    except AttributeError:
-        stars_SNII_redshifts = (
-            1 / snapshot.stars.last_sniifeedback_scale_factors.value - 1
-        )
+    stars_AGN_redshifts = 1 / snapshot.stars.last_agnfeedback_scale_factors.value - 1
 
-    gas_SNII_densities = snapshot.gas.densities_at_last_supernova_event.to(
-        "g/cm**3"
-    ) / mh.to("g")
+    gas_AGN_densities = snapshot.gas.densities_at_last_agnevent.to("g/cm**3") / mh.to(
+        "g"
+    )
 
-    try:
-        gas_SNII_redshifts = (
-            1 / snapshot.gas.last_sniithermal_feedback_scale_factors.value - 1
-        )
-    except AttributeError:
-        gas_SNII_redshifts = 1 / snapshot.gas.last_sniifeedback_scale_factors.value - 1
+    gas_AGN_redshifts = 1 / snapshot.gas.last_agnfeedback_scale_factors.value - 1
 
-    # Limit only to those gas/stellar particles that were in fact heated by SNII
-    stars_SNII_heated = stars_SNII_densities > 0.0
-    gas_SNII_heated = gas_SNII_densities > 0.0
+    # Limit only to those gas/stellar particles that were in fact heated by AGN
+    stars_AGN_heated = stars_AGN_densities > 0.0
+    gas_AGN_heated = gas_AGN_densities > 0.0
 
-    # Select only those parts that were heated by SNII in the past
-    stars_SNII_densities = stars_SNII_densities[stars_SNII_heated]
-    stars_SNII_redshifts = stars_SNII_redshifts[stars_SNII_heated]
-    gas_SNII_densities = gas_SNII_densities[gas_SNII_heated]
-    gas_SNII_redshifts = gas_SNII_redshifts[gas_SNII_heated]
+    # Select only those parts that were heated by AGN in the past
+    stars_AGN_densities = stars_AGN_densities[stars_AGN_heated]
+    stars_AGN_redshifts = stars_AGN_redshifts[stars_AGN_heated]
+    gas_AGN_densities = gas_AGN_densities[gas_AGN_heated]
+    gas_AGN_redshifts = gas_AGN_redshifts[gas_AGN_heated]
 
-    # Segment SNII densities into redshift bins
-    stars_SNII_densities_by_redshift = {
-        "$z < 1$": stars_SNII_densities[stars_SNII_redshifts < 1],
-        "$1 < z < 3$": stars_SNII_densities[
-            np.logical_and(stars_SNII_redshifts > 1, stars_SNII_redshifts < 3)
+    # Segment AGN densities into redshift bins
+    stars_AGN_densities_by_redshift = {
+        "$z < 1$": stars_AGN_densities[stars_AGN_redshifts < 1],
+        "$1 < z < 3$": stars_AGN_densities[
+            np.logical_and(stars_AGN_redshifts > 1, stars_AGN_redshifts < 3)
         ],
-        "$z > 3$": stars_SNII_densities[stars_SNII_redshifts > 3],
+        "$z > 3$": stars_AGN_densities[stars_AGN_redshifts > 3],
     }
 
-    gas_SNII_densities_by_redshift = {
-        "$z < 1$": gas_SNII_densities[gas_SNII_redshifts < 1],
-        "$1 < z < 3$": gas_SNII_densities[
-            np.logical_and(gas_SNII_redshifts > 1, gas_SNII_redshifts < 3)
+    gas_AGN_densities_by_redshift = {
+        "$z < 1$": gas_AGN_densities[gas_AGN_redshifts < 1],
+        "$1 < z < 3$": gas_AGN_densities[
+            np.logical_and(gas_AGN_redshifts > 1, gas_AGN_redshifts < 3)
         ],
-        "$z > 3$": gas_SNII_densities[gas_SNII_redshifts > 3],
+        "$z > 3$": gas_AGN_densities[gas_AGN_redshifts > 3],
     }
 
     # Compute the critical density from DV&S2012
-    SNII_heating_temperature = float(
-        snapshot.metadata.parameters["COLIBREFeedback:SNII_delta_T_K"].decode("utf-8")
+    AGN_heating_temperature = float(
+        snapshot.metadata.parameters["COLIBREAGN:AGN_delta_T_K"].decode("utf-8")
     )  # in K
     N_ngb_target = snapshot.metadata.hydro_scheme["Kernel target N_ngb"][0]
     X_H = snapshot.metadata.hydro_scheme["Hydrogen mass fraction"][0]
     M_gas = snapshot.metadata.initial_mass_table.gas.to("Msun")  # in Solar Masses
 
     n_crit = critical_density_DVS2012(
-        T_K=SNII_heating_temperature, M_gas=M_gas.value, N_ngb=N_ngb_target, X_H=X_H
+        T_K=AGN_heating_temperature, M_gas=M_gas.value, N_ngb=N_ngb_target, X_H=X_H
     )
 
     for redshift, ax in ax_dict.items():
         data = np.concatenate(
             [
-                stars_SNII_densities_by_redshift[redshift],
-                gas_SNII_densities_by_redshift[redshift],
+                stars_AGN_densities_by_redshift[redshift],
+                gas_AGN_densities_by_redshift[redshift],
             ]
         )
 
-        H, _ = np.histogram(data, bins=SNII_density_bins)
+        H, _ = np.histogram(data, bins=AGN_density_bins)
 
-        # Total number SNII-heated gas particles
+        # Total number AGN-heated gas particles
         Num_of_obj = np.sum(H)
 
         # Check to avoid division by zero
         if Num_of_obj:
-            y_points = H / log_SNII_density_bin_width / Num_of_obj
+            y_points = H / log_AGN_density_bin_width / Num_of_obj
         else:
             y_points = np.zeros_like(H)
 
         ax.plot(
-            SNII_density_centers,
+            AGN_density_centers,
             y_points,
             label=name,
             color=f"C{color}",
@@ -221,8 +208,8 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
 
 axes[0].legend(loc="upper right", markerfirst=False)
 axes[2].set_xlabel(
-    "Density of the gas heated by SNII $\\rho_{\\rm SNII}$ [$n_H$ cm$^{-3}$]"
+    "Density of the gas heated by AGN $\\rho_{\\rm AGN}$ [$n_H$ cm$^{-3}$]"
 )
-axes[1].set_ylabel("$N_{\\rm bin}$ / d$\\log\\rho_{\\rm SNII}$ / $N_{\\rm total}$")
+axes[1].set_ylabel("$N_{\\rm bin}$ / d$\\log\\rho_{\\rm AGN}$ / $N_{\\rm total}$")
 
-fig.savefig(f"{arguments.output_directory}/SNII_density_distribution.png")
+fig.savefig(f"{arguments.output_directory}/AGN_density_distribution.png")


### PR DESCRIPTION
An example of the update is shown below

![Screenshot from 2021-03-31 16-20-17](https://user-images.githubusercontent.com/20153933/113159874-3d0f3800-923d-11eb-8c0d-872bc3b1802b.png)

@MatthieuSchaller I believe when this PR is merged, this plot can also added to the BAHAMAS config.