### PR TITLE
O abundance diffuse and sfgasonly redo

### DIFF
--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -255,16 +255,16 @@ def register_oxygen_to_hydrogen(self, catalogue, aperture_sizes):
             f"O_over_H_times_gas_mass_{aperture_size}_kpc",
         )
         # Fetch gas mass in apertures
-        gas_mass = getattr(catalogue.apertures, f"mass_gas_{aperture_size}_kpc")
+        gas_sf_mass = getattr(catalogue.apertures, f"mass_gas_sf_{aperture_size}_kpc")
 
         # Compute gas-mass weighted O over H
-        O_over_H = unyt.unyt_array(np.zeros_like(gas_mass), "dimensionless")
+        O_over_H = unyt.unyt_array(np.zeros_like(gas_sf_mass), "dimensionless")
         # Avoid division by zero
-        mask = gas_mass > 0.0 * gas_mass.units
-        O_over_H[mask] = O_over_H_times_gas_mass[mask] / gas_mass[mask]
+        mask = gas_sf_mass > 0.0 * gas_sf_mass.units
+        O_over_H[mask] = O_over_H_times_gas_mass[mask] / gas_sf_mass[mask]
 
         # Convert to units used in observations (16 is the mass ratio between O and H)
-        O_abundance = unyt.unyt_array(12 + np.log10(O_over_H / 16.0), "dimensionless")
+        O_abundance = unyt.unyt_array(12 + np.log10(O_over_H), "dimensionless")
         O_abundance.name = f"Gas $12+\\log_{10}({{\\rm O/H}})$ ({aperture_size} kpc)"
 
         # Register the field

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -477,9 +477,7 @@ def register_cold_gas_mass_ratios(self, catalogue, aperture_sizes):
 
         # Finally, register all the above fields
         setattr(
-            self,
-            f"gas_neutral_H_mass_{aperture_size}_kpc",
-            neutral_H_mass,
+            self, f"gas_neutral_H_mass_{aperture_size}_kpc", neutral_H_mass,
         )
 
         setattr(


### PR DESCRIPTION
(redo of https://github.com/SWIFTSIM/pipeline-configs/pull/110) Small changes, PR already rebased to `rearrange_colibre_registration`, and intended for merging once https://gitlab.cosma.dur.ac.uk/EAGLE/swift-colibre/-/merge_requests/167 and https://github.com/SWIFTSIM/velociraptor-python/pull/54 merged:

- take factor 16 out of O abundance calculation as built into pre-processing step
- divide by SF gas mass to pair with changes to pre-processing here https://gitlab.cosma.dur.ac.uk/EAGLE/swift-colibre/-/merge_requests/167#note_36665
