### PR TITLE
Update SF gas metallicity plot

### DIFF
--- a/colibre/auto_plotter/metallicity.yml
+++ b/colibre/auto_plotter/metallicity.yml
@@ -4,7 +4,7 @@ stellar_mass_gas_sf_metallicity_30:
   selection_mask: "derived_quantities.is_active_30_kpc"
   comment: "Active only"
   y:
-    quantity: "derived_quantities.gas_sf_twelve_plus_log_OH_30_kpc"
+    quantity: "derived_quantities.gas_o_abundance_30_kpc"
     log: false
     units: "dimensionless"
     start: 7
@@ -27,7 +27,7 @@ stellar_mass_gas_sf_metallicity_30:
       units: solar_mass
   metadata:
     title: "Stellar mass - Gas metallicity relation (30 kpc aperture)"
-    caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (displayed as 12 + $\log_{10}$ O/H) over the star forming gas. A minimum metallicity of 12 + log O/H = 7.5 is imposed for the star-forming gas on a galaxy-by-galaxy basis. All haloes are plotted, including subhaloes. This uses un-depleted gas metallicity, i.e. it includes metals that may also be present in dust.
+    caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (displayed as 12 + $\log_{10}$ O/H) of the star forming gas. No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Metallicity
     show_on_webpage: false
   observational_data:
@@ -41,7 +41,7 @@ stellar_mass_gas_sf_metallicity_100:
   selection_mask: "derived_quantities.is_active_100_kpc"
   comment: "Active only"
   y:
-    quantity: "derived_quantities.gas_sf_twelve_plus_log_OH_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_100_kpc"
     log: false
     units: "dimensionless"
     start: 7
@@ -64,7 +64,7 @@ stellar_mass_gas_sf_metallicity_100:
       units: solar_mass
   metadata:
     title: "Stellar mass - Gas metallicity relation (100 kpc aperture)"
-    caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (displayed as 12 + $\log_{10}$ O/H) over the star forming gas. A minimum metallicity of 12 + log O/H = 7.5 is imposed for the star-forming gas on a galaxy-by-galaxy basis. All haloes are plotted, including subhaloes. This uses un-depleted gas metallicity, i.e. it includes metals that may also be present in dust.
+    caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (displayed as 12 + $\log_{10}$ O/H) of the star forming gas. No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Metallicity
   observational_data:
     - filename: GalaxyStellarMassGasMetallicity/Tremonti2004_Data.hdf5


### PR DESCRIPTION
Hi @wmfw23,

In this PR, I update the star-forming gas metallicity plot.

Instead of scaling with the solar metallicity, I now compute the O/H of the star-forming gas directly

Note that in the new plot,

- No minimum metallicity is imposed.
- Uses depleted gas metalicities


<h2>EXAMPLE</h2>

**Before**
![before](https://user-images.githubusercontent.com/20153933/113507488-0d1ca900-954b-11eb-9f79-9bf39741d8a0.png)


**After**
![after](https://user-images.githubusercontent.com/20153933/113507490-1148c680-954b-11eb-8df9-910cc0cd0ef4.png)
