### PR TITLE
WIP: Update gas metallicity plot with floors

### DIFF
--- a/colibre/auto_plotter/depletion_relations.yml
+++ b/colibre/auto_plotter/depletion_relations.yml
@@ -1,7 +1,7 @@
 oxygen_abundance_v_dust_to_gas:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.dust_valid_abundances_100_kpc"
+  selection_mask: "derived_quantities.is_active_30_kpc"
   x:
     quantity: "derived_quantities.gas_o_abundance_100_kpc"
     units: "dimensionless"

--- a/colibre/auto_plotter/depletion_relations.yml
+++ b/colibre/auto_plotter/depletion_relations.yml
@@ -1,9 +1,9 @@
 oxygen_abundance_v_dust_to_gas:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_30_kpc"
+  selection_mask: "derived_quantities.is_active_100_kpc"
   x:
-    quantity: "derived_quantities.gas_o_abundance_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_low_100_kpc"
     units: "dimensionless"
     start: 6.8
     end: 9.2

--- a/colibre/auto_plotter/dust_scaling_relations.yml
+++ b/colibre/auto_plotter/dust_scaling_relations.yml
@@ -73,7 +73,7 @@ hi_stellar_fraction_o_abundance:
   legend_loc: "upper right"
   selection_mask: "derived_quantities.is_active_100_kpc"
   x:
-    quantity: "derived_quantities.gas_o_abundance_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_low_100_kpc"
     units: "dimensionless"
     start: 6.8
     end: 9.2

--- a/colibre/auto_plotter/metallicity.yml
+++ b/colibre/auto_plotter/metallicity.yml
@@ -4,7 +4,7 @@ stellar_mass_gas_sf_metallicity_30:
   selection_mask: "derived_quantities.is_active_30_kpc"
   comment: "Active only"
   y:
-    quantity: "derived_quantities.gas_sf_twelve_plus_log_OH_30_kpc"
+    quantity: "derived_quantities.gas_o_abundance_30_kpc"
     log: false
     units: "dimensionless"
     start: 7
@@ -27,7 +27,7 @@ stellar_mass_gas_sf_metallicity_30:
       units: solar_mass
   metadata:
     title: "Stellar mass - Gas metallicity relation (30 kpc aperture)"
-    caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (displayed as 12 + $\log_{10}$ O/H) over the star forming gas. A minimum metallicity of 12 + log O/H = 7.5 is imposed for the star-forming gas on a galaxy-by-galaxy basis. All haloes are plotted, including subhaloes. This uses un-depleted gas metallicity, i.e. it includes metals that may also be present in dust.
+    caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (displayed as 12 + $\log_{10}$ O/H) of the star forming gas. No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Metallicity
     show_on_webpage: false
   observational_data:
@@ -41,7 +41,7 @@ stellar_mass_gas_sf_metallicity_100:
   selection_mask: "derived_quantities.is_active_100_kpc"
   comment: "Active only"
   y:
-    quantity: "derived_quantities.gas_sf_twelve_plus_log_OH_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_100_kpc"
     log: false
     units: "dimensionless"
     start: 7
@@ -64,7 +64,7 @@ stellar_mass_gas_sf_metallicity_100:
       units: solar_mass
   metadata:
     title: "Stellar mass - Gas metallicity relation (100 kpc aperture)"
-    caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (displayed as 12 + $\log_{10}$ O/H) over the star forming gas. A minimum metallicity of 12 + log O/H = 7.5 is imposed for the star-forming gas on a galaxy-by-galaxy basis. All haloes are plotted, including subhaloes. This uses un-depleted gas metallicity, i.e. it includes metals that may also be present in dust.
+    caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (displayed as 12 + $\log_{10}$ O/H) of the star forming gas. No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Metallicity
   observational_data:
     - filename: GalaxyStellarMassGasMetallicity/Tremonti2004_Data.hdf5

--- a/colibre/auto_plotter/metallicity.yml
+++ b/colibre/auto_plotter/metallicity.yml
@@ -4,7 +4,7 @@ stellar_mass_gas_sf_metallicity_30:
   selection_mask: "derived_quantities.is_active_30_kpc"
   comment: "Active only"
   y:
-    quantity: "derived_quantities.gas_o_abundance_30_kpc"
+    quantity: "derived_quantities.gas_o_abundance_low_30_kpc"
     log: false
     units: "dimensionless"
     start: 7
@@ -41,7 +41,7 @@ stellar_mass_gas_sf_metallicity_100:
   selection_mask: "derived_quantities.is_active_100_kpc"
   comment: "Active only"
   y:
-    quantity: "derived_quantities.gas_o_abundance_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_low_100_kpc"
     log: false
     units: "dimensionless"
     start: 7

--- a/colibre/auto_plotter/metallicity.yml
+++ b/colibre/auto_plotter/metallicity.yml
@@ -1,10 +1,10 @@
-stellar_mass_gas_sf_metallicity_30:
+stellar_mass_gas_sf_metallicity_fromz_lom_30:
   type: "scatter"
   legend_loc: "upper left"
   selection_mask: "derived_quantities.is_active_30_kpc"
-  comment: "Active only"
+  comment: "Active only, LoM, Diffuse, from Z"
   y:
-    quantity: "derived_quantities.gas_o_abundance_low_30_kpc"
+    quantity: "derived_quantities.gas_o_abundance_fromz_avglin_30_kpc"
     log: false
     units: "dimensionless"
     start: 7
@@ -26,14 +26,200 @@ stellar_mass_gas_sf_metallicity_30:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Gas metallicity relation (30 kpc aperture)"
-    caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (displayed as 12 + $\log_{10}$ O/H) of the star forming gas. No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
-    section: Metallicity
-    show_on_webpage: false
+    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, from Z, 30 kpc aperture)"
+    caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (converted to 12 + $\log_{10}$ O/H by assuming solar abundance patterns) of cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
+    section: SF Gas Metallicity
+    show_on_webpage: true
   observational_data:
     - filename: GalaxyStellarMassGasMetallicity/Tremonti2004_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Zahid2014_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
+
+stellar_mass_gas_sf_metallicity_lom_30:
+  type: "scatter"
+  legend_loc: "upper left"
+  selection_mask: "derived_quantities.is_active_30_kpc"
+  comment: "Active only, LoM, Diffuse, from O"
+  y:
+    quantity: "derived_quantities.gas_o_abundance_avglin_30_kpc"
+    log: false
+    units: "dimensionless"
+    start: 7
+    end: 10
+  x:
+    quantity: "apertures.mass_star_30_kpc"
+    units: solar_mass
+    start: 1e6
+    end: 1e12
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+  metadata:
+    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, 30 kpc aperture)"
+    caption: Only shown for star forming galaxies. Represented by 12 + $\log_{10}$ O/H (where O/H is linearly averaged for diffuse O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
+    section: SF Gas Metallicity
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyStellarMassGasMetallicity/Tremonti2004_Data.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Zahid2014_Data.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
+
+stellar_mass_gas_sf_metallicity_total_lom_30:
+  type: "scatter"
+  legend_loc: "upper left"
+  selection_mask: "derived_quantities.is_active_30_kpc"
+  comment: "Active only, LoM, Total (Diffuse + Dust), from O"
+  y:
+    quantity: "derived_quantities.gas_o_abundance_total_avglin_30_kpc"
+    log: false
+    units: "dimensionless"
+    start: 7
+    end: 10
+  x:
+    quantity: "apertures.mass_star_30_kpc"
+    units: solar_mass
+    start: 1e6
+    end: 1e12
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+  metadata:
+    title: "Stellar mass - Gas total metallicity relation (log-of-mean, 30 kpc aperture)"
+    caption: Only shown for star forming galaxies. Represented by 12 + $\log_{10}$ O/H (where O/H is linearly averaged for total O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
+    section: SF Gas Metallicity
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyStellarMassGasMetallicity/Tremonti2004_Data.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Zahid2014_Data.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
+
+stellar_mass_gas_sf_metallicity_mol_lowfloor_30:
+  type: "scatter"
+  legend_loc: "upper left"
+  selection_mask: "derived_quantities.is_active_30_kpc"
+  comment: "Active only, MoL w. [O/H]=-4 floor, Diffuse, from O"
+  y:
+    quantity: "derived_quantities.gas_o_abundance_avglog_low_30_kpc"
+    log: false
+    units: "dimensionless"
+    start: 7
+    end: 10
+  x:
+    quantity: "apertures.mass_star_30_kpc"
+    units: solar_mass
+    start: 1e6
+    end: 1e12
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+  metadata:
+    title: "Stellar mass - Gas diffuse metallicity relation (mean-of-log, 30 kpc aperture)"
+    caption: Only shown for star forming galaxies. Represented by 12 + $\log_{10}$ O/H (where $\log_{10}$ O/H is averaged between gas particles with a [O/H]=-4 floor and diffuse O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
+    section: SF Gas Metallicity
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyStellarMassGasMetallicity/Tremonti2004_Data.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Zahid2014_Data.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
+
+stellar_mass_gas_sf_metallicity_mol_hifloor_30:
+  type: "scatter"
+  legend_loc: "upper left"
+  selection_mask: "derived_quantities.is_active_30_kpc"
+  comment: "Active only, MoL w. [O/H]=-3 floor, Diffuse, from O"
+  y:
+    quantity: "derived_quantities.gas_o_abundance_avglog_high_30_kpc"
+    log: false
+    units: "dimensionless"
+    start: 7
+    end: 10
+  x:
+    quantity: "apertures.mass_star_30_kpc"
+    units: solar_mass
+    start: 1e6
+    end: 1e12
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+  metadata:
+    title: "Stellar mass - Gas diffuse metallicity relation (mean-of-log, 30 kpc aperture)"
+    caption: Only shown for star forming galaxies. Represented by 12 + $\log_{10}$ O/H (where $\log_{10}$ O/H is averaged between gas particles with a [O/H]=-3 floor for diffuse O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
+    section: SF Gas Metallicity
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyStellarMassGasMetallicity/Tremonti2004_Data.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Zahid2014_Data.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
+
+stellar_mass_gas_sf_metallicity_lom_allgals_30:
+  type: "scatter"
+  legend_loc: "upper left"
+  selection_mask: "derived_quantities.has_cold_dense_gas_30_kpc"
+  comment: "All galaxies, LoM, Diffuse, from O"
+  y:
+    quantity: "derived_quantities.gas_o_abundance_avglin_30_kpc"
+    log: false
+    units: "dimensionless"
+    start: 7
+    end: 10
+  x:
+    quantity: "apertures.mass_star_30_kpc"
+    units: solar_mass
+    start: 1e6
+    end: 1e12
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+  metadata:
+    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, 30 kpc aperture)"
+    caption: Only shown for galaxies with cold, dense gas. Represented by 12 + $\log_{10}$ O/H (where O/H is linearly averaged for diffuse O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
+    section: SF Gas Metallicity
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyStellarMassGasMetallicity/Tremonti2004_Data.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Zahid2014_Data.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
+
 
 stellar_mass_gas_sf_metallicity_100:
   type: "scatter"
@@ -41,7 +227,7 @@ stellar_mass_gas_sf_metallicity_100:
   selection_mask: "derived_quantities.is_active_100_kpc"
   comment: "Active only"
   y:
-    quantity: "derived_quantities.gas_o_abundance_low_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_avglin_100_kpc"
     log: false
     units: "dimensionless"
     start: 7
@@ -64,8 +250,8 @@ stellar_mass_gas_sf_metallicity_100:
       units: solar_mass
   metadata:
     title: "Stellar mass - Gas metallicity relation (100 kpc aperture)"
-    caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (displayed as 12 + $\log_{10}$ O/H) of the star forming gas. No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
-    section: Metallicity
+    caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (displayed as 12 + $\log_{10}$ O/H) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
+    section: SF Gas Metallicity
   observational_data:
     - filename: GalaxyStellarMassGasMetallicity/Tremonti2004_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Zahid2014_Data.hdf5
@@ -99,6 +285,7 @@ stellar_mass_star_metallicity_100:
     title: "Stellar mass - Star metallicity relation (100 kpc aperture)"
     caption: Metallicity is measured in the same aperture as the stellar mass. Gallazzi data is corrected from their choice of solar metallicity (0.02) to ours (0.0126).
     section: Metallicity
+    show_on_webpage: false
   observational_data:
     - filename: GalaxyStellarMassStellarMetallicity/Gallazzi2005_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
@@ -130,8 +317,8 @@ stellar_mass_star_metallicity_30:
   metadata:
     title: "Stellar mass - Star metallicity relation (30 kpc aperture)"
     caption: Metallicity is measured in the same aperture as the stellar mass. Gallazzi data is corrected from their choice of solar metallicity (0.02) to ours (0.0126).
-    section: Metallicity
-    show_on_webpage: false
+    section: Stellar Metallicity
+    show_on_webpage: true
   observational_data:
     - filename: GalaxyStellarMassStellarMetallicity/Gallazzi2005_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -33,6 +33,7 @@ solar_metal_mass_fraction = 0.0134
 # Solar Fe abundance (from Wiersma et al 2009a)
 solar_fe_abundance = 2.82e-5
 
+
 def register_spesific_star_formation_rates(self, catalogue, aperture_sizes):
 
     # Lowest sSFR below which the galaxy is considered passive
@@ -211,16 +212,21 @@ def register_oxygen_to_hydrogen(self, catalogue, aperture_sizes):
         O_over_H = unyt.unyt_array(np.zeros_like(gas_sf_mass), "dimensionless")
         # Avoid division by zero
         mask = gas_sf_mass > 0.0 * gas_sf_mass.units
-        O_over_H[mask] = pow(10.,log_O_over_H_times_gas_mass[mask]) / gas_sf_mass[mask]
+        O_over_H[mask] = (
+            pow(10.0, log_O_over_H_times_gas_mass[mask]) / gas_sf_mass[mask]
+        )
 
         # Convert to units used in observations
         O_abundance = unyt.unyt_array(12 + np.log10(O_over_H), "dimensionless")
-        O_abundance.name = f"SF Gas $12+\\log_{{10}}({{\\rm O/H}})$ ({aperture_size} kpc)"
+        O_abundance.name = (
+            f"SF Gas $12+\\log_{{10}}({{\\rm O/H}})$ ({aperture_size} kpc)"
+        )
 
         # Register the field
         setattr(self, f"gas_o_abundance_{aperture_size}_kpc", O_abundance)
 
     return
+
 
 def register_iron_to_hydrogen(self, catalogue, aperture_sizes):
 
@@ -240,10 +246,14 @@ def register_iron_to_hydrogen(self, catalogue, aperture_sizes):
         Fe_over_H = unyt.unyt_array(np.zeros_like(star_mass), "dimensionless")
         # Avoid division by zero
         mask = star_mass > 0.0 * star_mass.units
-        Fe_over_H[mask] = pow(10.,log_Fe_over_H_times_star_mass[mask]) / star_mass[mask]
+        Fe_over_H[mask] = (
+            pow(10.0, log_Fe_over_H_times_star_mass[mask]) / star_mass[mask]
+        )
 
         # Convert to units used in observations
-        Fe_abundance = unyt.unyt_array(np.log10(Fe_over_H / solar_fe_abundance), "dimensionless")
+        Fe_abundance = unyt.unyt_array(
+            np.log10(Fe_over_H / solar_fe_abundance), "dimensionless"
+        )
         Fe_abundance.name = f"Stellar $[{{\\rm Fe/H}}]$ ({aperture_size} kpc)"
 
         # Register the field
@@ -455,9 +465,7 @@ def register_cold_gas_mass_ratios(self, catalogue, aperture_sizes):
 
         # Finally, register all the above fields
         setattr(
-            self,
-            f"gas_neutral_H_mass_{aperture_size}_kpc",
-            neutral_H_mass,
+            self, f"gas_neutral_H_mass_{aperture_size}_kpc", neutral_H_mass,
         )
 
         setattr(

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -212,8 +212,8 @@ def register_oxygen_to_hydrogen(self, catalogue, aperture_sizes):
         O_over_H = unyt.unyt_array(np.zeros_like(gas_sf_mass), "dimensionless")
         # Avoid division by zero
         mask = gas_sf_mass > 0.0 * gas_sf_mass.units
-        O_over_H[mask] = (
-            pow(10.0, log_O_over_H_times_gas_mass[mask] / gas_sf_mass[mask])
+        O_over_H[mask] = pow(
+            10.0, log_O_over_H_times_gas_mass[mask] / gas_sf_mass[mask]
         )
 
         # Convert to units used in observations
@@ -228,7 +228,7 @@ def register_oxygen_to_hydrogen(self, catalogue, aperture_sizes):
     return
 
 
-def register_iron_to_hydrogen(self, catalogue, aperture_sizes):
+def register_iron_to_hydrogen(self, catalogue, aperture_sizes, fe_solar_abundance):
 
     # Loop over apertures
     for aperture_size in aperture_sizes:
@@ -246,8 +246,8 @@ def register_iron_to_hydrogen(self, catalogue, aperture_sizes):
         Fe_over_H = unyt.unyt_array(np.zeros_like(star_mass), "dimensionless")
         # Avoid division by zero
         mask = star_mass > 0.0 * star_mass.units
-        Fe_over_H[mask] = (
-            pow(10.0, log_Fe_over_H_times_star_mass[mask] / star_mass[mask])
+        Fe_over_H[mask] = pow(
+            10.0, log_Fe_over_H_times_star_mass[mask] / star_mass[mask]
         )
 
         # Convert to units used in observations
@@ -653,7 +653,7 @@ register_star_metallicities(self, catalogue, aperture_sizes, solar_metal_mass_fr
 register_stellar_to_halo_mass_ratios(self, catalogue, aperture_sizes)
 register_dust(self, catalogue, aperture_sizes)
 register_oxygen_to_hydrogen(self, catalogue, aperture_sizes)
-register_iron_to_hydrogen(self, catalogue, aperture_sizes)
+register_iron_to_hydrogen(self, catalogue, aperture_sizes, solar_fe_abundance)
 register_hi_masses(self, catalogue, aperture_sizes)
 register_h2_masses(self, catalogue, aperture_sizes)
 register_dust_to_hi_ratio(self, catalogue, aperture_sizes)

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -213,7 +213,7 @@ def register_oxygen_to_hydrogen(self, catalogue, aperture_sizes):
         # Avoid division by zero
         mask = gas_sf_mass > 0.0 * gas_sf_mass.units
         O_over_H[mask] = (
-            pow(10.0, log_O_over_H_times_gas_mass[mask]) / gas_sf_mass[mask]
+            pow(10.0, log_O_over_H_times_gas_mass[mask] / gas_sf_mass[mask])
         )
 
         # Convert to units used in observations
@@ -247,7 +247,7 @@ def register_iron_to_hydrogen(self, catalogue, aperture_sizes):
         # Avoid division by zero
         mask = star_mass > 0.0 * star_mass.units
         Fe_over_H[mask] = (
-            pow(10.0, log_Fe_over_H_times_star_mass[mask]) / star_mass[mask]
+            pow(10.0, log_Fe_over_H_times_star_mass[mask] / star_mass[mask])
         )
 
         # Convert to units used in observations

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -231,13 +231,13 @@ def register_iron_to_hydrogen(self, catalogue, aperture_sizes, fe_solar_abundanc
     # Loop over apertures
     for aperture_size in aperture_sizes:
     
-        for thr, thr_label in zip(["low", "high"], ["Min = $10^{{-4}}$", "Min = $10^{{-3}}$"]):
+        for floor, floor_label in zip(["low", "high"], ["Min = $10^{{-4}}$", "Min = $10^{{-3}}$"]):
 
             # Fetch Fe over H times stellar mass computed in apertures. The
             # mass ratio between Fe and H has already been accounted for.
             log_Fe_over_H_times_star_mass = getattr(
                 catalogue.element_ratios_times_masses,
-                f"log_Fe_over_H_times_star_mass_{thr}floor_{aperture_size}_kpc",
+                f"log_Fe_over_H_times_star_mass_{floor}floor_{aperture_size}_kpc",
             )
             # Fetch stellar mass in apertures
             star_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
@@ -251,10 +251,10 @@ def register_iron_to_hydrogen(self, catalogue, aperture_sizes, fe_solar_abundanc
             )
             # Convert to units used in observations
             Fe_abundance = unyt.unyt_array(Fe_over_H / fe_solar_abundance, "dimensionless")
-            Fe_abundance.name = f"Stellar $[{{\\rm Fe/H}}]$ ({thr_label}, {aperture_size} kpc)"
+            Fe_abundance.name = f"Stellar $[{{\\rm Fe/H}}]$ ({floor_label}, {aperture_size} kpc)"
     
             # Register the field
-            setattr(self, f"star_fe_abundance_{thr}_{aperture_size}_kpc", Fe_abundance)
+            setattr(self, f"star_fe_abundance_{floor}_{aperture_size}_kpc", Fe_abundance)
 
 
     return

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -209,15 +209,13 @@ def register_oxygen_to_hydrogen(self, catalogue, aperture_sizes):
         gas_sf_mass = getattr(catalogue.apertures, f"mass_gas_sf_{aperture_size}_kpc")
 
         # Compute gas-mass weighted O over H
-        O_over_H = unyt.unyt_array(np.zeros_like(gas_sf_mass), "dimensionless")
+        log_O_over_H = unyt.unyt_array(np.zeros_like(gas_sf_mass), "dimensionless")
         # Avoid division by zero
         mask = gas_sf_mass > 0.0 * gas_sf_mass.units
-        O_over_H[mask] = pow(
-            10.0, log_O_over_H_times_gas_mass[mask] / gas_sf_mass[mask]
-        )
+        log_O_over_H[mask] = log_O_over_H_times_gas_mass[mask] / gas_sf_mass[mask]
 
         # Convert to units used in observations
-        O_abundance = unyt.unyt_array(12 + np.log10(O_over_H), "dimensionless")
+        O_abundance = unyt.unyt_array(12 + log_O_over_H, "dimensionless")
         O_abundance.name = (
             f"SF Gas $12+\\log_{{10}}({{\\rm O/H}})$ ({aperture_size} kpc)"
         )
@@ -249,10 +247,9 @@ def register_iron_to_hydrogen(self, catalogue, aperture_sizes, fe_solar_abundanc
         Fe_over_H[mask] = pow(
             10.0, log_Fe_over_H_times_star_mass[mask] / star_mass[mask]
         )
-
         # Convert to units used in observations
         Fe_abundance = unyt.unyt_array(
-            np.log10(Fe_over_H / solar_fe_abundance), "dimensionless"
+            np.log10(Fe_over_H / fe_solar_abundance), "dimensionless"
         )
         Fe_abundance.name = f"Stellar $[{{\\rm Fe/H}}]$ ({aperture_size} kpc)"
 


### PR DESCRIPTION
following colibre PR https://gitlab.cosma.dur.ac.uk/EAGLE/swift-colibre/-/merge_requests/168 and VR python PR https://github.com/SWIFTSIM/velociraptor-python/pull/55

@EvgeniiChaikin on top of your `update_gat_metallicity_plot` branch, building on your https://github.com/SWIFTSIM/pipeline-configs/pull/112 changes

- register sf gas O/H using mean-of-log with a floor value for particles
-  register stellar Fe/H using mean-of-log with a floor value for particles too, though not remaking @EvgeniiChaikin 's plot
-  two floor values are produced through pre-processing and picked up by VR  python, but use lower floor as default here for now (could register both)