### PR TITLE
Make BH scripts work in the casethe run has no BHs

### DIFF
--- a/colibre/scripts/number_of_agn_thermal_injections.py
+++ b/colibre/scripts/number_of_agn_thermal_injections.py
@@ -4,6 +4,7 @@ Makes a histogram of the number of AGN thermal injections. Uses the swiftsimio l
 
 import matplotlib.pyplot as plt
 import numpy as np
+import unyt
 
 from swiftsimio import load
 
@@ -17,7 +18,11 @@ def get_data(filename):
 
     data = load(filename)
 
-    num_of_agn_thermal_injections = data.black_holes.number_of_heating_events
+    try:
+        num_of_agn_thermal_injections = data.black_holes.number_of_heating_events
+    # In case the run has no BHs
+    except AttributeError:
+        num_of_agn_thermal_injections = unyt.unyt_array([], units="Dimensionless")
 
     # Take only those BHs that have had at least one AGN thermal injection event
     # (i.e. heated at least one gas particle)


### PR DESCRIPTION
This update is needed when we want to compare, say, runs A, B, and C where runs A and B have BHs with different BH evolution models and run C was run w/o BHs.

Without this update, some of the BH scripts would crash because run C has no BH particles. But we might still want to compare runs A and B...

