### PR TITLE
Change normalisation in z-split distributions from 'per z-interval' to 'total'

### DIFF
--- a/colibre/scripts/birth_density_distribution.py
+++ b/colibre/scripts/birth_density_distribution.py
@@ -134,25 +134,17 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         T_K=SNII_heating_temperature, M_gas=M_gas.value, N_ngb=N_ngb_target, X_H=X_H
     )
 
+    # Total number of stars formed
+    Num_of_stars_total = len(birth_redshifts)
+
     for redshift, ax in ax_dict.items():
         data = birth_densities_by_redshift[redshift]
 
         H, _ = np.histogram(data, bins=birth_density_bins)
-
-        # Total number of stars formed
-        Num_of_obj = np.sum(H)
-
-        # Check to avoid division by zero
-        if Num_of_obj:
-            y_points = H / log_birth_density_bin_width / Num_of_obj
-        else:
-            y_points = np.zeros_like(H)
+        y_points = H / log_birth_density_bin_width / Num_of_stars_total
 
         ax.plot(
-            birth_density_centers,
-            y_points,
-            label=name,
-            color=f"C{color}",
+            birth_density_centers, y_points, label=name, color=f"C{color}",
         )
 
         # Add the median stellar birth-density line
@@ -166,11 +158,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
 
         # Add the DV&S2012 line
         ax.axvline(
-            n_crit,
-            color=f"C{color}",
-            linestyle="dotted",
-            zorder=-10,
-            alpha=0.5,
+            n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5,
         )
 
 axes[0].legend(loc="upper right", markerfirst=False)

--- a/colibre/scripts/last_AGN_density_distribution.py
+++ b/colibre/scripts/last_AGN_density_distribution.py
@@ -164,6 +164,9 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         T_K=AGN_heating_temperature, M_gas=M_gas.value, N_ngb=N_ngb_target, X_H=X_H
     )
 
+    # Total number of objects received AGN energy
+    Num_of_heated_parts_total = len(gas_AGN_redshifts) + len(stars_AGN_redshifts)
+
     for redshift, ax in ax_dict.items():
         data = np.concatenate(
             [
@@ -173,21 +176,10 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         )
 
         H, _ = np.histogram(data, bins=AGN_density_bins)
-
-        # Total number AGN-heated gas particles
-        Num_of_obj = np.sum(H)
-
-        # Check to avoid division by zero
-        if Num_of_obj:
-            y_points = H / log_AGN_density_bin_width / Num_of_obj
-        else:
-            y_points = np.zeros_like(H)
+        y_points = H / log_AGN_density_bin_width / Num_of_heated_parts_total
 
         ax.plot(
-            AGN_density_centers,
-            y_points,
-            label=name,
-            color=f"C{color}",
+            AGN_density_centers, y_points, label=name, color=f"C{color}",
         )
         ax.axvline(
             np.median(data),
@@ -199,11 +191,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
 
         # Add the DV&S2012 line
         ax.axvline(
-            n_crit,
-            color=f"C{color}",
-            linestyle="dotted",
-            zorder=-10,
-            alpha=0.5,
+            n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5,
         )
 
 axes[0].legend(loc="upper right", markerfirst=False)

--- a/colibre/scripts/last_SNII_density_distribution.py
+++ b/colibre/scripts/last_SNII_density_distribution.py
@@ -177,6 +177,9 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         T_K=SNII_heating_temperature, M_gas=M_gas.value, N_ngb=N_ngb_target, X_H=X_H
     )
 
+    # Total number of objects received SNII thermal energy
+    Num_of_heated_parts_total = len(gas_SNII_redshifts) + len(stars_SNII_redshifts)
+
     for redshift, ax in ax_dict.items():
         data = np.concatenate(
             [
@@ -186,21 +189,10 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         )
 
         H, _ = np.histogram(data, bins=SNII_density_bins)
-
-        # Total number SNII-heated gas particles
-        Num_of_obj = np.sum(H)
-
-        # Check to avoid division by zero
-        if Num_of_obj:
-            y_points = H / log_SNII_density_bin_width / Num_of_obj
-        else:
-            y_points = np.zeros_like(H)
+        y_points = H / log_SNII_density_bin_width / Num_of_heated_parts_total
 
         ax.plot(
-            SNII_density_centers,
-            y_points,
-            label=name,
-            color=f"C{color}",
+            SNII_density_centers, y_points, label=name, color=f"C{color}",
         )
         ax.axvline(
             np.median(data),
@@ -212,11 +204,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
 
         # Add the DV&S2012 line
         ax.axvline(
-            n_crit,
-            color=f"C{color}",
-            linestyle="dotted",
-            zorder=-10,
-            alpha=0.5,
+            n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5,
         )
 
 axes[0].legend(loc="upper right", markerfirst=False)

--- a/colibre/scripts/last_SNII_kick_velocity_distribution.py
+++ b/colibre/scripts/last_SNII_kick_velocity_distribution.py
@@ -99,6 +99,9 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         )
     )  # in km/s
 
+    # Total number of objects received SNII kinetic energy
+    Num_of_kicked_parts_total = len(gas_SNII_redshifts) + len(stars_SNII_redshifts)
+
     for redshift, ax in ax_dict.items():
         data = np.concatenate(
             [
@@ -108,21 +111,10 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         )
 
         H, _ = np.histogram(data, bins=SNII_v_kick_bins)
-
-        # Total number of particles kicked by SNIIe
-        Num_of_obj = np.sum(H)
-
-        # Check to avoid division by zero
-        if Num_of_obj:
-            y_points = H / log_SNII_v_kick_bin_width / Num_of_obj
-        else:
-            y_points = np.zeros_like(H)
+        y_points = H / log_SNII_v_kick_bin_width / Num_of_kicked_parts_total
 
         ax.plot(
-            SNII_v_kick_centres,
-            y_points,
-            label=name,
-            color=f"C{color}",
+            SNII_v_kick_centres, y_points, label=name, color=f"C{color}",
         )
         ax.axvline(
             np.median(data),


### PR DESCRIPTION
In figures where we plot distributions per redshift intervals **(z>3, 1<z<3, and z<1)**, change normalization from **per z-interval** to **total**

This change solves the problem with the AGN density distribution plots.

<h2>Before</h2>

![AGN_density_distribution_old](https://user-images.githubusercontent.com/20153933/120812906-b719b100-c54d-11eb-9d3a-dcba14c0c7d0.png)

<h2>After</h2>

![AGN_density_distribution](https://user-images.githubusercontent.com/20153933/120813081-df091480-c54d-11eb-9139-21acca18c0d5.png)


Note that the difference arises because for AGNs there are too few events at z>3. Hence, the normalization in this interval range (z>3) is a very small number which affects the y axis limits and disrupts the other two panels.

If we look at what happens, e.g., with **SN density distribution**, then the effect is minor


<h2>Before</h2>

![SNII_density_distribution_old](https://user-images.githubusercontent.com/20153933/120813171-f1834e00-c54d-11eb-92a5-56a1fe3d513d.png)

<h2>After</h2>

![SNII_density_distribution](https://user-images.githubusercontent.com/20153933/120813193-f516d500-c54d-11eb-8f22-2aff8951d3be.png)
