### PR TITLE
Updated baryon fraction and GSMF Flamingo

### DIFF
--- a/flamingo/auto_plotter/baryon_fractions.yml
+++ b/flamingo/auto_plotter/baryon_fractions.yml
@@ -1,10 +1,12 @@
 baryon_fraction_500:
   type: "2dhistogram"
+  select_structure_type: 10
+  comment: "Centrals only"
   legend_loc: "upper left"
   x:
     quantity: "spherical_overdensities.mass_500_rhocrit"
     units: Solar_Mass
-    start: 1e11
+    start: 1e13
     end: 1e15
   y:
     quantity: "derived_quantities.baryon_fraction_true_R500"
@@ -18,7 +20,7 @@ baryon_fraction_500:
     adaptive: true
     number_of_bins: 20
     start:
-      value: 1e11
+      value: 1e13
       units: Solar_Mass
     end:
       value: 1e15
@@ -30,11 +32,13 @@ baryon_fraction_500:
 
 gas_fraction_500:
   type: "2dhistogram"
+  select_structure_type: 10
+  comment: "Centrals only"
   legend_loc: "upper left"
   x:
     quantity: "spherical_overdensities.mass_500_rhocrit"
     units: Solar_Mass
-    start: 1e11
+    start: 1e13
     end: 1e15
   y:
     quantity: "derived_quantities.gas_fraction_true_R500"
@@ -48,7 +52,7 @@ gas_fraction_500:
     adaptive: true
     number_of_bins: 20
     start:
-      value: 1e11
+      value: 1e13
       units: Solar_Mass
     end:
       value: 1e15
@@ -66,11 +70,13 @@ gas_fraction_500:
 
 star_fraction_500:
   type: "2dhistogram"
+  select_structure_type: 10
+  comment: "Centrals only"
   legend_loc: "upper left"
   x:
     quantity: "spherical_overdensities.mass_500_rhocrit"
     units: Solar_Mass
-    start: 1e11
+    start: 1e13
     end: 1e15
   y:
     quantity: "derived_quantities.star_fraction_true_R500"
@@ -84,7 +90,7 @@ star_fraction_500:
     adaptive: true
     number_of_bins: 20
     start:
-      value: 1e11
+      value: 1e13
       units: Solar_Mass
     end:
       value: 1e15
@@ -97,11 +103,13 @@ star_fraction_500:
 
 gas_mass_500:
   type: "2dhistogram"
+  select_structure_type: 10
+  comment: "Centrals only"
   legend_loc: "upper left"
   x:
     quantity: "spherical_overdensities.mass_500_rhocrit"
     units: Solar_Mass
-    start: 1e11
+    start: 1e13
     end: 1e15
   y:
     quantity: "spherical_overdensities.mass_gas_500_rhocrit"
@@ -114,7 +122,7 @@ gas_mass_500:
     adaptive: true
     number_of_bins: 20
     start:
-      value: 1e11
+      value: 1e13
       units: Solar_Mass
     end:
       value: 1e15

--- a/flamingo/auto_plotter/mass_functions.yml
+++ b/flamingo/auto_plotter/mass_functions.yml
@@ -6,11 +6,11 @@ stellar_mass_function_30:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 1e13
+    end: 2e12
   y:
     units: 1/Mpc**3
     start: 1e-6
-    end: 0.316 # (1e-0.5)
+    end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (30 kpc aperture)
     caption: 30 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. For 30kpc look at the Li and White (2009) data.
@@ -30,11 +30,11 @@ adaptive_stellar_mass_function_30:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 1e13
+    end: 2e12
   y:
     units: 1/Mpc**3
     start: 1e-6
-    end: 0.316 # (1e-0.5)
+    end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (30 kpc aperture, adaptive)
     caption: 30 kpc aperture GSMF, showing all galaxies with an adaptive bin-width. For 30kpc look at the Li and White (2009) data.
@@ -57,11 +57,11 @@ stellar_mass_function_active_only_30:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 1e13
+    end: 2e12
   y:
     units: 1/Mpc**3
     start: 1e-6
-    end: 0.316 # (1e-0.5)
+    end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (30 kpc aperture)
     caption: Only for active galaxies. For 30kpc look at the Li and White (2009) data.
@@ -84,11 +84,11 @@ stellar_mass_function_passive_only_30:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 1e13
+    end: 2e12
   y:
     units: 1/Mpc**3
     start: 1e-6
-    end: 0.316 # (1e-0.5)
+    end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (30 kpc aperture)
     caption: Only for passive galaxies. For 30kpc look at the Li and White (2009) data.
@@ -108,11 +108,11 @@ stellar_mass_function_100:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 1e13
+    end: 2e12
   y:
     units: 1/Mpc**3
     start: 1e-6
-    end: 0.316 # (1e-0.5)
+    end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (100 kpc aperture)
     caption: 100 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex.
@@ -131,11 +131,11 @@ adaptive_stellar_mass_function_100:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 1e13
+    end: 2e12
   y:
     units: 1/Mpc**3
     start: 1e-6
-    end: 0.316 # (1e-0.5)
+    end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (100 kpc aperture, adaptive)
     caption: 100 kpc aperture GSMF, showing all galaxies with an adaptive bin-width.
@@ -157,11 +157,11 @@ stellar_mass_function_passive_only_100:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 1e13
+    end: 2e12
   y:
     units: 1/Mpc**3
     start: 1e-6
-    end: 0.316 # (1e-0.5)
+    end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (100 kpc aperture)
     caption: Only for passive galaxies.
@@ -183,11 +183,11 @@ stellar_mass_function_active_only_100:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 1e13
+    end: 2e12
   y:
     units: 1/Mpc**3
     start: 1e-6
-    end: 0.316 # (1e-0.5)
+    end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (100 kpc aperture)
     caption: Only for active galaxies.
@@ -206,11 +206,11 @@ stellar_mass_function_50:
     quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 1e13
+    end: 2e12
   y:
     units: 1/Mpc**3
     start: 1e-6
-    end: 0.316 # (1e-0.5)
+    end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (50 kpc aperture)
     caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. For 50kpc, look at D'Souza (2015) data.
@@ -230,11 +230,11 @@ adaptive_stellar_mass_function_50:
     quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 1e13
+    end: 2e12
   y:
     units: 1/Mpc**3
     start: 1e-6
-    end: 0.316 # (1e-0.5)
+    end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (50 kpc aperture, adaptive)
     caption: 50 kpc aperture GSMF, showing all galaxies with an adaptive bin-width. For 50kpc, look at D'Souza (2015) data.
@@ -253,11 +253,11 @@ stellar_mass_eddington_function_30:
     quantity: "derived_quantities.stellar_mass_eddington_30_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 1e13
+    end: 2e12
   y:
     units: 1/Mpc**3
     start: 1e-6
-    end: 0.316 # (1e-0.5)
+    end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (30 kpc aperture) with Eddington bias
     caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Includes Eddington bias.
@@ -277,11 +277,11 @@ stellar_mass_eddington_function_50:
     quantity: "derived_quantities.stellar_mass_eddington_50_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 1e13
+    end: 2e12
   y:
     units: 1/Mpc**3
     start: 1e-6
-    end: 0.316 # (1e-0.5)
+    end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (50 kpc aperture) with Eddington bias
     caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Includes Eddington bias.
@@ -301,11 +301,11 @@ stellar_mass_eddington_function_100:
     quantity: "derived_quantities.stellar_mass_eddington_100_kpc"
     units: Solar_Mass
     start: 1e9
-    end: 1e13
+    end: 2e12
   y:
     units: 1/Mpc**3
     start: 1e-6
-    end: 0.316 # (1e-0.5)
+    end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (100 kpc aperture) with Eddington bias
     caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Includes Eddington bias.


### PR DESCRIPTION
Updated baryon fraction and GSMF auto_plotter configs for a better visualisations for flamingo. Now only plot baryon fraction  for field haloes.