### PR TITLE
Added GSMF data from Leja+ (2020) to FLAMINGO and EAGLE-XL.

### DIFF
--- a/eagle-xl/auto_plotter/mass_functions.yml
+++ b/eagle-xl/auto_plotter/mass_functions.yml
@@ -21,6 +21,7 @@ stellar_mass_function_30:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 adaptive_stellar_mass_function_30:
   type: "adaptivemassfunction"
@@ -45,6 +46,7 @@ adaptive_stellar_mass_function_30:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 adaptive_stellar_mass_function_active_only_30:
   type: "adaptivemassfunction"
@@ -72,6 +74,7 @@ adaptive_stellar_mass_function_active_only_30:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 adaptive_stellar_mass_function_passive_only_30:
   type: "adaptivemassfunction"
@@ -99,6 +102,7 @@ adaptive_stellar_mass_function_passive_only_30:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 stellar_mass_function_100:
   type: "massfunction"
@@ -122,6 +126,7 @@ stellar_mass_function_100:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 adaptive_stellar_mass_function_100:
   type: "adaptivemassfunction"
@@ -145,6 +150,7 @@ adaptive_stellar_mass_function_100:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 adaptive_stellar_mass_function_passive_only_100:
   type: "adaptivemassfunction"
@@ -171,6 +177,7 @@ adaptive_stellar_mass_function_passive_only_100:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 adaptive_stellar_mass_function_active_only_100:
   type: "adaptivemassfunction"
@@ -197,3 +204,4 @@ adaptive_stellar_mass_function_active_only_100:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5

--- a/flamingo/auto_plotter/mass_functions.yml
+++ b/flamingo/auto_plotter/mass_functions.yml
@@ -21,6 +21,7 @@ stellar_mass_function_30:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 adaptive_stellar_mass_function_30:
   type: "adaptivemassfunction"
@@ -45,6 +46,7 @@ adaptive_stellar_mass_function_30:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 stellar_mass_function_active_only_30:
   type: "massfunction"
@@ -72,6 +74,7 @@ stellar_mass_function_active_only_30:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 stellar_mass_function_passive_only_30:
   type: "massfunction"
@@ -99,6 +102,7 @@ stellar_mass_function_passive_only_30:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 stellar_mass_function_100:
   type: "massfunction"
@@ -122,6 +126,7 @@ stellar_mass_function_100:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 adaptive_stellar_mass_function_100:
   type: "adaptivemassfunction"
@@ -145,6 +150,7 @@ adaptive_stellar_mass_function_100:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 stellar_mass_function_passive_only_100:
   type: "massfunction"
@@ -171,6 +177,7 @@ stellar_mass_function_passive_only_100:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 stellar_mass_function_active_only_100:
   type: "massfunction"
@@ -197,6 +204,7 @@ stellar_mass_function_active_only_100:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 stellar_mass_function_50:
   type: "massfunction"
@@ -221,6 +229,7 @@ stellar_mass_function_50:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 adaptive_stellar_mass_function_50:
   type: "adaptivemassfunction"
@@ -244,6 +253,7 @@ adaptive_stellar_mass_function_50:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 stellar_mass_eddington_function_30:
   type: "massfunction"
@@ -268,6 +278,7 @@ stellar_mass_eddington_function_30:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 stellar_mass_eddington_function_50:
   type: "massfunction"
@@ -292,6 +303,7 @@ stellar_mass_eddington_function_50:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 stellar_mass_eddington_function_100:
   type: "massfunction"
@@ -316,3 +328,4 @@ stellar_mass_eddington_function_100:
     - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5


### PR DESCRIPTION
Added GSMF data from Leja+ (2020) to FLAMINGO and EAGLE-XL. Uses panchromatic SED models that infer systematically higher masses and lower star formation rates than standard approaches.