### PR TITLE
Include Moster2018 SMHM data

### DIFF
--- a/colibre-zooms/auto_plotter/stellar_mass_halo_mass.yml
+++ b/colibre-zooms/auto_plotter/stellar_mass_halo_mass.yml
@@ -65,6 +65,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_100:
     section: Stellar Mass-Halo Mass
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Behroozi2019Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018Ratio.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_Ratio.hdf5
 
 stellar_mass_halo_mass_M200_centrals_ratio_stellar_100:
@@ -134,6 +135,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
     section: Stellar Mass-Halo Mass
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Behroozi2019RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018RatioStellar.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_RatioStellar.hdf5
 
 stellar_mass_halo_mass_M200_all_100:

--- a/colibre/auto_plotter/stellar_mass_halo_mass.yml
+++ b/colibre/auto_plotter/stellar_mass_halo_mass.yml
@@ -65,6 +65,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_100:
     section: Stellar Mass-Halo Mass
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Behroozi2019Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018Ratio.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_Ratio.hdf5
 
 stellar_mass_halo_mass_M200_centrals_ratio_stellar_100:
@@ -134,6 +135,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
     section: Stellar Mass-Halo Mass
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Behroozi2019RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018RatioStellar.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_RatioStellar.hdf5
 
 stellar_mass_halo_mass_M200_all_100:

--- a/eagle-xl/auto_plotter/stellar_mass_halo_mass.yml
+++ b/eagle-xl/auto_plotter/stellar_mass_halo_mass.yml
@@ -65,6 +65,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_100:
     section: Stellar Mass-Halo Mass
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Behroozi2019Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018Ratio.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_Ratio.hdf5
 
 stellar_mass_halo_mass_M200_centrals_ratio_stellar_100:
@@ -134,6 +135,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
     section: Stellar Mass-Halo Mass
   observational_data:
     - filename: GalaxyStellarMassHaloMass/Behroozi2019RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018RatioStellar.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_RatioStellar.hdf5
 
 stellar_mass_halo_mass_M200_all_100:


### PR DESCRIPTION
Add SMHM data spanning redshifts between z=0 and z=8 from Moster's emperical model 2018

Data is added to

- colibre
- colibre-zoom
- eagle-xl