### PR TITLE
fix captions and selections for cold gas fraction plots

### DIFF
--- a/colibre-zooms/auto_plotter/gas_fraction_plots.yml
+++ b/colibre-zooms/auto_plotter/gas_fraction_plots.yml
@@ -68,7 +68,7 @@ h2_frac_func_ssfr:
 h2_frac_func_stellar_surface_density_xgass_selection:
   type: "scatter"
   legend_loc: "lower left"
-  selection_mask: "derived_quantities.xcoldgass_galaxy_selection"
+  selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
     quantity: "derived_quantities.mu_star_100_kpc"
@@ -127,7 +127,7 @@ hi_frac_func_stellar_mass_xgass_selection:
   metadata:
     title: Stellar Mass-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. 
     show_on_webpage: false
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_M_star.hdf5
@@ -136,6 +136,7 @@ hi_frac_func_ssfr:
   type: "scatter"
   legend_loc: "lower right"
   selection_mask: "derived_quantities.xgass_galaxy_selection"
+  comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
     quantity: "derived_quantities.specific_sfr_gas_100_kpc"
     units: 1 / gigayear
@@ -160,7 +161,7 @@ hi_frac_func_ssfr:
   metadata:
     title: sSFR-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy HI mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -168,6 +169,7 @@ hi_frac_func_stellar_surface_density:
   type: "scatter"
   legend_loc: "lower left"
   selection_mask: "derived_quantities.xgass_galaxy_selection"
+  comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
     quantity: "derived_quantities.mu_star_100_kpc"
     units: "Solar_Mass / (kpc**2)"
@@ -192,7 +194,7 @@ hi_frac_func_stellar_surface_density:
   metadata:
     title: Stellar Mass Surface Density-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass surface density in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass surface density in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_mu_star.hdf5
 
@@ -269,6 +271,8 @@ hi_frac_func_stellar_mass:
 cold_gas_frac_func_ssfr:
   type: "scatter"
   legend_loc: "upper right"
+  selection_mask: "derived_quantities.xgass_galaxy_selection"
+  comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
     quantity: "derived_quantities.specific_sfr_gas_100_kpc"
     units: 1 / gigayear
@@ -293,7 +297,7 @@ cold_gas_frac_func_ssfr:
   metadata:
     title: sSFR-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy neutral gas mass over stellar mass as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures
+    caption: Galaxy neutral gas mass over stellar mass as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyColdGasFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -324,7 +328,7 @@ h2_to_neutral_gas_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass over neutral gas (HI+H$_2$) mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS and XCOLDGASS samples are uniform in mass in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$ and $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$ and plotting those above the CO detection limit ($M_{\rm H2}/M_*$ > $1.5\%$).
+    caption: Galaxy H$_2$ mass over neutral gas (HI+H$_2$) mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS and XCOLDGASS samples are uniform in mass in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$ and $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$ and plotting those above the CO detection limit ($M_{\rm H2}/M_*$ > $1.5\%$). 
   observational_data:
     - filename: GalaxyColdGasFractions/CatinellaSaintongeComposite_abcissa_M_star.hdf5
     - filename: GalaxyColdGasFractions/Hunt2020_Data.hdf5
@@ -334,6 +338,8 @@ h2_to_neutral_gas_frac_func_stellar_mass:
 h2_to_neutral_gas_frac_func_ssfr:
   type: "scatter"
   legend_loc: "upper right"
+  selection_mask: "derived_quantities.xgass_galaxy_selection"
+  comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
     quantity: "derived_quantities.specific_sfr_gas_100_kpc"
     units: 1 / gigayear
@@ -356,9 +362,9 @@ h2_to_neutral_gas_frac_func_ssfr:
       value: 6e1
       units: 1 / gigayear
   metadata:
-    title: sSFR-H2 Fraction
+    title: sSFR-Neutral Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass over neutral gas mass (HI+H$_2$) as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass over neutral gas mass (HI+H$_2$) as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XCOLDGASS (Saintonge+17) and XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyColdGasFractions/CatinellaSaintongeComposite_abcissa_sSFR.hdf5
 

--- a/colibre-zooms/auto_plotter/gas_fraction_plots.yml
+++ b/colibre-zooms/auto_plotter/gas_fraction_plots.yml
@@ -161,7 +161,7 @@ hi_frac_func_ssfr:
   metadata:
     title: sSFR-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy HI mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -194,7 +194,7 @@ hi_frac_func_stellar_surface_density:
   metadata:
     title: Stellar Mass Surface Density-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass surface density in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass surface density in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_mu_star.hdf5
 
@@ -260,7 +260,7 @@ hi_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. LITTLE THINGS galaxies are dIrrs selected to be within 10 Mpc, with 50$\%$ of galaxies within 3.6 Mpc, and detected in HI. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. LITTLE THINGS galaxies are dIrrs selected to be within 10 Mpc, with 50$\%$ of galaxies within 3.6 Mpc, and detected in HI. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_M_star.hdf5
     - filename: GalaxyHIFractions/Hunt2020_Data.hdf5
@@ -297,7 +297,7 @@ cold_gas_frac_func_ssfr:
   metadata:
     title: sSFR-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy neutral gas mass over stellar mass as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy neutral gas mass over stellar mass as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyColdGasFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -364,7 +364,7 @@ h2_to_neutral_gas_frac_func_ssfr:
   metadata:
     title: sSFR-Neutral Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass over neutral gas mass (HI+H$_2$) as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XCOLDGASS (Saintonge+17) and XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy H$_2$ mass over neutral gas mass (HI+H$_2$) as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XCOLDGASS (Saintonge+17) and XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyColdGasFractions/CatinellaSaintongeComposite_abcissa_sSFR.hdf5
 

--- a/colibre/auto_plotter/gas_fraction_plots.yml
+++ b/colibre/auto_plotter/gas_fraction_plots.yml
@@ -68,7 +68,7 @@ h2_frac_func_ssfr:
 h2_frac_func_stellar_surface_density_xgass_selection:
   type: "scatter"
   legend_loc: "lower left"
-  selection_mask: "derived_quantities.xcoldgass_galaxy_selection"
+  selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
     quantity: "derived_quantities.mu_star_100_kpc"
@@ -127,7 +127,7 @@ hi_frac_func_stellar_mass_xgass_selection:
   metadata:
     title: Stellar Mass-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. 
     show_on_webpage: false
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_M_star.hdf5
@@ -136,6 +136,7 @@ hi_frac_func_ssfr:
   type: "scatter"
   legend_loc: "lower right"
   selection_mask: "derived_quantities.xgass_galaxy_selection"
+  comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
     quantity: "derived_quantities.specific_sfr_gas_100_kpc"
     units: 1 / gigayear
@@ -160,7 +161,7 @@ hi_frac_func_ssfr:
   metadata:
     title: sSFR-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy HI mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -168,6 +169,7 @@ hi_frac_func_stellar_surface_density:
   type: "scatter"
   legend_loc: "lower left"
   selection_mask: "derived_quantities.xgass_galaxy_selection"
+  comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
     quantity: "derived_quantities.mu_star_100_kpc"
     units: "Solar_Mass / (kpc**2)"
@@ -192,7 +194,7 @@ hi_frac_func_stellar_surface_density:
   metadata:
     title: Stellar Mass Surface Density-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass surface density in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass surface density in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_mu_star.hdf5
 
@@ -269,6 +271,8 @@ hi_frac_func_stellar_mass:
 cold_gas_frac_func_ssfr:
   type: "scatter"
   legend_loc: "upper right"
+  selection_mask: "derived_quantities.xgass_galaxy_selection"
+  comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
     quantity: "derived_quantities.specific_sfr_gas_100_kpc"
     units: 1 / gigayear
@@ -293,7 +297,7 @@ cold_gas_frac_func_ssfr:
   metadata:
     title: sSFR-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy neutral gas mass over stellar mass as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures
+    caption: Galaxy neutral gas mass over stellar mass as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyColdGasFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -324,7 +328,7 @@ h2_to_neutral_gas_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass over neutral gas (HI+H$_2$) mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS and XCOLDGASS samples are uniform in mass in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$ and $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$ and plotting those above the CO detection limit ($M_{\rm H2}/M_*$ > $1.5\%$).
+    caption: Galaxy H$_2$ mass over neutral gas (HI+H$_2$) mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS and XCOLDGASS samples are uniform in mass in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$ and $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$ and plotting those above the CO detection limit ($M_{\rm H2}/M_*$ > $1.5\%$). 
   observational_data:
     - filename: GalaxyColdGasFractions/CatinellaSaintongeComposite_abcissa_M_star.hdf5
     - filename: GalaxyColdGasFractions/Hunt2020_Data.hdf5
@@ -334,6 +338,8 @@ h2_to_neutral_gas_frac_func_stellar_mass:
 h2_to_neutral_gas_frac_func_ssfr:
   type: "scatter"
   legend_loc: "upper right"
+  selection_mask: "derived_quantities.xgass_galaxy_selection"
+  comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
     quantity: "derived_quantities.specific_sfr_gas_100_kpc"
     units: 1 / gigayear
@@ -356,9 +362,9 @@ h2_to_neutral_gas_frac_func_ssfr:
       value: 6e1
       units: 1 / gigayear
   metadata:
-    title: sSFR-H2 Fraction
+    title: sSFR-Neutral Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass over neutral gas mass (HI+H$_2$) as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass over neutral gas mass (HI+H$_2$) as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XCOLDGASS (Saintonge+17) and XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyColdGasFractions/CatinellaSaintongeComposite_abcissa_sSFR.hdf5
 

--- a/colibre/auto_plotter/gas_fraction_plots.yml
+++ b/colibre/auto_plotter/gas_fraction_plots.yml
@@ -161,7 +161,7 @@ hi_frac_func_ssfr:
   metadata:
     title: sSFR-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy HI mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -194,7 +194,7 @@ hi_frac_func_stellar_surface_density:
   metadata:
     title: Stellar Mass Surface Density-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass surface density in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass surface density in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_mu_star.hdf5
 
@@ -260,7 +260,7 @@ hi_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. LITTLE THINGS galaxies are dIrrs selected to be within 10 Mpc, with 50$\%$ of galaxies within 3.6 Mpc, and detected in HI. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. LITTLE THINGS galaxies are dIrrs selected to be within 10 Mpc, with 50$\%$ of galaxies within 3.6 Mpc, and detected in HI. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_M_star.hdf5
     - filename: GalaxyHIFractions/Hunt2020_Data.hdf5
@@ -297,7 +297,7 @@ cold_gas_frac_func_ssfr:
   metadata:
     title: sSFR-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy neutral gas mass over stellar mass as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy neutral gas mass over stellar mass as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyColdGasFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -364,7 +364,7 @@ h2_to_neutral_gas_frac_func_ssfr:
   metadata:
     title: sSFR-Neutral Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass over neutral gas mass (HI+H$_2$) as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XCOLDGASS (Saintonge+17) and XGASS (Catinella+18) galaxies are selected with to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy H$_2$ mass over neutral gas mass (HI+H$_2$) as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XCOLDGASS (Saintonge+17) and XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyColdGasFractions/CatinellaSaintongeComposite_abcissa_sSFR.hdf5
 


### PR DESCRIPTION
Ensure that where Catinella+18 is the only comparison, XGASS-like selection is imposed