### PR TITLE
Make medial line visible in the plots with too many scatter points

### DIFF
--- a/colibre/scripts/stellar_abundances_FeH_Fe_snia_fraction.py
+++ b/colibre/scripts/stellar_abundances_FeH_Fe_snia_fraction.py
@@ -2,6 +2,7 @@
 Plots [Fe/H] vs mass fraction of Fe from SNIa
 """
 import matplotlib.pyplot as plt
+import matplotlib.patheffects as pe
 import numpy as np
 import swiftsimio
 import unyt
@@ -64,7 +65,7 @@ for snapshot_filename, name in zip(snapshot_filenames, names):
     Fe_H, Fe_snia_fr = read_data(snapshot_data)
 
     # low zorder, as we want these points to be in the background
-    dots = ax.plot(Fe_H, Fe_snia_fr, ".", markersize=0.2, alpha=0.15, zorder=-99)[0]
+    dots = ax.plot(Fe_H, Fe_snia_fr, ".", markersize=0.2, alpha=0.2, zorder=-99)[0]
 
     # Bins along the X axis (Fe_H) to plot the median line
     bins = np.arange(-7.2, 1, 0.2)
@@ -82,7 +83,16 @@ for snapshot_filename, name in zip(snapshot_filenames, names):
 
     # high zorder, as we want the simulation lines to be on top of everything else
     # we steal the color of the dots to make sure the line has the same color
-    simulation_lines.append(ax.plot(xm, ym, color=dots.get_color(), zorder=1000)[0])
+    simulation_lines.append(
+        ax.plot(
+            xm,
+            ym,
+            lw=2,
+            color=dots.get_color(),
+            zorder=1000,
+            path_effects=[pe.Stroke(linewidth=4, foreground="white"), pe.Normal()],
+        )[0]
+    )
     simulation_labels.append(f"{name} ($z={redshift:.1f}$)")
 
 ax.set_xlabel("[Fe/H]")

--- a/colibre/scripts/stellar_abundances_FeH_MgFe.py
+++ b/colibre/scripts/stellar_abundances_FeH_MgFe.py
@@ -2,6 +2,7 @@
 Plots the stellar abundances ([Fe/H] vs [Mg/Fe]) for a given snapshot
 """
 import matplotlib.pyplot as plt
+import matplotlib.patheffects as pe
 import numpy as np
 import unyt
 import glob
@@ -71,7 +72,7 @@ for snapshot_filename, name in zip(snapshot_filenames, names):
     Fe_H, Mg_Fe = read_data(data)
 
     # low zorder, as we want these points to be in the background
-    dots = ax.plot(Fe_H, Mg_Fe, ".", markersize=0.2, alpha=0.15, zorder=-99)[0]
+    dots = ax.plot(Fe_H, Mg_Fe, ".", markersize=0.2, alpha=0.2, zorder=-99)[0]
 
     # Bins along the X axis (Fe_H) to plot the median line
     bins = np.arange(-7.2, 1, 0.2)
@@ -89,7 +90,16 @@ for snapshot_filename, name in zip(snapshot_filenames, names):
 
     # high zorder, as we want the simulation lines to be on top of everything else
     # we steal the color of the dots to make sure the line has the same color
-    simulation_lines.append(ax.plot(xm, ym, color=dots.get_color(), zorder=1000)[0])
+    simulation_lines.append(
+        ax.plot(
+            xm,
+            ym,
+            lw=2,
+            color=dots.get_color(),
+            zorder=1000,
+            path_effects=[pe.Stroke(linewidth=4, foreground="white"), pe.Normal()],
+        )[0]
+    )
     simulation_labels.append(f"{name} ($z={redshift:.1f}$)")
 
 # We select all Tolstoy* files containing FeH-MgFe.

--- a/colibre/scripts/stellar_abundances_FeH_OFe.py
+++ b/colibre/scripts/stellar_abundances_FeH_OFe.py
@@ -2,6 +2,7 @@
 Plots the stellar abundances ([Fe/H] vs [O/Fe]) for a given snapshot
 """
 import matplotlib.pyplot as plt
+import matplotlib.patheffects as pe
 import numpy as np
 import unyt
 import glob
@@ -71,7 +72,7 @@ for snapshot_filename, name in zip(snapshot_filenames, names):
     Fe_H, O_Fe = read_data(data)
 
     # low zorder, as we want these points to be in the background
-    dots = ax.plot(Fe_H, O_Fe, ".", markersize=0.2, alpha=0.15, zorder=-99)[0]
+    dots = ax.plot(Fe_H, O_Fe, ".", markersize=0.2, alpha=0.2, zorder=-99)[0]
 
     # Bins along the X axis (Fe_H) to plot the median line
     bins = np.arange(-7.2, 1, 0.2)
@@ -90,6 +91,16 @@ for snapshot_filename, name in zip(snapshot_filenames, names):
     # high zorder, as we want the simulation lines to be on top of everything else
     # we steal the color of the dots to make sure the line has the same color
     simulation_lines.append(ax.plot(xm, ym, color=dots.get_color(), zorder=1000)[0])
+    simulation_lines.append(
+        ax.plot(
+            xm,
+            ym,
+            lw=2,
+            color=dots.get_color(),
+            zorder=1000,
+            path_effects=[pe.Stroke(linewidth=4, foreground="white"), pe.Normal()],
+        )[0]
+    )
     simulation_labels.append(f"{name} ($z={redshift:.1f}$)")
 
 # We select all files except the Tolstoy* ones containing FeH-MgFe.


### PR DESCRIPTION
A short update that improves the readability of several plots in the pipeline

<h3>Example</h3>
<h2>Before</h2>

![before](https://user-images.githubusercontent.com/20153933/133423896-ef54cd82-5da2-4740-8bec-baeadd81adb9.png)

<h2>After</h2>

![after](https://user-images.githubusercontent.com/20153933/133423942-534a634b-47b0-4dd2-8411-75e5623bd547.png)

