### PR TITLE
LOS stellar velocity dispersion

### DIFF
--- a/colibre-zooms/auto_plotter/black_holes.yml
+++ b/colibre-zooms/auto_plotter/black_holes.yml
@@ -101,7 +101,7 @@ stellar_veldisp_black_hole_mass_10:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.veldisp_star_10_kpc"
+    quantity: "derived_quantities.los_veldisp_star_10_kpc"
     units: km/s
     start: 1e1
     end: 1e3
@@ -122,8 +122,8 @@ stellar_veldisp_black_hole_mass_10:
       value: 1e3
       units: km/s
   metadata:
-    title: Stellar Velocity Dispersion-Black Hole Mass relation (10 kpc)
-    caption: Note that the stellar velocity dispersion is measured in observations in a fixed 1 kpc aperture
+    title: LOS Stellar Velocity Dispersion-Black Hole Mass relation (10 kpc)
+    caption: The 3D stellar velocity dispersion is converted into a LOS velocity dispersion using a $1/\sqrt{3}$ correction factor. Note that the stellar velocity dispersion is measured in observations in a fixed 1 kpc aperture
     section: Black Holes
   observational_data:
     - filename: StellarVelocityDispersionBlackHoleMass/Sahu2019.hdf5
@@ -133,7 +133,7 @@ stellar_veldisp_black_hole_mass_30:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.veldisp_star_30_kpc"
+    quantity: "derived_quantities.los_veldisp_star_30_kpc"
     units: km/s
     start: 10
     end: 1e3
@@ -154,9 +154,39 @@ stellar_veldisp_black_hole_mass_30:
       value: 1e3
       units: km/s
   metadata:
-    title: Stellar Velocity Dispersion-Black Hole Mass relation (30 kpc)
-    caption: Note that the stellar velocity dispersion is measured in observations in a fixed 1 kpc aperture
+    title: LOS Stellar Velocity Dispersion-Black Hole Mass relation (30 kpc)
+    caption: The 3D stellar velocity dispersion is converted into a LOS velocity dispersion using a $1/\sqrt{3}$ correction factor. Note that the stellar velocity dispersion is measured in observations in a fixed 1 kpc aperture
     section: Black Holes
     show_on_webpage: false
   observational_data:
     - filename: StellarVelocityDispersionBlackHoleMass/Sahu2019.hdf5
+
+stellar_mass_stellar_veldisp_10:
+  type: "scatter"
+  legend_loc: "upper left"
+  x:
+    quantity: "apertures.mass_star_10_kpc"
+    units: Solar_Mass
+    start: 1e7
+    end: 1e12
+  y:
+    quantity: "derived_quantities.los_veldisp_star_10_kpc"
+    units: km/s
+    start: 10
+    end: 1e3
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 10
+    start:
+      value: 1e7
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-LOS Stellar Velocity Dispersion relation (10 kpc)
+    caption: The 3D stellar velocity dispersion is converted into a LOS velocity dispersion using a $1/\sqrt{3}$ correction factor.
+    section: Black Holes
+    show_on_webpage: true

--- a/colibre-zooms/registration.py
+++ b/colibre-zooms/registration.py
@@ -22,6 +22,9 @@ This file calculates:
         apertures.
     + average of log of stellar birth densities (average_of_log_stellar_birth_density)
         velociraptor outputs the log of the quantity we need, so we take exp(...) of it
+    + LOS stellar velocity dispersions (10, 30 kpc) (los_veldisp_star_{x}_kpc)
+        The LOS velocity dispersion, obtained by multiplying the 3D velocity
+        dispersion with 1/sqrt(3).
 """
 
 # Define aperture size in kpc
@@ -772,6 +775,15 @@ def register_stellar_birth_densities(self, catalogue):
 
     return
 
+def register_los_star_veldisp(self, catalogue):
+    for aperture_size in [10, 30]:
+        veldisp = getattr(catalogue.apertures, f"veldisp_star_{aperture_size}_kpc")
+        los_veldisp = veldisp / np.sqrt(3.0)
+        los_veldisp.name = f"LOS stellar velocity dispersion ({aperture_size} kpc)"
+        setattr(self, f"los_veldisp_star_{aperture_size}_kpc", los_veldisp)
+
+    return
+
 
 # Register derived fields
 register_spesific_star_formation_rates(self, catalogue, aperture_sizes)
@@ -790,3 +802,4 @@ register_cold_gas_mass_ratios(self, catalogue, aperture_sizes)
 register_species_fractions(self, catalogue, aperture_sizes)
 register_stellar_birth_densities(self, catalogue)
 register_global_mask(self, catalogue)
+register_los_star_veldisp(self, catalogue)

--- a/colibre/auto_plotter/black_holes.yml
+++ b/colibre/auto_plotter/black_holes.yml
@@ -154,7 +154,7 @@ stellar_veldisp_black_hole_mass_30:
       value: 1e3
       units: km/s
   metadata:
-    title: Stellar Velocity Dispersion-Black Hole Mass relation (30 kpc)
+    title: LOS Stellar Velocity Dispersion-Black Hole Mass relation (30 kpc)
     caption: The 3D stellar velocity dispersion is converted into a LOS velocity dispersion using a $1/\sqrt{3}$ correction factor. Note that the stellar velocity dispersion in observations is measured in a fixed 1 kpc aperture.
     section: Black Holes
     show_on_webpage: false
@@ -186,7 +186,7 @@ stellar_mass_stellar_veldisp_10:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Stellar Velocity Dispersion relation (10 kpc)
+    title: Stellar Mass-LOS Stellar Velocity Dispersion relation (10 kpc)
     caption: The 3D stellar velocity dispersion is converted into a LOS velocity dispersion using a $1/\sqrt{3}$ correction factor.
     section: Black Holes
     show_on_webpage: true

--- a/colibre/auto_plotter/black_holes.yml
+++ b/colibre/auto_plotter/black_holes.yml
@@ -122,7 +122,7 @@ stellar_veldisp_black_hole_mass_10:
       value: 1e3
       units: km/s
   metadata:
-    title: Stellar Velocity Dispersion-Black Hole Mass relation (10 kpc)
+    title: LOS Stellar Velocity Dispersion-Black Hole Mass relation (10 kpc)
     caption: The 3D stellar velocity dispersion is converted into a LOS velocity dispersion using a $1/\sqrt{3}$ correction factor. Note that the stellar velocity dispersion in observations is measured in a fixed 1 kpc aperture.
     section: Black Holes
   observational_data:

--- a/colibre/auto_plotter/black_holes.yml
+++ b/colibre/auto_plotter/black_holes.yml
@@ -101,7 +101,7 @@ stellar_veldisp_black_hole_mass_10:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.veldisp_star_10_kpc"
+    quantity: "derived_quantities.los_veldisp_star_10_kpc"
     units: km/s
     start: 1e1
     end: 1e3
@@ -123,7 +123,7 @@ stellar_veldisp_black_hole_mass_10:
       units: km/s
   metadata:
     title: Stellar Velocity Dispersion-Black Hole Mass relation (10 kpc)
-    caption: Note that the stellar velocity dispersion is measured in observations in a fixed 1 kpc aperture
+    caption: The 3D stellar velocity dispersion is converted into a LOS velocity dispersion using a $1/\sqrt{3}$ correction factor. Note that the stellar velocity dispersion in observations is measured in a fixed 1 kpc aperture.
     section: Black Holes
   observational_data:
     - filename: StellarVelocityDispersionBlackHoleMass/Sahu2019.hdf5
@@ -133,7 +133,7 @@ stellar_veldisp_black_hole_mass_30:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.veldisp_star_30_kpc"
+    quantity: "derived_quantities.los_veldisp_star_30_kpc"
     units: km/s
     start: 10
     end: 1e3
@@ -155,8 +155,38 @@ stellar_veldisp_black_hole_mass_30:
       units: km/s
   metadata:
     title: Stellar Velocity Dispersion-Black Hole Mass relation (30 kpc)
-    caption: Note that the stellar velocity dispersion is measured in observations in a fixed 1 kpc aperture
+    caption: The 3D stellar velocity dispersion is converted into a LOS velocity dispersion using a $1/\sqrt{3}$ correction factor. Note that the stellar velocity dispersion in observations is measured in a fixed 1 kpc aperture.
     section: Black Holes
     show_on_webpage: false
   observational_data:
     - filename: StellarVelocityDispersionBlackHoleMass/Sahu2019.hdf5
+
+stellar_mass_stellar_veldisp_10:
+  type: "scatter"
+  legend_loc: "upper left"
+  x:
+    quantity: "apertures.mass_star_10_kpc"
+    units: Solar_Mass
+    start: 1e7
+    end: 1e12
+  y:
+    quantity: "derived_quantities.los_veldisp_star_10_kpc"
+    units: km/s
+    start: 10
+    end: 1e3
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 10
+    start:
+      value: 1e7
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-Stellar Velocity Dispersion relation (10 kpc)
+    caption: The 3D stellar velocity dispersion is converted into a LOS velocity dispersion using a $1/\sqrt{3}$ correction factor.
+    section: Black Holes
+    show_on_webpage: true

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -22,6 +22,9 @@ This file calculates:
         apertures.
     + average of log of stellar birth densities (average_of_log_stellar_birth_density)
         velociraptor outputs the log of the quantity we need, so we take exp(...) of it
+    + LOS stellar velocity dispersions (10, 30 kpc) (los_veldisp_star_{x}_kpc)
+        The LOS velocity dispersion, obtained by multiplying the 3D velocity
+        dispersion with 1/sqrt(3).
 """
 
 # Define aperture size in kpc
@@ -762,6 +765,15 @@ def register_stellar_birth_densities(self, catalogue):
     return
 
 
+def register_los_star_veldisp(self, catalogue):
+    for aperture_size in [10, 30]:
+        veldisp = getattr(catalogue.apertures, f"veldisp_star_{aperture_size}_kpc")
+        los_veldisp = veldisp / np.sqrt(3.0)
+        setattr(self, f"los_veldisp_star_{aperture_size}_kpc", los_veldisp)
+
+    return
+
+
 # Register derived fields
 register_spesific_star_formation_rates(self, catalogue, aperture_sizes)
 register_star_metallicities(self, catalogue, aperture_sizes, solar_metal_mass_fraction)
@@ -778,3 +790,4 @@ register_dust_to_hi_ratio(self, catalogue, aperture_sizes)
 register_cold_gas_mass_ratios(self, catalogue, aperture_sizes)
 register_species_fractions(self, catalogue, aperture_sizes)
 register_stellar_birth_densities(self, catalogue)
+register_los_star_veldisp(self, catalogue)

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -769,6 +769,7 @@ def register_los_star_veldisp(self, catalogue):
     for aperture_size in [10, 30]:
         veldisp = getattr(catalogue.apertures, f"veldisp_star_{aperture_size}_kpc")
         los_veldisp = veldisp / np.sqrt(3.0)
+        los_veldisp.name = f"LOS stellar velocity dispersion ({aperture_size} kpc)"
         setattr(self, f"los_veldisp_star_{aperture_size}_kpc", los_veldisp)
 
     return


### PR DESCRIPTION
The stellar velocity dispersion output by VR is a 3D velocity dispersion. To compare this with observations, we should convert it to a LOS velocity dispersion, which can be done by multiplying with 1/sqrt(3).

The new LOS velocity dispersion shifts the simulation data in the Stellar Velocity Dispersion-Black Hole Mass relation, e.g.:
old plot:
![old_stellar_veldisp_black_hole_mass_10](https://user-images.githubusercontent.com/7336967/134644959-3734e162-946e-45c1-b975-b26e73043722.png)
new plot:
![new_stellar_veldisp_black_hole_mass_10](https://user-images.githubusercontent.com/7336967/134644974-fe49da7b-5155-4458-9a7d-85f1cbb2bae6.png)

A new Stellar Mass-Stellar Velocity Dispersion plot was added:
![new_stellar_mass_stellar_veldisp_10](https://user-images.githubusercontent.com/7336967/134645056-d05a61c5-dffd-4e36-a36b-c026c43c08c6.png)
In this plot, the new LOS velocity dispersion is used. Both the velocity dispersion and the mass are measured in the same 10 kpc aperture.
