### PR TITLE
Update captions in metallicity and gas-fraction plots

### DIFF
--- a/colibre-zooms/auto_plotter/gas_fraction_plots.yml
+++ b/colibre-zooms/auto_plotter/gas_fraction_plots.yml
@@ -27,7 +27,7 @@ h2_frac_func_stellar_mass_xgass_selection:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
     show_on_webpage: false
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
@@ -61,7 +61,7 @@ h2_frac_func_ssfr:
   metadata:
     title: sSFR-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_sSFR.hdf5
 
@@ -94,7 +94,7 @@ h2_frac_func_stellar_surface_density_xgass_selection:
   metadata:
     title: Stellar Mass Surface Density-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_mu_star.hdf5
 
@@ -225,7 +225,9 @@ h2_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy neutral gas mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
+Galaxies with Mstar > 10^10 Msun. If the H2 fraction is below 1.5%,
+set them to 1.5%.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
     - filename: GalaxyH2Fractions/Hunt2020_Data.hdf5

--- a/colibre-zooms/auto_plotter/gas_fraction_plots.yml
+++ b/colibre-zooms/auto_plotter/gas_fraction_plots.yml
@@ -27,7 +27,7 @@ h2_frac_func_stellar_mass_xgass_selection:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
     show_on_webpage: false
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
@@ -61,7 +61,7 @@ h2_frac_func_ssfr:
   metadata:
     title: sSFR-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_sSFR.hdf5
 
@@ -94,7 +94,7 @@ h2_frac_func_stellar_surface_density_xgass_selection:
   metadata:
     title: Stellar Mass Surface Density-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_mu_star.hdf5
 
@@ -127,7 +127,7 @@ hi_frac_func_stellar_mass_xgass_selection:
   metadata:
     title: Stellar Mass-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. 
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures.
     show_on_webpage: false
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_M_star.hdf5
@@ -225,9 +225,7 @@ h2_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
-Galaxies with Mstar > 10^10 Msun. If the H2 fraction is below 1.5%,
-set them to 1.5%.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
     - filename: GalaxyH2Fractions/Hunt2020_Data.hdf5

--- a/colibre-zooms/auto_plotter/metallicity.yml
+++ b/colibre-zooms/auto_plotter/metallicity.yml
@@ -534,9 +534,9 @@ stellar_mass_star_fe_over_h_mol_lofloor_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Star metallicity (Fe/H) relation (mean-of-log, 100 kpc aperture)"
+    title: 'Stellar mass - [Fe/H]$_*$ relation (mean-of-log, 100 kpc aperture)'
     section: Stellar Metallicity
-    caption: Computed as the mass-weighted average of log stellar metal mass fraction (displayed as [Fe/H]). The floor value is set to [Fe/H]=-4. All haloes are plotted, including subhaloes.
+    caption: 'Computed as the mass-weighted average of log [Fe/H]$_*$. The floor value is set to [Fe/H]=-4. All haloes are plotted, including subhaloes.'
   observational_data:
     - filename: GalaxyStellarMassStellarMetallicity/Gallazzi2005_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
@@ -567,9 +567,9 @@ stellar_mass_star_fe_over_h_mol_hifloor_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Star metallicity (Fe/H) relation (mean-of-log, 100 kpc aperture)"
+    title: 'Stellar mass - [Fe/H]$_*$ relation (mean-of-log, 100 kpc aperture)'
     section: Stellar Metallicity
-    caption: Computed as the mass-weighted average of log stellar metal mass fraction (displayed as [Fe/H]). The floor value is set to [Fe/H]=-3. All haloes are plotted, including subhaloes.
+    caption: 'Computed as the mass-weighted average of log [Fe/H]$_*$. The floor value is set to [Fe/H]=-3. All haloes are plotted, including subhaloes.'
   observational_data:
     - filename: GalaxyStellarMassStellarMetallicity/Gallazzi2005_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
@@ -600,9 +600,9 @@ stellar_mass_star_fe_over_h_lom_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Star metallicity (Fe/H) relation (100 kpc aperture)"
+    title: 'Stellar mass - [Fe/H]$_*$ relation (100 kpc aperture)'
     section: Stellar Metallicity
-    caption: Computed as the mass-weighted average of stellar metal mass fraction (displayed as [Fe/H]). All haloes are plotted, including subhaloes.
+    caption: 'Computed as the mass-weighted average of [Fe/H]$_*$. All haloes are plotted, including subhaloes.'
   observational_data:
     - filename: GalaxyStellarMassStellarMetallicity/Gallazzi2005_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5

--- a/colibre/auto_plotter/gas_fraction_plots.yml
+++ b/colibre/auto_plotter/gas_fraction_plots.yml
@@ -27,7 +27,7 @@ h2_frac_func_stellar_mass_xgass_selection:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
     show_on_webpage: false
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
@@ -61,7 +61,7 @@ h2_frac_func_ssfr:
   metadata:
     title: sSFR-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_sSFR.hdf5
 
@@ -94,7 +94,7 @@ h2_frac_func_stellar_surface_density_xgass_selection:
   metadata:
     title: Stellar Mass Surface Density-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_mu_star.hdf5
 
@@ -127,7 +127,7 @@ hi_frac_func_stellar_mass_xgass_selection:
   metadata:
     title: Stellar Mass-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. 
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures.
     show_on_webpage: false
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_M_star.hdf5
@@ -225,7 +225,7 @@ h2_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
     - filename: GalaxyH2Fractions/Hunt2020_Data.hdf5

--- a/colibre/auto_plotter/gas_fraction_plots.yml
+++ b/colibre/auto_plotter/gas_fraction_plots.yml
@@ -27,7 +27,7 @@ h2_frac_func_stellar_mass_xgass_selection:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
     show_on_webpage: false
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
@@ -61,7 +61,7 @@ h2_frac_func_ssfr:
   metadata:
     title: sSFR-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_sSFR.hdf5
 
@@ -94,7 +94,7 @@ h2_frac_func_stellar_surface_density_xgass_selection:
   metadata:
     title: Stellar Mass Surface Density-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_mu_star.hdf5
 
@@ -225,7 +225,7 @@ h2_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy neutral gas mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we muptilpy $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
     - filename: GalaxyH2Fractions/Hunt2020_Data.hdf5

--- a/colibre/auto_plotter/metallicity.yml
+++ b/colibre/auto_plotter/metallicity.yml
@@ -534,9 +534,9 @@ stellar_mass_star_fe_over_h_mol_lofloor_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Star metallicity (Fe/H) relation (mean-of-log, 100 kpc aperture)"
+    title: 'Stellar mass - [Fe/H]$_*$ relation (mean-of-log, 100 kpc aperture)'
     section: Stellar Metallicity
-    caption: Computed as the mass-weighted average of log stellar metal mass fraction (displayed as [Fe/H]). The floor value is set to [Fe/H]=-4. All haloes are plotted, including subhaloes.
+    caption: 'Computed as the mass-weighted average of log [Fe/H]$_*$. The floor value is set to [Fe/H]=-4. All haloes are plotted, including subhaloes.'
   observational_data:
     - filename: GalaxyStellarMassStellarMetallicity/Gallazzi2005_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
@@ -567,9 +567,9 @@ stellar_mass_star_fe_over_h_mol_hifloor_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Star metallicity (Fe/H) relation (mean-of-log, 100 kpc aperture)"
+    title: 'Stellar mass - [Fe/H]$_*$ relation (mean-of-log, 100 kpc aperture)'
     section: Stellar Metallicity
-    caption: Computed as the mass-weighted average of log stellar metal mass fraction (displayed as [Fe/H]). The floor value is set to [Fe/H]=-3. All haloes are plotted, including subhaloes.
+    caption: 'Computed as the mass-weighted average of log [Fe/H]$_*$. The floor value is set to [Fe/H]=-3. All haloes are plotted, including subhaloes.'
   observational_data:
     - filename: GalaxyStellarMassStellarMetallicity/Gallazzi2005_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
@@ -600,9 +600,9 @@ stellar_mass_star_fe_over_h_lom_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Star metallicity (Fe/H) relation (100 kpc aperture)"
+    title: 'Stellar mass - [Fe/H]$_*$ relation (100 kpc aperture)'
     section: Stellar Metallicity
-    caption: Computed as the mass-weighted average of stellar metal mass fraction (displayed as [Fe/H]). All haloes are plotted, including subhaloes.
+    caption: 'Computed as the mass-weighted average of [Fe/H]$_*$. All haloes are plotted, including subhaloes.'
   observational_data:
     - filename: GalaxyStellarMassStellarMetallicity/Gallazzi2005_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5


### PR DESCRIPTION
**Update captions in metallicity and gas-fraction plots**

- Indicate that [Fe/H]* are plotted rather than Z* shown as [Fe/H]*
- Indicate how the correction due to He is computed when H2 mass is plotted
- Indicate that Saintonge2017+ data has floor values for M_H2/Mstar

The above changes are present in both colibre and colibre/zoom