### PR TITLE
Better timesteps.txt reading

### DIFF
--- a/colibre-zooms/scripts/simulation_time_number_of_steps.py
+++ b/colibre-zooms/scripts/simulation_time_number_of_steps.py
@@ -42,10 +42,15 @@ for idx, (run_name, run_directory, snapshot_name) in enumerate(
         cosmology = snapshot.metadata.cosmology
 
     data = np.genfromtxt(
-        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
-    ).T
+        timesteps_filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(1),
+        dtype="f4",
+    )
 
-    sim_time = unyt.unyt_array(data[1], units=snapshot.units.time).to("Gyr")
+    sim_time = unyt.unyt_array(data, units=snapshot.units.time).to("Gyr")
 
     # Update the maximum cosmic time if needed
     if sim_time[-1] > t_max:

--- a/colibre/scripts/particle_updates_step_cost.py
+++ b/colibre/scripts/particle_updates_step_cost.py
@@ -9,7 +9,6 @@ import numpy as np
 from matplotlib.colors import LogNorm
 
 from swiftpipeline.argumentparser import ScriptArgumentParser
-from swiftsimio import load
 from glob import glob
 
 # Set the limits of the figure.
@@ -23,10 +22,17 @@ def get_data(filename):
     Grabs the data (number of updates, wallclock time in milliseconds).
     """
 
-    data = np.genfromtxt(filename, skip_footer=5, loose=True, invalid_raise=False).T
+    data = np.genfromtxt(
+        filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(7, 12),
+        dtype=[("updates", "i8"), ("wallclock", "f4")],
+    )
 
-    number_of_updates = unyt.unyt_array(data[7], units="dimensionless")
-    wallclock_time = unyt.unyt_array(data[-2], units="ms")
+    number_of_updates = unyt.unyt_array(data["updates"], units="dimensionless")
+    wallclock_time = unyt.unyt_array(data["wallclock"], units="ms")
 
     return number_of_updates, wallclock_time
 

--- a/colibre/scripts/simulation_time_number_of_steps.py
+++ b/colibre/scripts/simulation_time_number_of_steps.py
@@ -42,10 +42,15 @@ for idx, (run_name, run_directory, snapshot_name) in enumerate(
         cosmology = snapshot.metadata.cosmology
 
     data = np.genfromtxt(
-        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
-    ).T
+        timesteps_filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(1),
+        dtype="f4",
+    )
 
-    sim_time = unyt.unyt_array(data[1], units=snapshot.units.time).to("Gyr")
+    sim_time = unyt.unyt_array(data, units=snapshot.units.time).to("Gyr")
 
     # Update the maximum cosmic time if needed
     if sim_time[-1] > t_max:

--- a/colibre/scripts/wallclock_number_of_steps.py
+++ b/colibre/scripts/wallclock_number_of_steps.py
@@ -7,7 +7,6 @@ import unyt
 import matplotlib.pyplot as plt
 import numpy as np
 
-from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 
@@ -30,14 +29,17 @@ for run_name, run_directory, snapshot_name in zip(
 
     timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
     timesteps_filename = timesteps_glob[0]
-    snapshot_filename = f"{run_directory}/{snapshot_name}"
 
-    snapshot = load(snapshot_filename)
     data = np.genfromtxt(
-        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
-    ).T
+        timesteps_filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(12),
+        dtype="f4",
+    )
 
-    wallclock_time = unyt.unyt_array(np.cumsum(data[-2]), units="ms").to("Hour")
+    wallclock_time = unyt.unyt_array(np.cumsum(data), units="ms").to("Hour")
     number_of_steps = np.arange(wallclock_time.size) / 1e6
 
     # Simulation data plotting

--- a/colibre/scripts/wallclock_simulation_time.py
+++ b/colibre/scripts/wallclock_simulation_time.py
@@ -42,16 +42,23 @@ for idx, (run_name, run_directory, snapshot_name) in enumerate(
         cosmology = snapshot.metadata.cosmology
 
     data = np.genfromtxt(
-        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
-    ).T
+        timesteps_filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(1, 12),
+        dtype=[("time", "f4"), ("wallclock", "f4")],
+    )
 
-    sim_time = unyt.unyt_array(data[1], units=snapshot.units.time).to("Gyr")
+    sim_time = unyt.unyt_array(data["time"], units=snapshot.units.time).to("Gyr")
 
     # Update the maximum cosmic time if needed
     if sim_time[-1] > t_max:
         t_max = sim_time[-1]
 
-    wallclock_time = unyt.unyt_array(np.cumsum(data[-2]), units="ms").to("Hour")
+    wallclock_time = unyt.unyt_array(np.cumsum(data["wallclock"]), units="ms").to(
+        "Hour"
+    )
 
     # Simulation data plotting
     (mpl_line,) = ax.plot(wallclock_time, sim_time, label=run_name)

--- a/colibre/scripts/wallclock_timebin_hist.py
+++ b/colibre/scripts/wallclock_timebin_hist.py
@@ -7,7 +7,6 @@ import unyt
 import matplotlib.pyplot as plt
 import numpy as np
 
-from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 
@@ -30,15 +29,18 @@ for run_name, run_directory, snapshot_name in zip(
 
     timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
     timesteps_filename = timesteps_glob[0]
-    snapshot_filename = f"{run_directory}/{snapshot_name}"
 
-    snapshot = load(snapshot_filename)
     data = np.genfromtxt(
-        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
-    ).T
+        timesteps_filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(6, 12),
+        dtype=[("time_bin", "i1"), ("wallclock", "f4")],
+    )
 
-    time_bin_max = unyt.unyt_array(data[6], units="dimensionless")
-    wallclock_time = unyt.unyt_array(data[-2], units="ms").to("Hour")
+    time_bin_max = unyt.unyt_array(data["time_bin"], units="dimensionless")
+    wallclock_time = unyt.unyt_array(data["wallclock"], units="ms").to("Hour")
 
     time_bins = np.linspace(0, 57, 58)
     times = unyt.unyt_array(np.zeros(np.size(time_bins)), units="Hour")

--- a/eagle-xl/scripts/particle_updates_step_cost.py
+++ b/eagle-xl/scripts/particle_updates_step_cost.py
@@ -9,7 +9,6 @@ import numpy as np
 from matplotlib.colors import LogNorm
 
 from swiftpipeline.argumentparser import ScriptArgumentParser
-from swiftsimio import load
 from glob import glob
 
 # Set the limits of the figure.
@@ -23,10 +22,17 @@ def get_data(filename):
     Grabs the data (number of updates, wallclock time in milliseconds).
     """
 
-    data = np.genfromtxt(filename, skip_footer=5, loose=True, invalid_raise=False).T
+    data = np.genfromtxt(
+        filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(7, 12),
+        dtype=[("updates", "i8"), ("wallclock", "f4")],
+    )
 
-    number_of_updates = unyt.unyt_array(data[7], units="dimensionless")
-    wallclock_time = unyt.unyt_array(data[-2], units="ms")
+    number_of_updates = unyt.unyt_array(data["updates"], units="dimensionless")
+    wallclock_time = unyt.unyt_array(data["wallclock"], units="ms")
 
     return number_of_updates, wallclock_time
 

--- a/eagle-xl/scripts/simulation_time_number_of_steps.py
+++ b/eagle-xl/scripts/simulation_time_number_of_steps.py
@@ -42,10 +42,15 @@ for idx, (run_name, run_directory, snapshot_name) in enumerate(
         cosmology = snapshot.metadata.cosmology
 
     data = np.genfromtxt(
-        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
-    ).T
+        timesteps_filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(1),
+        dtype="f4",
+    )
 
-    sim_time = unyt.unyt_array(data[1], units=snapshot.units.time).to("Gyr")
+    sim_time = unyt.unyt_array(data, units=snapshot.units.time).to("Gyr")
 
     # Update the maximum cosmic time if needed
     if sim_time[-1] > t_max:

--- a/eagle-xl/scripts/wallclock_number_of_steps.py
+++ b/eagle-xl/scripts/wallclock_number_of_steps.py
@@ -7,7 +7,6 @@ import unyt
 import matplotlib.pyplot as plt
 import numpy as np
 
-from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 
@@ -30,14 +29,17 @@ for run_name, run_directory, snapshot_name in zip(
 
     timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
     timesteps_filename = timesteps_glob[0]
-    snapshot_filename = f"{run_directory}/{snapshot_name}"
 
-    snapshot = load(snapshot_filename)
     data = np.genfromtxt(
-        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
-    ).T
+        timesteps_filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(12),
+        dtype="f4",
+    )
 
-    wallclock_time = unyt.unyt_array(np.cumsum(data[-2]), units="ms").to("Hour")
+    wallclock_time = unyt.unyt_array(np.cumsum(data), units="ms").to("Hour")
     number_of_steps = np.arange(wallclock_time.size) / 1e6
 
     # Simulation data plotting

--- a/eagle-xl/scripts/wallclock_simulation_time.py
+++ b/eagle-xl/scripts/wallclock_simulation_time.py
@@ -34,11 +34,18 @@ for run_name, run_directory, snapshot_name in zip(
 
     snapshot = load(snapshot_filename)
     data = np.genfromtxt(
-        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
-    ).T
+        timesteps_filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(1, 12),
+        dtype=[("time", "f4"), ("wallclock", "f4")],
+    )
 
-    sim_time = unyt.unyt_array(data[1], units=snapshot.units.time).to("Gyr")
-    wallclock_time = unyt.unyt_array(np.cumsum(data[-2]), units="ms").to("Hour")
+    sim_time = unyt.unyt_array(data["time"], units=snapshot.units.time).to("Gyr")
+    wallclock_time = unyt.unyt_array(np.cumsum(data["wallclock"]), units="ms").to(
+        "Hour"
+    )
 
     # Simulation data plotting
     (mpl_line,) = ax.plot(wallclock_time, sim_time, label=run_name)

--- a/eagle-xl/scripts/wallclock_timebin_hist.py
+++ b/eagle-xl/scripts/wallclock_timebin_hist.py
@@ -7,7 +7,6 @@ import unyt
 import matplotlib.pyplot as plt
 import numpy as np
 
-from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 
@@ -30,15 +29,18 @@ for run_name, run_directory, snapshot_name in zip(
 
     timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
     timesteps_filename = timesteps_glob[0]
-    snapshot_filename = f"{run_directory}/{snapshot_name}"
 
-    snapshot = load(snapshot_filename)
     data = np.genfromtxt(
-        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
-    ).T
+        timesteps_filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(6, 12),
+        dtype=[("time_bin", "i1"), ("wallclock", "f4")],
+    )
 
-    time_bin_max = unyt.unyt_array(data[6], units="dimensionless")
-    wallclock_time = unyt.unyt_array(data[-2], units="ms").to("Hour")
+    time_bin_max = unyt.unyt_array(data["time_bin"], units="dimensionless")
+    wallclock_time = unyt.unyt_array(data["wallclock"], units="ms").to("Hour")
 
     time_bins = np.linspace(0, 57, 58)
     times = unyt.unyt_array(np.zeros(np.size(time_bins)), units="Hour")

--- a/flamingo/scripts/particle_updates_step_cost.py
+++ b/flamingo/scripts/particle_updates_step_cost.py
@@ -9,7 +9,6 @@ import numpy as np
 from matplotlib.colors import LogNorm
 
 from swiftpipeline.argumentparser import ScriptArgumentParser
-from swiftsimio import load
 from glob import glob
 
 # Set the limits of the figure.
@@ -23,10 +22,17 @@ def get_data(filename):
     Grabs the data (number of updates, wallclock time in milliseconds).
     """
 
-    data = np.genfromtxt(filename, skip_footer=5, loose=True, invalid_raise=False).T
+    data = np.genfromtxt(
+        filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(7, 12),
+        dtype=[("updates", "i8"), ("wallclock", "f4")],
+    )
 
-    number_of_updates = unyt.unyt_array(data[7], units="dimensionless")
-    wallclock_time = unyt.unyt_array(data[-2], units="ms")
+    number_of_updates = unyt.unyt_array(data["updates"], units="dimensionless")
+    wallclock_time = unyt.unyt_array(data["wallclock"], units="ms")
 
     return number_of_updates, wallclock_time
 

--- a/flamingo/scripts/simulation_time_number_of_steps.py
+++ b/flamingo/scripts/simulation_time_number_of_steps.py
@@ -42,10 +42,15 @@ for idx, (run_name, run_directory, snapshot_name) in enumerate(
         cosmology = snapshot.metadata.cosmology
 
     data = np.genfromtxt(
-        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
-    ).T
+        timesteps_filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(1),
+        dtype="f4",
+    )
 
-    sim_time = unyt.unyt_array(data[1], units=snapshot.units.time).to("Gyr")
+    sim_time = unyt.unyt_array(data, units=snapshot.units.time).to("Gyr")
 
     # Update the maximum cosmic time if needed
     if sim_time[-1] > t_max:

--- a/flamingo/scripts/wallclock_number_of_steps.py
+++ b/flamingo/scripts/wallclock_number_of_steps.py
@@ -7,7 +7,6 @@ import unyt
 import matplotlib.pyplot as plt
 import numpy as np
 
-from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 
@@ -30,14 +29,17 @@ for run_name, run_directory, snapshot_name in zip(
 
     timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
     timesteps_filename = timesteps_glob[0]
-    snapshot_filename = f"{run_directory}/{snapshot_name}"
 
-    snapshot = load(snapshot_filename)
     data = np.genfromtxt(
-        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
-    ).T
+        timesteps_filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(12),
+        dtype="f4",
+    )
 
-    wallclock_time = unyt.unyt_array(np.cumsum(data[-2]), units="ms").to("Hour")
+    wallclock_time = unyt.unyt_array(np.cumsum(data), units="ms").to("Hour")
     number_of_steps = np.arange(wallclock_time.size) / 1e6
 
     # Simulation data plotting

--- a/flamingo/scripts/wallclock_simulation_time.py
+++ b/flamingo/scripts/wallclock_simulation_time.py
@@ -34,11 +34,18 @@ for run_name, run_directory, snapshot_name in zip(
 
     snapshot = load(snapshot_filename)
     data = np.genfromtxt(
-        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
-    ).T
+        timesteps_filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(1, 12),
+        dtype=[("time", "f4"), ("wallclock", "f4")],
+    )
 
-    sim_time = unyt.unyt_array(data[1], units=snapshot.units.time).to("Gyr")
-    wallclock_time = unyt.unyt_array(np.cumsum(data[-2]), units="ms").to("Hour")
+    sim_time = unyt.unyt_array(data["time"], units=snapshot.units.time).to("Gyr")
+    wallclock_time = unyt.unyt_array(np.cumsum(data["wallclock"]), units="ms").to(
+        "Hour"
+    )
 
     # Simulation data plotting
     (mpl_line,) = ax.plot(wallclock_time, sim_time, label=run_name)

--- a/flamingo/scripts/wallclock_timebin_hist.py
+++ b/flamingo/scripts/wallclock_timebin_hist.py
@@ -7,7 +7,6 @@ import unyt
 import matplotlib.pyplot as plt
 import numpy as np
 
-from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 
@@ -30,15 +29,18 @@ for run_name, run_directory, snapshot_name in zip(
 
     timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
     timesteps_filename = timesteps_glob[0]
-    snapshot_filename = f"{run_directory}/{snapshot_name}"
 
-    snapshot = load(snapshot_filename)
     data = np.genfromtxt(
-        timesteps_filename, skip_footer=5, loose=True, invalid_raise=False
-    ).T
+        timesteps_filename,
+        skip_footer=5,
+        loose=True,
+        invalid_raise=False,
+        usecols=(6, 12),
+        dtype=[("time_bin", "i1"), ("wallclock", "f4")],
+    )
 
-    time_bin_max = unyt.unyt_array(data[6], units="dimensionless")
-    wallclock_time = unyt.unyt_array(data[-2], units="ms").to("Hour")
+    time_bin_max = unyt.unyt_array(data["time_bin"], units="dimensionless")
+    wallclock_time = unyt.unyt_array(data["wallclock"], units="ms").to("Hour")
 
     time_bins = np.linspace(0, 57, 58)
     times = unyt.unyt_array(np.zeros(np.size(time_bins)), units="Hour")


### PR DESCRIPTION
Since I plan to add another column to the timesteps.txt log file, I made sure scripts that read this file use proper column indices starting from 0 rather than using indices starting from the end that would change if you add a column. While doing so, I got rid of some unnecessary imports and snapshot reads (!) and added `usecols` and `dtype` parameters to the `genfromtxt` calls to avoid reading more than necessary and to have better type control.