### PR TITLE
Added dead time plots to run performance section.

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -198,6 +198,16 @@ scripts:
     title: Wall-clock time per time-bin
     section: Run Performance
     output_file: wallclock_timebin_hist.png
+  - filename: scripts/deadtime_timebin_hist.py
+    caption: Dead time fraction in each simulation time-bin.
+    title: Deadtime fraction per time-bin
+    section: Run Performance
+    output_file: deadtime_timebin_hist.png
+  - filename: scripts/stepsize_deadtime.py
+    caption: Dead time fraction as a function of number of updates per rank.
+    title: Step size vs deadtime fraction
+    section: Run Performance
+    output_file: stepsize_deadtime.png
   - filename: scripts/density_temperature_species.py
     caption: Density-temperature diagram shaded by H$_2$ mass fraction. The fraction is computed as the H$_2$ mass contained in each cell over the mass of gas in that cell.
     output_file: subgrid_density_temperature_H2.png

--- a/colibre/scripts/deadtime_timebin_hist.py
+++ b/colibre/scripts/deadtime_timebin_hist.py
@@ -1,0 +1,73 @@
+"""
+Plots dead time fraction v.s. time-bin
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftpipeline.argumentparser import ScriptArgumentParser
+from glob import glob
+
+arguments = ScriptArgumentParser(
+    description="Creates a run performance plot: deadtime fraction in each time-bin"
+)
+
+run_names = arguments.name_list
+run_directories = [f"{directory}" for directory in arguments.directory_list]
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+fig, ax = plt.subplots()
+
+for run_name, run_directory in zip(run_names, run_directories):
+
+    timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
+    timesteps_filename = timesteps_glob[0]
+
+    try:
+        data = np.genfromtxt(
+            timesteps_filename,
+            skip_footer=5,
+            loose=True,
+            invalid_raise=True,
+            usecols=(6, 12, 14),
+            dtype=[("time_bin", "i1"), ("wallclock", "f4"), ("deadtime", "f4")],
+        )
+    except:
+        ax.step([], [], label=f"{run_name} - no deadtime data")
+        continue
+
+    time_bin_max = data["time_bin"]
+    wallclock_time = data["wallclock"]
+    dead_time = data["deadtime"]
+
+    time_bins = np.linspace(0, 57, 58)
+    wallclock_times = np.zeros(time_bins.shape)
+    dead_times = np.zeros(time_bins.shape)
+    time_bin_max = time_bin_max[1:]
+    wallclock_time = wallclock_time[1:]
+    dead_time = dead_time[1:]
+
+    for i in range(np.size(time_bins)):
+        wallclock_times[i] = np.sum(wallclock_time[time_bin_max == time_bins[i]])
+        dead_times[i] = np.sum(dead_time[time_bin_max == time_bins[i]])
+
+    fractions = np.zeros(dead_times.shape)
+    fractions[wallclock_times > 0] = (
+        dead_times[wallclock_times > 0] / wallclock_times[wallclock_times > 0]
+    )
+
+    # Simulation data plotting
+    ax.step(time_bins + 0.5, fractions, zorder=10, label=run_name)
+
+ax.axvline(56, color="k", ls="--", lw=1)
+
+ax.set_xlim(28, 57)
+
+ax.legend(loc="upper left")
+
+ax.set_xlabel("Time-bin [-]")
+ax.set_ylabel("Deadtime fraction")
+
+fig.savefig(f"{output_path}/deadtime_timebin_hist.png")

--- a/colibre/scripts/stepsize_deadtime.py
+++ b/colibre/scripts/stepsize_deadtime.py
@@ -1,0 +1,96 @@
+"""
+Plots dead time fraction v.s. step size
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftpipeline.argumentparser import ScriptArgumentParser
+from glob import glob
+import re
+
+arguments = ScriptArgumentParser(
+    description="Creates a run performance plot: dead time fraction vs step size"
+)
+
+run_names = arguments.name_list
+run_directories = [f"{directory}" for directory in arguments.directory_list]
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+fig, ax = plt.subplots()
+
+color_index = 0
+for run_name, run_directory in zip(run_names, run_directories):
+
+    color = f"C{color_index}"
+    color_index += 1
+
+    timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
+    timesteps_filename = timesteps_glob[0]
+
+    # extract the number of ranks from the file
+    nrank = 1
+    with open(timesteps_filename, "r") as file:
+        header = file.readlines()[:10]
+        for line in header:
+            match = re.findall("Number of MPI ranks: (\d+)", line)
+            if len(match) > 0:
+                nrank = int(match[0])
+                break
+    try:
+        data = np.genfromtxt(
+            timesteps_filename,
+            skip_footer=5,
+            loose=True,
+            invalid_raise=True,
+            usecols=(8, 12, 13, 14),
+            dtype=[
+                ("updates", "i8"),
+                ("wallclock", "f4"),
+                ("properties", "i4"),
+                ("deadtime", "f4"),
+            ],
+        )
+    except:
+        ax.plot([], [], "-", color=color, label=f"{run_name} - no deadtime data")
+        continue
+
+    # filter out all steps where something special happened
+    data = data[data["properties"] == 0]
+
+    nupdates = data["updates"] / nrank
+    deadtime = data["deadtime"] / data["wallclock"]
+
+    # bin the data
+    nbins = 10.0 ** np.linspace(np.log10(nupdates.min()), np.log10(nupdates.max()), 51)
+    # make sure the highest values is inside the top bin
+    nbins[-1] += 0.0001 * (nbins[-1] - nbins[0])
+    means = np.zeros(50)
+    keep = np.array([], dtype=np.int32)
+    for ibin in range(50):
+        sel = np.nonzero((nupdates >= nbins[ibin]) & (nupdates < nbins[ibin + 1]))[0]
+        # do not bin values if there are less than 5 in the bin
+        if sel.shape[0] < 5:
+            means[ibin] = np.nan
+            keep = np.append(keep, sel)
+        else:
+            means[ibin] = np.mean(deadtime[sel])
+
+    nbins = 0.5 * (nbins[1:] + nbins[:-1])
+
+    # Simulation data plotting
+    # first plot the values that were not part of any bin
+    ax.semilogx(nupdates[keep], deadtime[keep], ".", color=color)
+    # now add the binned values
+    ax.semilogx(nbins, means, "-", color=color, label=f"{run_name} [{nrank} ranks]")
+
+ax.legend(loc="upper left")
+
+ax.set_xlim(1.0e-3, 1e9)
+ax.set_ylim(0.0, 1.0)
+ax.set_xlabel("Number of updates per rank")
+ax.set_ylabel("Deadtime fraction")
+
+fig.savefig(f"{output_path}/stepsize_deadtime.png")

--- a/eagle-xl/config.yml
+++ b/eagle-xl/config.yml
@@ -166,4 +166,13 @@ scripts:
     title: Wall-clock time per time-bin
     section: Run Performance
     output_file: wallclock_timebin_hist.png
-
+  - filename: scripts/deadtime_timebin_hist.py
+    caption: Dead time fraction in each simulation time-bin.
+    title: Deadtime fraction per time-bin
+    section: Run Performance
+    output_file: deadtime_timebin_hist.png
+  - filename: scripts/stepsize_deadtime.py
+    caption: Dead time fraction as a function of number of updates per rank.
+    title: Step size vs deadtime fraction
+    section: Run Performance
+    output_file: stepsize_deadtime.png

--- a/eagle-xl/scripts/deadtime_timebin_hist.py
+++ b/eagle-xl/scripts/deadtime_timebin_hist.py
@@ -1,0 +1,73 @@
+"""
+Plots dead time fraction v.s. time-bin
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftpipeline.argumentparser import ScriptArgumentParser
+from glob import glob
+
+arguments = ScriptArgumentParser(
+    description="Creates a run performance plot: deadtime fraction in each time-bin"
+)
+
+run_names = arguments.name_list
+run_directories = [f"{directory}" for directory in arguments.directory_list]
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+fig, ax = plt.subplots()
+
+for run_name, run_directory in zip(run_names, run_directories):
+
+    timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
+    timesteps_filename = timesteps_glob[0]
+
+    try:
+        data = np.genfromtxt(
+            timesteps_filename,
+            skip_footer=5,
+            loose=True,
+            invalid_raise=True,
+            usecols=(6, 12, 14),
+            dtype=[("time_bin", "i1"), ("wallclock", "f4"), ("deadtime", "f4")],
+        )
+    except:
+        ax.step([], [], label=f"{run_name} - no deadtime data")
+        continue
+
+    time_bin_max = data["time_bin"]
+    wallclock_time = data["wallclock"]
+    dead_time = data["deadtime"]
+
+    time_bins = np.linspace(0, 57, 58)
+    wallclock_times = np.zeros(time_bins.shape)
+    dead_times = np.zeros(time_bins.shape)
+    time_bin_max = time_bin_max[1:]
+    wallclock_time = wallclock_time[1:]
+    dead_time = dead_time[1:]
+
+    for i in range(np.size(time_bins)):
+        wallclock_times[i] = np.sum(wallclock_time[time_bin_max == time_bins[i]])
+        dead_times[i] = np.sum(dead_time[time_bin_max == time_bins[i]])
+
+    fractions = np.zeros(dead_times.shape)
+    fractions[wallclock_times > 0] = (
+        dead_times[wallclock_times > 0] / wallclock_times[wallclock_times > 0]
+    )
+
+    # Simulation data plotting
+    ax.step(time_bins + 0.5, fractions, zorder=10, label=run_name)
+
+ax.axvline(56, color="k", ls="--", lw=1)
+
+ax.set_xlim(28, 57)
+
+ax.legend(loc="upper left")
+
+ax.set_xlabel("Time-bin [-]")
+ax.set_ylabel("Deadtime fraction")
+
+fig.savefig(f"{output_path}/deadtime_timebin_hist.png")

--- a/eagle-xl/scripts/stepsize_deadtime.py
+++ b/eagle-xl/scripts/stepsize_deadtime.py
@@ -1,0 +1,96 @@
+"""
+Plots dead time fraction v.s. step size
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftpipeline.argumentparser import ScriptArgumentParser
+from glob import glob
+import re
+
+arguments = ScriptArgumentParser(
+    description="Creates a run performance plot: dead time fraction vs step size"
+)
+
+run_names = arguments.name_list
+run_directories = [f"{directory}" for directory in arguments.directory_list]
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+fig, ax = plt.subplots()
+
+color_index = 0
+for run_name, run_directory in zip(run_names, run_directories):
+
+    color = f"C{color_index}"
+    color_index += 1
+
+    timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
+    timesteps_filename = timesteps_glob[0]
+
+    # extract the number of ranks from the file
+    nrank = 1
+    with open(timesteps_filename, "r") as file:
+        header = file.readlines()[:10]
+        for line in header:
+            match = re.findall("Number of MPI ranks: (\d+)", line)
+            if len(match) > 0:
+                nrank = int(match[0])
+                break
+    try:
+        data = np.genfromtxt(
+            timesteps_filename,
+            skip_footer=5,
+            loose=True,
+            invalid_raise=True,
+            usecols=(8, 12, 13, 14),
+            dtype=[
+                ("updates", "i8"),
+                ("wallclock", "f4"),
+                ("properties", "i4"),
+                ("deadtime", "f4"),
+            ],
+        )
+    except:
+        ax.plot([], [], "-", color=color, label=f"{run_name} - no deadtime data")
+        continue
+
+    # filter out all steps where something special happened
+    data = data[data["properties"] == 0]
+
+    nupdates = data["updates"] / nrank
+    deadtime = data["deadtime"] / data["wallclock"]
+
+    # bin the data
+    nbins = 10.0 ** np.linspace(np.log10(nupdates.min()), np.log10(nupdates.max()), 51)
+    # make sure the highest values is inside the top bin
+    nbins[-1] += 0.0001 * (nbins[-1] - nbins[0])
+    means = np.zeros(50)
+    keep = np.array([], dtype=np.int32)
+    for ibin in range(50):
+        sel = np.nonzero((nupdates >= nbins[ibin]) & (nupdates < nbins[ibin + 1]))[0]
+        # do not bin values if there are less than 5 in the bin
+        if sel.shape[0] < 5:
+            means[ibin] = np.nan
+            keep = np.append(keep, sel)
+        else:
+            means[ibin] = np.mean(deadtime[sel])
+
+    nbins = 0.5 * (nbins[1:] + nbins[:-1])
+
+    # Simulation data plotting
+    # first plot the values that were not part of any bin
+    ax.semilogx(nupdates[keep], deadtime[keep], ".", color=color)
+    # now add the binned values
+    ax.semilogx(nbins, means, "-", color=color, label=f"{run_name} [{nrank} ranks]")
+
+ax.legend(loc="upper left")
+
+ax.set_xlim(1.0e-3, 1e9)
+ax.set_ylim(0.0, 1.0)
+ax.set_xlabel("Number of updates per rank")
+ax.set_ylabel("Deadtime fraction")
+
+fig.savefig(f"{output_path}/stepsize_deadtime.png")

--- a/flamingo/config.yml
+++ b/flamingo/config.yml
@@ -151,4 +151,13 @@ scripts:
     title: Wall-clock time per time-bin
     section: Run Performance
     output_file: wallclock_timebin_hist.png
-
+  - filename: scripts/deadtime_timebin_hist.py
+    caption: Dead time fraction in each simulation time-bin.
+    title: Deadtime fraction per time-bin
+    section: Run Performance
+    output_file: deadtime_timebin_hist.png
+  - filename: scripts/stepsize_deadtime.py
+    caption: Dead time fraction as a function of number of updates per rank.
+    title: Step size vs deadtime fraction
+    section: Run Performance
+    output_file: stepsize_deadtime.png

--- a/flamingo/scripts/deadtime_timebin_hist.py
+++ b/flamingo/scripts/deadtime_timebin_hist.py
@@ -1,0 +1,73 @@
+"""
+Plots dead time fraction v.s. time-bin
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftpipeline.argumentparser import ScriptArgumentParser
+from glob import glob
+
+arguments = ScriptArgumentParser(
+    description="Creates a run performance plot: deadtime fraction in each time-bin"
+)
+
+run_names = arguments.name_list
+run_directories = [f"{directory}" for directory in arguments.directory_list]
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+fig, ax = plt.subplots()
+
+for run_name, run_directory in zip(run_names, run_directories):
+
+    timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
+    timesteps_filename = timesteps_glob[0]
+
+    try:
+        data = np.genfromtxt(
+            timesteps_filename,
+            skip_footer=5,
+            loose=True,
+            invalid_raise=True,
+            usecols=(6, 12, 14),
+            dtype=[("time_bin", "i1"), ("wallclock", "f4"), ("deadtime", "f4")],
+        )
+    except:
+        ax.step([], [], label=f"{run_name} - no deadtime data")
+        continue
+
+    time_bin_max = data["time_bin"]
+    wallclock_time = data["wallclock"]
+    dead_time = data["deadtime"]
+
+    time_bins = np.linspace(0, 57, 58)
+    wallclock_times = np.zeros(time_bins.shape)
+    dead_times = np.zeros(time_bins.shape)
+    time_bin_max = time_bin_max[1:]
+    wallclock_time = wallclock_time[1:]
+    dead_time = dead_time[1:]
+
+    for i in range(np.size(time_bins)):
+        wallclock_times[i] = np.sum(wallclock_time[time_bin_max == time_bins[i]])
+        dead_times[i] = np.sum(dead_time[time_bin_max == time_bins[i]])
+
+    fractions = np.zeros(dead_times.shape)
+    fractions[wallclock_times > 0] = (
+        dead_times[wallclock_times > 0] / wallclock_times[wallclock_times > 0]
+    )
+
+    # Simulation data plotting
+    ax.step(time_bins + 0.5, fractions, zorder=10, label=run_name)
+
+ax.axvline(56, color="k", ls="--", lw=1)
+
+ax.set_xlim(28, 57)
+
+ax.legend(loc="upper left")
+
+ax.set_xlabel("Time-bin [-]")
+ax.set_ylabel("Deadtime fraction")
+
+fig.savefig(f"{output_path}/deadtime_timebin_hist.png")

--- a/flamingo/scripts/stepsize_deadtime.py
+++ b/flamingo/scripts/stepsize_deadtime.py
@@ -1,0 +1,96 @@
+"""
+Plots dead time fraction v.s. step size
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftpipeline.argumentparser import ScriptArgumentParser
+from glob import glob
+import re
+
+arguments = ScriptArgumentParser(
+    description="Creates a run performance plot: dead time fraction vs step size"
+)
+
+run_names = arguments.name_list
+run_directories = [f"{directory}" for directory in arguments.directory_list]
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+fig, ax = plt.subplots()
+
+color_index = 0
+for run_name, run_directory in zip(run_names, run_directories):
+
+    color = f"C{color_index}"
+    color_index += 1
+
+    timesteps_glob = glob(f"{run_directory}/timesteps_*.txt")
+    timesteps_filename = timesteps_glob[0]
+
+    # extract the number of ranks from the file
+    nrank = 1
+    with open(timesteps_filename, "r") as file:
+        header = file.readlines()[:10]
+        for line in header:
+            match = re.findall("Number of MPI ranks: (\d+)", line)
+            if len(match) > 0:
+                nrank = int(match[0])
+                break
+    try:
+        data = np.genfromtxt(
+            timesteps_filename,
+            skip_footer=5,
+            loose=True,
+            invalid_raise=True,
+            usecols=(8, 12, 13, 14),
+            dtype=[
+                ("updates", "i8"),
+                ("wallclock", "f4"),
+                ("properties", "i4"),
+                ("deadtime", "f4"),
+            ],
+        )
+    except:
+        ax.plot([], [], "-", color=color, label=f"{run_name} - no deadtime data")
+        continue
+
+    # filter out all steps where something special happened
+    data = data[data["properties"] == 0]
+
+    nupdates = data["updates"] / nrank
+    deadtime = data["deadtime"] / data["wallclock"]
+
+    # bin the data
+    nbins = 10.0 ** np.linspace(np.log10(nupdates.min()), np.log10(nupdates.max()), 51)
+    # make sure the highest values is inside the top bin
+    nbins[-1] += 0.0001 * (nbins[-1] - nbins[0])
+    means = np.zeros(50)
+    keep = np.array([], dtype=np.int32)
+    for ibin in range(50):
+        sel = np.nonzero((nupdates >= nbins[ibin]) & (nupdates < nbins[ibin + 1]))[0]
+        # do not bin values if there are less than 5 in the bin
+        if sel.shape[0] < 5:
+            means[ibin] = np.nan
+            keep = np.append(keep, sel)
+        else:
+            means[ibin] = np.mean(deadtime[sel])
+
+    nbins = 0.5 * (nbins[1:] + nbins[:-1])
+
+    # Simulation data plotting
+    # first plot the values that were not part of any bin
+    ax.semilogx(nupdates[keep], deadtime[keep], ".", color=color)
+    # now add the binned values
+    ax.semilogx(nbins, means, "-", color=color, label=f"{run_name} [{nrank} ranks]")
+
+ax.legend(loc="upper left")
+
+ax.set_xlim(1.0e-3, 1e9)
+ax.set_ylim(0.0, 1.0)
+ax.set_xlabel("Number of updates per rank")
+ax.set_ylabel("Deadtime fraction")
+
+fig.savefig(f"{output_path}/stepsize_deadtime.png")


### PR DESCRIPTION
Recent versions of SWIFT output an additional column in timesteps.txt that quantifies the dead time during every step. This pull request adds two plots to the run performance section of the pipeline that use this information.

The first plot is a dead time fraction per time-bin plot:
![deadtime_timebin_hist](https://user-images.githubusercontent.com/7336967/142643013-0a080e90-c43a-44b8-a800-75587c199ded.png)

The second one is a dead time fraction per number of updates in the step plot:
![DMO_stepsize_deadtime](https://user-images.githubusercontent.com/7336967/142643151-90feba01-c705-41f5-90bb-bf0e98598e8e.png)

In the second plot, only steps where nothing special happens (e.g. a rebuild, snapshot output...) are included, which explains the apparent discrepancy between the two plots.

The scripts detect when an old timesteps.txt file is used that does not have the extra column, and simply add an empty line to the plot with an additional message in the label warning about the missing data.