### PR TITLE
Copy baryon fraction plots from Flamingo to Colibre

### DIFF
--- a/colibre-zooms/auto_plotter/baryon_fractions.yml
+++ b/colibre-zooms/auto_plotter/baryon_fractions.yml
@@ -1,0 +1,134 @@
+baryon_fraction_500:
+  type: "2dhistogram"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "spherical_overdensities.mass_500_rhocrit"
+    units: Solar_Mass
+    start: 1e12
+    end: 1e15
+  y:
+    quantity: "derived_quantities.baryon_fraction_true_R500"
+    units:  "dimensionless"
+    log: false
+    start: 0.
+    end: 1.2
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 1e12
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: "Halo baryon fractions within $R_{500}$"
+    caption: Baryon (gas + stars) fractions within $R_{500}$ normalised by the cosmic mean. These are 'true' values, i.e. no cut or observational correction was applied.
+    section: Baryon Fractions
+
+gas_fraction_500:
+  type: "2dhistogram"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "spherical_overdensities.mass_500_rhocrit"
+    units: Solar_Mass
+    start: 1e12
+    end: 1e15
+  y:
+    quantity: "derived_quantities.gas_fraction_true_R500"
+    units:  "dimensionless"
+    log: false
+    start: 0.
+    end: 1.2
+  median:
+    plot: true
+    log: true
+    min_num_points_highlight: 0
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 1e12
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: "Halo gas fractions within $R_{500}$"
+    caption: Gas fractions within $R_{500}$ normalised by the cosmic mean. These are 'true' values, i.e. no cut or observational correction was applied.
+    section: Baryon Fractions
+  observational_data:
+    - filename: HaloMassGasFractions/Lin2012.hdf5
+    - filename: HaloMassGasFractions/Sun2009.hdf5
+    - filename: HaloMassGasFractions/Vikhlinin2006.hdf5
+    - filename: HaloMassGasFractions/Eckert2016.hdf5
+    - filename: HaloMassGasFractions/Lovisari2015.hdf5
+
+star_fraction_500:
+  type: "2dhistogram"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "spherical_overdensities.mass_500_rhocrit"
+    units: Solar_Mass
+    start: 1e12
+    end: 1e15
+  y:
+    quantity: "derived_quantities.star_fraction_true_R500"
+    units:  "dimensionless"
+    log: false
+    start: 0.
+    end: 1.2
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 1e13
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: "Halo stellar fractions within $R_{500}$"
+    caption: Stellar fractions within $R_{500}$ normalised by the cosmic mean. These are 'true' values, i.e. no cut or observational correction was applied.
+    section: Baryon Fractions
+
+
+gas_mass_500:
+  type: "2dhistogram"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "spherical_overdensities.mass_500_rhocrit"
+    units: Solar_Mass
+    start: 1e13
+    end: 1e15
+  y:
+    quantity: "spherical_overdensities.mass_gas_500_rhocrit"
+    units: Solar_Mass
+    start: 3e9
+    end: 5e14
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 1e12
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: "Halo gas masses within $R_{500}$"
+    caption: Gas masses within $R_{500}$. These are 'true' values, i.e. no cut or observational correction was applied.
+    section: Baryon Fractions

--- a/colibre-zooms/auto_plotter/stellar_mass_halo_mass.yml
+++ b/colibre-zooms/auto_plotter/stellar_mass_halo_mass.yml
@@ -7,7 +7,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_100:
     quantity: "masses.mass_200crit"
     units: Solar_Mass
     start: 1e8
-    end: 1e13
+    end: 1e15
   y:
     quantity: "derived_quantities.stellar_mass_to_halo_mass_200crit_100_kpc"
     units: "dimensionless"
@@ -17,12 +17,12 @@ stellar_mass_halo_mass_M200_centrals_ratio_100:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 30
+    number_of_bins: 40
     start:
       value: 1e8
       units: Solar_Mass
     end:
-      value: 1e13
+      value: 1e15
       units: Solar_Mass
   metadata:
     title: Stellar Mass-Halo Mass relation (ratio, 100 kpc aperture, $M_{200,crit}$, centrals only)
@@ -42,7 +42,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_100:
     quantity: "masses.mass_bn98"
     units: Solar_Mass
     start: 1e8
-    end: 1e13
+    end: 1e15
   y:
     quantity: "derived_quantities.stellar_mass_to_halo_mass_bn98_100_kpc"
     units: "dimensionless"
@@ -52,15 +52,85 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_100:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 30
+    number_of_bins: 40
     start:
       value: 1e8
       units: Solar_Mass
     end:
-      value: 1e13
+      value: 1e15
       units: Solar_Mass
   metadata:
     title: Stellar Mass-Halo Mass relation (ratio, 100 kpc aperture, $M_{\rm BN98}$, centrals only)
+    caption: Includes only central haloes.
+    section: Stellar Mass-Halo Mass
+  observational_data:
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_Ratio.hdf5
+
+stellar_mass_halo_mass_MBN98_centrals_ratio_50:
+  type: "scatter"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "masses.mass_bn98"
+    units: Solar_Mass
+    start: 1e8
+    end: 1e15
+  y:
+    quantity: "derived_quantities.stellar_mass_to_halo_mass_bn98_50_kpc"
+    units: "dimensionless"
+    start: 1e-4
+    end: 1e-1
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 40
+    start:
+      value: 1e8
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-Halo Mass relation (ratio, 50 kpc aperture, $M_{\rm BN98}$, centrals only)
+    caption: Includes only central haloes.
+    section: Stellar Mass-Halo Mass
+  observational_data:
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_Ratio.hdf5
+
+stellar_mass_halo_mass_MBN98_centrals_ratio_30:
+  type: "scatter"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "masses.mass_bn98"
+    units: Solar_Mass
+    start: 1e8
+    end: 1e15
+  y:
+    quantity: "derived_quantities.stellar_mass_to_halo_mass_bn98_30_kpc"
+    units: "dimensionless"
+    start: 1e-4
+    end: 1e-1
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 40
+    start:
+      value: 1e8
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-Halo Mass relation (ratio, 30 kpc aperture, $M_{\rm BN98}$, centrals only)
     caption: Includes only central haloes.
     section: Stellar Mass-Halo Mass
   observational_data:
@@ -138,6 +208,76 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
     - filename: GalaxyStellarMassHaloMass/Moster2018RatioStellar.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_RatioStellar.hdf5
 
+stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_50:
+  type: "scatter"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 9e3
+    end: 1e12
+  y:
+    quantity: "derived_quantities.stellar_mass_to_halo_mass_bn98_50_kpc"
+    units: "dimensionless"
+    start: 1e-4
+    end: 1e-1
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 9e3
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-Halo Mass relation (ratio, 50 kpc aperture, $M_{\rm BN98}$, centrals only, stellar x-axis)
+    caption: Includes only central haloes.
+    section: Stellar Mass-Halo Mass
+  observational_data:
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_RatioStellar.hdf5
+
+stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_30:
+  type: "scatter"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "apertures.mass_star_30_kpc"
+    units: Solar_Mass
+    start: 9e3
+    end: 1e12
+  y:
+    quantity: "derived_quantities.stellar_mass_to_halo_mass_bn98_30_kpc"
+    units: "dimensionless"
+    start: 1e-4
+    end: 1e-1
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 9e3
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-Halo Mass relation (ratio, 30 kpc aperture, $M_{\rm BN98}$, centrals only, stellar x-axis)
+    caption: Includes only central haloes.
+    section: Stellar Mass-Halo Mass
+  observational_data:
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_RatioStellar.hdf5
+
 stellar_mass_halo_mass_M200_all_100:
   type: "scatter"
   legend_loc: "upper left"
@@ -145,7 +285,7 @@ stellar_mass_halo_mass_M200_all_100:
     quantity: "masses.mass_200crit"
     units: Solar_Mass
     start: 9e3
-    end: 1e13
+    end: 1e15
   y:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
@@ -155,12 +295,12 @@ stellar_mass_halo_mass_M200_all_100:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 25
+    number_of_bins: 40
     start:
       value: 9e3
       units: Solar_Mass
     end:
-      value: 1e13
+      value: 1e15
       units: Solar_Mass
   metadata:
     title: Stellar Mass-Halo Mass relation (100 kpc aperture, $M_{200,crit}$)
@@ -178,7 +318,7 @@ stellar_mass_halo_mass_MBN98_all_100:
     quantity: "masses.mass_bn98"
     units: Solar_Mass
     start: 9e3
-    end: 1e13
+    end: 1e15
   y:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
@@ -188,12 +328,12 @@ stellar_mass_halo_mass_MBN98_all_100:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 25
+    number_of_bins: 40
     start:
       value: 9e3
       units: Solar_Mass
     end:
-      value: 1e13
+      value: 1e15
       units: Solar_Mass
   metadata:
     title: Stellar Mass-Halo Mass relation (100 kpc aperture, $M_{\rm BN98}$)

--- a/colibre-zooms/registration.py
+++ b/colibre-zooms/registration.py
@@ -28,7 +28,8 @@ This file calculates:
 """
 
 # Define aperture size in kpc
-aperture_sizes = [30, 100]
+aperture_sizes_30_100_kpc = {30, 100}
+aperture_sizes_30_50_100_kpc = {30, 50, 100}
 
 # Solar metal mass fraction used in Plöckinger S. & Schaye J. (2020)
 solar_metal_mass_fraction = 0.0134
@@ -844,6 +845,35 @@ def register_stellar_birth_densities(self, catalogue):
     return
 
 
+def register_gas_fraction(self, catalogue):
+
+    Omega_m = catalogue.units.cosmology.Om0
+    Omega_b = catalogue.units.cosmology.Ob0
+
+    M_500 = catalogue.spherical_overdensities.mass_500_rhocrit
+    M_500_gas = catalogue.spherical_overdensities.mass_gas_500_rhocrit
+    M_500_star = catalogue.spherical_overdensities.mass_star_500_rhocrit
+    M_500_baryon = M_500_gas + M_500_star
+
+    f_b_500 = (M_500_baryon / M_500) / (Omega_b / Omega_m)
+    name = "$f_{\\rm b, 500, true} / (\\Omega_{\\rm b} / \\Omega_{\\rm m})$"
+    f_b_500.name = name
+
+    f_gas_500 = (M_500_gas / M_500) / (Omega_b / Omega_m)
+    name = "$f_{\\rm gas, 500, true} / (\\Omega_{\\rm b} / \\Omega_{\\rm m})$"
+    f_gas_500.name = name
+
+    f_star_500 = (M_500_star / M_500) / (Omega_b / Omega_m)
+    name = "$f_{\\rm star, 500, true} / (\\Omega_{\\rm b} / \\Omega_{\\rm m})$"
+    f_star_500.name = name
+
+    setattr(self, "baryon_fraction_true_R500", f_b_500)
+    setattr(self, "gas_fraction_true_R500", f_gas_500)
+    setattr(self, "star_fraction_true_R500", f_star_500)
+
+    return
+
+
 def register_los_star_veldisp(self, catalogue):
     for aperture_size in [10, 30]:
         veldisp = getattr(catalogue.apertures, f"veldisp_star_{aperture_size}_kpc")
@@ -855,21 +885,30 @@ def register_los_star_veldisp(self, catalogue):
 
 
 # Register derived fields
-register_spesific_star_formation_rates(self, catalogue, aperture_sizes)
-register_star_metallicities(self, catalogue, aperture_sizes, solar_metal_mass_fraction)
-register_stellar_to_halo_mass_ratios(self, catalogue, aperture_sizes)
-register_dust(self, catalogue, aperture_sizes)
-register_oxygen_to_hydrogen(self, catalogue, aperture_sizes)
-register_cold_dense_gas_metallicity(
-    self, catalogue, aperture_sizes, solar_metal_mass_fraction, twelve_plus_log_OH_solar
+register_spesific_star_formation_rates(self, catalogue, aperture_sizes_30_100_kpc)
+register_star_metallicities(
+    self, catalogue, aperture_sizes_30_100_kpc, solar_metal_mass_fraction
 )
-register_iron_to_hydrogen(self, catalogue, aperture_sizes, solar_fe_abundance)
-register_hi_masses(self, catalogue, aperture_sizes)
-register_h2_masses(self, catalogue, aperture_sizes)
-register_dust_to_hi_ratio(self, catalogue, aperture_sizes)
-register_cold_gas_mass_ratios(self, catalogue, aperture_sizes)
-register_species_fractions(self, catalogue, aperture_sizes)
+register_stellar_to_halo_mass_ratios(self, catalogue, aperture_sizes_30_50_100_kpc)
+register_dust(self, catalogue, aperture_sizes_30_100_kpc)
+register_oxygen_to_hydrogen(self, catalogue, aperture_sizes_30_100_kpc)
+register_cold_dense_gas_metallicity(
+    self,
+    catalogue,
+    aperture_sizes_30_100_kpc,
+    solar_metal_mass_fraction,
+    twelve_plus_log_OH_solar,
+)
+register_iron_to_hydrogen(
+    self, catalogue, aperture_sizes_30_100_kpc, solar_fe_abundance
+)
+register_hi_masses(self, catalogue, aperture_sizes_30_100_kpc)
+register_h2_masses(self, catalogue, aperture_sizes_30_100_kpc)
+register_dust_to_hi_ratio(self, catalogue, aperture_sizes_30_100_kpc)
+register_cold_gas_mass_ratios(self, catalogue, aperture_sizes_30_100_kpc)
+register_species_fractions(self, catalogue, aperture_sizes_30_100_kpc)
 register_stellar_birth_densities(self, catalogue)
 register_global_mask(self, catalogue)
 register_los_star_veldisp(self, catalogue)
-register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes)
+register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes_30_100_kpc)
+register_gas_fraction(self, catalogue)

--- a/colibre-zooms/scripts/birth_density_distribution.py
+++ b/colibre-zooms/scripts/birth_density_distribution.py
@@ -86,7 +86,7 @@ data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
 number_of_bins = 256
 
 birth_density_bins = unyt.unyt_array(
-    np.logspace(-2, 6.5, number_of_bins), units="1/cm**3"
+    np.logspace(-2, 7, number_of_bins), units="1/cm**3"
 )
 log_birth_density_bin_width = np.log10(birth_density_bins[1].value) - np.log10(
     birth_density_bins[0].value
@@ -134,25 +134,17 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         T_K=SNII_heating_temperature, M_gas=M_gas.value, N_ngb=N_ngb_target, X_H=X_H
     )
 
+    # Total number of stars formed
+    Num_of_stars_total = len(birth_redshifts)
+
     for redshift, ax in ax_dict.items():
         data = birth_densities_by_redshift[redshift]
 
         H, _ = np.histogram(data, bins=birth_density_bins)
-
-        # Total number of stars formed
-        Num_of_obj = np.sum(H)
-
-        # Check to avoid division by zero
-        if Num_of_obj:
-            y_points = H / log_birth_density_bin_width / Num_of_obj
-        else:
-            y_points = np.zeros_like(H)
+        y_points = H / log_birth_density_bin_width / Num_of_stars_total
 
         ax.plot(
-            birth_density_centers,
-            y_points,
-            label=name,
-            color=f"C{color}",
+            birth_density_centers, y_points, label=name, color=f"C{color}",
         )
 
         # Add the median stellar birth-density line
@@ -166,11 +158,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
 
         # Add the DV&S2012 line
         ax.axvline(
-            n_crit,
-            color=f"C{color}",
-            linestyle="dotted",
-            zorder=-10,
-            alpha=0.5,
+            n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5,
         )
 
 axes[0].legend(loc="upper right", markerfirst=False)

--- a/colibre-zooms/scripts/birth_density_metallicity.py
+++ b/colibre-zooms/scripts/birth_density_metallicity.py
@@ -11,7 +11,7 @@ from unyt import mh
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-density_bounds = [0.01, 10 ** 6.5]  # in nh/cm^3
+density_bounds = [0.01, 10 ** 7.0]  # in nh/cm^3
 metal_mass_fraction_bounds = [1e-4, 0.5]  # dimensionless
 bins = 128
 

--- a/colibre-zooms/scripts/birth_density_redshift.py
+++ b/colibre-zooms/scripts/birth_density_redshift.py
@@ -11,7 +11,7 @@ from unyt import mh
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-density_bounds = [0.01, 10 ** 6.5]  # in nh/cm^3
+density_bounds = [0.01, 10 ** 7.0]  # in nh/cm^3
 redshift_bounds = [-1.5, 12]  # dimensionless
 bins = 128
 

--- a/colibre-zooms/scripts/max_temperature_redshift.py
+++ b/colibre-zooms/scripts/max_temperature_redshift.py
@@ -9,7 +9,7 @@ from swiftsimio import load
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-max_temperature_bounds = [1e5, 5e10]  # in K
+max_temperature_bounds = [1e5, 1e12]  # in K
 redshift_bounds = [-1.5, 12]  # dimensionless
 bins = 128
 

--- a/colibre-zooms/scripts/max_temperatures.py
+++ b/colibre-zooms/scripts/max_temperatures.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from swiftsimio import load
 
-T_bounds = [1e5, 1e11]  # in K
+T_bounds = [1e5, 1e12]  # in K
 
 
 def get_data(filename):

--- a/colibre/auto_plotter/baryon_fractions.yml
+++ b/colibre/auto_plotter/baryon_fractions.yml
@@ -1,0 +1,134 @@
+baryon_fraction_500:
+  type: "2dhistogram"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "spherical_overdensities.mass_500_rhocrit"
+    units: Solar_Mass
+    start: 1e12
+    end: 1e15
+  y:
+    quantity: "derived_quantities.baryon_fraction_true_R500"
+    units:  "dimensionless"
+    log: false
+    start: 0.
+    end: 1.2
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 1e12
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: "Halo baryon fractions within $R_{500}$"
+    caption: Baryon (gas + stars) fractions within $R_{500}$ normalised by the cosmic mean. These are 'true' values, i.e. no cut or observational correction was applied.
+    section: Baryon Fractions
+
+gas_fraction_500:
+  type: "2dhistogram"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "spherical_overdensities.mass_500_rhocrit"
+    units: Solar_Mass
+    start: 1e12
+    end: 1e15
+  y:
+    quantity: "derived_quantities.gas_fraction_true_R500"
+    units:  "dimensionless"
+    log: false
+    start: 0.
+    end: 1.2
+  median:
+    plot: true
+    log: true
+    min_num_points_highlight: 0
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 1e12
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: "Halo gas fractions within $R_{500}$"
+    caption: Gas fractions within $R_{500}$ normalised by the cosmic mean. These are 'true' values, i.e. no cut or observational correction was applied.
+    section: Baryon Fractions
+  observational_data:
+    - filename: HaloMassGasFractions/Lin2012.hdf5
+    - filename: HaloMassGasFractions/Sun2009.hdf5
+    - filename: HaloMassGasFractions/Vikhlinin2006.hdf5
+    - filename: HaloMassGasFractions/Eckert2016.hdf5
+    - filename: HaloMassGasFractions/Lovisari2015.hdf5
+
+star_fraction_500:
+  type: "2dhistogram"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "spherical_overdensities.mass_500_rhocrit"
+    units: Solar_Mass
+    start: 1e12
+    end: 1e15
+  y:
+    quantity: "derived_quantities.star_fraction_true_R500"
+    units:  "dimensionless"
+    log: false
+    start: 0.
+    end: 1.2
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 1e13
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: "Halo stellar fractions within $R_{500}$"
+    caption: Stellar fractions within $R_{500}$ normalised by the cosmic mean. These are 'true' values, i.e. no cut or observational correction was applied.
+    section: Baryon Fractions
+
+
+gas_mass_500:
+  type: "2dhistogram"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "spherical_overdensities.mass_500_rhocrit"
+    units: Solar_Mass
+    start: 1e13
+    end: 1e15
+  y:
+    quantity: "spherical_overdensities.mass_gas_500_rhocrit"
+    units: Solar_Mass
+    start: 3e9
+    end: 5e14
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 1e12
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: "Halo gas masses within $R_{500}$"
+    caption: Gas masses within $R_{500}$. These are 'true' values, i.e. no cut or observational correction was applied.
+    section: Baryon Fractions

--- a/colibre/auto_plotter/stellar_mass_halo_mass.yml
+++ b/colibre/auto_plotter/stellar_mass_halo_mass.yml
@@ -7,7 +7,7 @@ stellar_mass_halo_mass_M200_centrals_ratio_100:
     quantity: "masses.mass_200crit"
     units: Solar_Mass
     start: 1e8
-    end: 1e13
+    end: 1e15
   y:
     quantity: "derived_quantities.stellar_mass_to_halo_mass_200crit_100_kpc"
     units: "dimensionless"
@@ -17,12 +17,12 @@ stellar_mass_halo_mass_M200_centrals_ratio_100:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 30
+    number_of_bins: 40
     start:
       value: 1e8
       units: Solar_Mass
     end:
-      value: 1e13
+      value: 1e15
       units: Solar_Mass
   metadata:
     title: Stellar Mass-Halo Mass relation (ratio, 100 kpc aperture, $M_{200,crit}$, centrals only)
@@ -42,7 +42,7 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_100:
     quantity: "masses.mass_bn98"
     units: Solar_Mass
     start: 1e8
-    end: 1e13
+    end: 1e15
   y:
     quantity: "derived_quantities.stellar_mass_to_halo_mass_bn98_100_kpc"
     units: "dimensionless"
@@ -52,15 +52,85 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_100:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 30
+    number_of_bins: 40
     start:
       value: 1e8
       units: Solar_Mass
     end:
-      value: 1e13
+      value: 1e15
       units: Solar_Mass
   metadata:
     title: Stellar Mass-Halo Mass relation (ratio, 100 kpc aperture, $M_{\rm BN98}$, centrals only)
+    caption: Includes only central haloes.
+    section: Stellar Mass-Halo Mass
+  observational_data:
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_Ratio.hdf5
+
+stellar_mass_halo_mass_MBN98_centrals_ratio_50:
+  type: "scatter"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "masses.mass_bn98"
+    units: Solar_Mass
+    start: 1e8
+    end: 1e15
+  y:
+    quantity: "derived_quantities.stellar_mass_to_halo_mass_bn98_50_kpc"
+    units: "dimensionless"
+    start: 1e-4
+    end: 1e-1
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 40
+    start:
+      value: 1e8
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-Halo Mass relation (ratio, 50 kpc aperture, $M_{\rm BN98}$, centrals only)
+    caption: Includes only central haloes.
+    section: Stellar Mass-Halo Mass
+  observational_data:
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018Ratio.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_Ratio.hdf5
+
+stellar_mass_halo_mass_MBN98_centrals_ratio_30:
+  type: "scatter"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "masses.mass_bn98"
+    units: Solar_Mass
+    start: 1e8
+    end: 1e15
+  y:
+    quantity: "derived_quantities.stellar_mass_to_halo_mass_bn98_30_kpc"
+    units: "dimensionless"
+    start: 1e-4
+    end: 1e-1
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 40
+    start:
+      value: 1e8
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-Halo Mass relation (ratio, 30 kpc aperture, $M_{\rm BN98}$, centrals only)
     caption: Includes only central haloes.
     section: Stellar Mass-Halo Mass
   observational_data:
@@ -138,6 +208,76 @@ stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_100:
     - filename: GalaxyStellarMassHaloMass/Moster2018RatioStellar.hdf5
     - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_RatioStellar.hdf5
 
+stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_50:
+  type: "scatter"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 9e3
+    end: 1e12
+  y:
+    quantity: "derived_quantities.stellar_mass_to_halo_mass_bn98_50_kpc"
+    units: "dimensionless"
+    start: 1e-4
+    end: 1e-1
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 9e3
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-Halo Mass relation (ratio, 50 kpc aperture, $M_{\rm BN98}$, centrals only, stellar x-axis)
+    caption: Includes only central haloes.
+    section: Stellar Mass-Halo Mass
+  observational_data:
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_RatioStellar.hdf5
+
+stellar_mass_halo_mass_MBN98_centrals_ratio_stellar_30:
+  type: "scatter"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "apertures.mass_star_30_kpc"
+    units: Solar_Mass
+    start: 9e3
+    end: 1e12
+  y:
+    quantity: "derived_quantities.stellar_mass_to_halo_mass_bn98_30_kpc"
+    units: "dimensionless"
+    start: 1e-4
+    end: 1e-1
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 9e3
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-Halo Mass relation (ratio, 30 kpc aperture, $M_{\rm BN98}$, centrals only, stellar x-axis)
+    caption: Includes only central haloes.
+    section: Stellar Mass-Halo Mass
+  observational_data:
+    - filename: GalaxyStellarMassHaloMass/Behroozi2019RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Moster2018RatioStellar.hdf5
+    - filename: GalaxyStellarMassHaloMass/Schaye2015_Ref_100_MBN98_RatioStellar.hdf5
+
 stellar_mass_halo_mass_M200_all_100:
   type: "scatter"
   legend_loc: "upper left"
@@ -145,7 +285,7 @@ stellar_mass_halo_mass_M200_all_100:
     quantity: "masses.mass_200crit"
     units: Solar_Mass
     start: 9e3
-    end: 1e13
+    end: 1e15
   y:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
@@ -155,12 +295,12 @@ stellar_mass_halo_mass_M200_all_100:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 25
+    number_of_bins: 40
     start:
       value: 9e3
       units: Solar_Mass
     end:
-      value: 1e13
+      value: 1e15
       units: Solar_Mass
   metadata:
     title: Stellar Mass-Halo Mass relation (100 kpc aperture, $M_{200,crit}$)
@@ -178,7 +318,7 @@ stellar_mass_halo_mass_MBN98_all_100:
     quantity: "masses.mass_bn98"
     units: Solar_Mass
     start: 9e3
-    end: 1e13
+    end: 1e15
   y:
     quantity: "apertures.mass_star_100_kpc"
     units: Solar_Mass
@@ -188,12 +328,12 @@ stellar_mass_halo_mass_MBN98_all_100:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 25
+    number_of_bins: 40
     start:
       value: 9e3
       units: Solar_Mass
     end:
-      value: 1e13
+      value: 1e15
       units: Solar_Mass
   metadata:
     title: Stellar Mass-Halo Mass relation (100 kpc aperture, $M_{\rm BN98}$)

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -28,7 +28,8 @@ This file calculates:
 """
 
 # Define aperture size in kpc
-aperture_sizes = [30, 100]
+aperture_sizes_30_100_kpc = {30, 100}
+aperture_sizes_30_50_100_kpc = {30, 50, 100}
 
 # Solar metal mass fraction used in Plöckinger S. & Schaye J. (2020)
 solar_metal_mass_fraction = 0.0134
@@ -829,6 +830,35 @@ def register_stellar_birth_densities(self, catalogue):
     return
 
 
+def register_gas_fraction(self, catalogue):
+
+    Omega_m = catalogue.units.cosmology.Om0
+    Omega_b = catalogue.units.cosmology.Ob0
+
+    M_500 = catalogue.spherical_overdensities.mass_500_rhocrit
+    M_500_gas = catalogue.spherical_overdensities.mass_gas_500_rhocrit
+    M_500_star = catalogue.spherical_overdensities.mass_star_500_rhocrit
+    M_500_baryon = M_500_gas + M_500_star
+
+    f_b_500 = (M_500_baryon / M_500) / (Omega_b / Omega_m)
+    name = "$f_{\\rm b, 500, true} / (\\Omega_{\\rm b} / \\Omega_{\\rm m})$"
+    f_b_500.name = name
+
+    f_gas_500 = (M_500_gas / M_500) / (Omega_b / Omega_m)
+    name = "$f_{\\rm gas, 500, true} / (\\Omega_{\\rm b} / \\Omega_{\\rm m})$"
+    f_gas_500.name = name
+
+    f_star_500 = (M_500_star / M_500) / (Omega_b / Omega_m)
+    name = "$f_{\\rm star, 500, true} / (\\Omega_{\\rm b} / \\Omega_{\\rm m})$"
+    f_star_500.name = name
+
+    setattr(self, "baryon_fraction_true_R500", f_b_500)
+    setattr(self, "gas_fraction_true_R500", f_gas_500)
+    setattr(self, "star_fraction_true_R500", f_star_500)
+
+    return
+
+
 def register_los_star_veldisp(self, catalogue):
     for aperture_size in [10, 30]:
         veldisp = getattr(catalogue.apertures, f"veldisp_star_{aperture_size}_kpc")
@@ -840,20 +870,29 @@ def register_los_star_veldisp(self, catalogue):
 
 
 # Register derived fields
-register_spesific_star_formation_rates(self, catalogue, aperture_sizes)
-register_star_metallicities(self, catalogue, aperture_sizes, solar_metal_mass_fraction)
-register_stellar_to_halo_mass_ratios(self, catalogue, aperture_sizes)
-register_dust(self, catalogue, aperture_sizes)
+register_spesific_star_formation_rates(self, catalogue, aperture_sizes_30_100_kpc)
+register_star_metallicities(
+    self, catalogue, aperture_sizes_30_100_kpc, solar_metal_mass_fraction
+)
+register_stellar_to_halo_mass_ratios(self, catalogue, aperture_sizes_30_50_100_kpc)
+register_dust(self, catalogue, aperture_sizes_30_100_kpc)
 register_oxygen_to_hydrogen(self, catalogue, aperture_sizes)
 register_cold_dense_gas_metallicity(
-    self, catalogue, aperture_sizes, solar_metal_mass_fraction, twelve_plus_log_OH_solar
+    self,
+    catalogue,
+    aperture_sizes_30_100_kpc,
+    solar_metal_mass_fraction,
+    twelve_plus_log_OH_solar,
 )
-register_iron_to_hydrogen(self, catalogue, aperture_sizes, solar_fe_abundance)
-register_hi_masses(self, catalogue, aperture_sizes)
-register_h2_masses(self, catalogue, aperture_sizes)
-register_dust_to_hi_ratio(self, catalogue, aperture_sizes)
-register_cold_gas_mass_ratios(self, catalogue, aperture_sizes)
-register_species_fractions(self, catalogue, aperture_sizes)
+register_iron_to_hydrogen(
+    self, catalogue, aperture_sizes_30_100_kpc, solar_fe_abundance
+)
+register_hi_masses(self, catalogue, aperture_sizes_30_100_kpc)
+register_h2_masses(self, catalogue, aperture_sizes_30_100_kpc)
+register_dust_to_hi_ratio(self, catalogue, aperture_sizes_30_100_kpc)
+register_cold_gas_mass_ratios(self, catalogue, aperture_sizes_30_100_kpc)
+register_species_fractions(self, catalogue, aperture_sizes_30_100_kpc)
 register_stellar_birth_densities(self, catalogue)
 register_los_star_veldisp(self, catalogue)
 register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes)
+register_gas_fraction(self, catalogue)

--- a/colibre/scripts/birth_density_distribution.py
+++ b/colibre/scripts/birth_density_distribution.py
@@ -86,7 +86,7 @@ data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
 number_of_bins = 256
 
 birth_density_bins = unyt.unyt_array(
-    np.logspace(-2, 6.5, number_of_bins), units="1/cm**3"
+    np.logspace(-2, 7, number_of_bins), units="1/cm**3"
 )
 log_birth_density_bin_width = np.log10(birth_density_bins[1].value) - np.log10(
     birth_density_bins[0].value

--- a/colibre/scripts/birth_density_metallicity.py
+++ b/colibre/scripts/birth_density_metallicity.py
@@ -11,7 +11,7 @@ from unyt import mh
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-density_bounds = [0.01, 10 ** 6.5]  # in nh/cm^3
+density_bounds = [0.01, 10 ** 7.0]  # in nh/cm^3
 metal_mass_fraction_bounds = [1e-4, 0.5]  # dimensionless
 bins = 128
 

--- a/colibre/scripts/birth_density_redshift.py
+++ b/colibre/scripts/birth_density_redshift.py
@@ -11,7 +11,7 @@ from unyt import mh
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-density_bounds = [0.01, 10 ** 6.5]  # in nh/cm^3
+density_bounds = [0.01, 10 ** 7.0]  # in nh/cm^3
 redshift_bounds = [-1.5, 12]  # dimensionless
 bins = 128
 

--- a/colibre/scripts/max_temperature_redshift.py
+++ b/colibre/scripts/max_temperature_redshift.py
@@ -9,7 +9,7 @@ from swiftsimio import load
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-max_temperature_bounds = [1e5, 5e10]  # in K
+max_temperature_bounds = [1e5, 1e12]  # in K
 redshift_bounds = [-1.5, 12]  # dimensionless
 bins = 128
 

--- a/colibre/scripts/max_temperatures.py
+++ b/colibre/scripts/max_temperatures.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from swiftsimio import load
 
-T_bounds = [1e5, 1e11]  # in K
+T_bounds = [1e5, 1e12]  # in K
 
 
 def get_data(filename):


### PR DESCRIPTION
**Main update**

- Copy baryon fraction plots from Flamingo pipeline to Colibre and Colibre zoom pipelines

**Also a few small updates**

- Extend upper limits to higher values in (i) maximum temperature plots, (ii) stellar-to-halo mass plots, and (iii) stellar birth density plots
- Add the version of stellar-to-halo mass plots where the stellar mass is computed in 50-kpc apertures