### PR TITLE
New radio data in star formation history plot

### DIFF
--- a/colibre/scripts/star_formation_history.py
+++ b/colibre/scripts/star_formation_history.py
@@ -161,7 +161,7 @@ for radio_data, color in zip(radio_data_sample, ["maroon", "goldenrod", "slategr
             zorder=-10,
         )
     )
-    observation_labels.append(radio_data.citation)
+    observation_labels.append(f"{radio_data.citation} [radio]")
 
 # Add Behroozi data
 Behroozi2019 = load_observations(

--- a/colibre/scripts/star_formation_history.py
+++ b/colibre/scripts/star_formation_history.py
@@ -135,8 +135,36 @@ for index, observation in enumerate(observational_data):
         )
     observation_labels.append(observation.description)
 
+# Add radio data
+radio_data = load_observations(
+    [
+        f"{path_to_obs_data}/data/StarFormationRateHistory/Novak2017.hdf5",
+        f"{path_to_obs_data}/data/StarFormationRateHistory/Gruppioni2020.hdf5",
+        f"{path_to_obs_data}/data/StarFormationRateHistory/Enia2022.hdf5",
+    ]
+)
 
-# Add Berhoozi data
+index = len(observational_data)
+for rdata in radio_data:
+    observation_lines.append(
+        ax.errorbar(
+            rdata.x.value,
+            rdata.y.value,
+            xerr=rdata.x_scatter.value,
+            yerr=rdata.y_scatter.value,
+            label=rdata.citation,
+            linestyle="none",
+            marker="o",
+            elinewidth=0.5,
+            markeredgecolor="none",
+            markersize=2,
+            zorder=index,
+        )
+    )
+    observation_labels.append(rdata.citation)
+    index += 1
+
+# Add Behroozi data
 Behroozi2019 = load_observations(
     [
         f"{path_to_obs_data}/data/StarFormationRateHistory/Behroozi2019_true.hdf5",

--- a/colibre/scripts/star_formation_history.py
+++ b/colibre/scripts/star_formation_history.py
@@ -136,7 +136,7 @@ for index, observation in enumerate(observational_data):
     observation_labels.append(observation.description)
 
 # Add radio data
-radio_data = load_observations(
+radio_data_sample = load_observations(
     [
         f"{path_to_obs_data}/data/StarFormationRateHistory/Novak2017.hdf5",
         f"{path_to_obs_data}/data/StarFormationRateHistory/Gruppioni2020.hdf5",
@@ -144,25 +144,24 @@ radio_data = load_observations(
     ]
 )
 
-index = len(observational_data)
-for rdata in radio_data:
+for radio_data, color in zip(radio_data_sample, ["maroon", "goldenrod", "slategrey"]):
     observation_lines.append(
         ax.errorbar(
-            rdata.x.value,
-            rdata.y.value,
-            xerr=rdata.x_scatter.value,
-            yerr=rdata.y_scatter.value,
-            label=rdata.citation,
+            radio_data.x.value,
+            radio_data.y.value,
+            xerr=radio_data.x_scatter.value,
+            yerr=radio_data.y_scatter.value,
+            label=radio_data.citation,
             linestyle="none",
             marker="o",
+            color=color,
             elinewidth=0.5,
             markeredgecolor="none",
             markersize=2,
-            zorder=index,
+            zorder=-10,
         )
     )
-    observation_labels.append(rdata.citation)
-    index += 1
+    observation_labels.append(radio_data.citation)
 
 # Add Behroozi data
 Behroozi2019 = load_observations(


### PR DESCRIPTION
Adds recent radio SFRD data from Novak et al. (2017), Gruppioni et al. (2020) and Enia et al. (2022) to the star formation history plot. Also fixes an issue with the observational data sub-module not being up-to-date with the latest version of the pipeline scripts.

I have only changed this for the COLIBRE pipeline for now, but I assume the same data needs to be added to the other projects. We will also need to remove some older datasets, since the plot has become unreadable. I will update the other projects once we are happy with the new COLIBRE version.