### PR TITLE
Extend plot ranges fix small bugs

### DIFF
--- a/colibre-zooms/config.yml
+++ b/colibre-zooms/config.yml
@@ -72,7 +72,7 @@ scripts:
     section: Metal Mass Fractions
     title: Metal Mass Fraction Distribution
   - filename: scripts/birth_density_distribution.py
-    caption: Distributions of stellar birth densities, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median stellar birth-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for f_t=10.
+    caption: Distributions of stellar birth densities, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median stellar birth-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for SN min and max heating temperatures with $f_t=10$.
     title: Stellar Birth Densities
     section: Stellar Birth Densities
     output_file: birth_density_distribution.png
@@ -92,12 +92,12 @@ scripts:
     section: Stellar Birth Densities
     output_file: metallicity_redshift.png
   - filename: scripts/last_SNII_density_distribution.py
-    caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles. The dashed vertical lines show the median SNII gas-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for $f_t=10$.
+    caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles. The dashed vertical lines show the median SNII gas-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for SN min and max heating temperatures with $f_t=10$.
     title: Density of the gas heated by SNII
     section: Feedback Densities
     output_file: SNII_density_distribution.png
   - filename: scripts/last_AGN_density_distribution.py
-    caption: Distributions of the gas densities recorded when the gas was last heated by AGN, split by redshift. The y axis shows the number of AGN-heated gas particles per bin divided by the bin width and by the total of AGN-heated gas particles. The dashed vertical lines show the median AGN gas-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for $f_t=10$.
+    caption: Distributions of the gas densities recorded when the gas was last heated by AGN, split by redshift. The y axis shows the number of AGN-heated gas particles per bin divided by the bin width and by the total of AGN-heated gas particles. The dashed vertical lines show the median AGN gas-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for AGN heating temperature with $f_t=10$.
     title: Density of the gas heated by AGN
     section: Feedback Densities
     output_file: AGN_density_distribution.png

--- a/colibre-zooms/scripts/density_internal_energy.py
+++ b/colibre-zooms/scripts/density_internal_energy.py
@@ -11,8 +11,8 @@ from unyt import mh, cm, s, km
 from matplotlib.colors import LogNorm
 
 # Constants; these could be put in the parameter file but are rarely changed.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
-internal_energy_bounds = [10 ** (-4), 10 ** 6]  # in
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
+internal_energy_bounds = [10 ** (-4), 10 ** 8]  # in
 bins = 256
 
 
@@ -62,7 +62,11 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/density_pressure.py
+++ b/colibre-zooms/scripts/density_pressure.py
@@ -12,7 +12,7 @@ from matplotlib.colors import LogNorm
 from matplotlib.animation import FuncAnimation
 
 # Constants; these could be put in the parameter file but are rarely changed.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 pressure_bounds = [10 ** (-8.0), 10 ** 8.0]  # in K/cm^3
 bins = 256
 
@@ -64,7 +64,11 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/density_species_interp.py
+++ b/colibre-zooms/scripts/density_species_interp.py
@@ -6,20 +6,14 @@ import matplotlib.pyplot as plt
 import numpy as np
 import glob
 
-import swiftsimio as sw
 from swiftsimio import load
 import h5py as h5
 
 from unyt import mh, cm
-from matplotlib.colors import LogNorm, ListedColormap, BoundaryNorm
-from matplotlib.animation import FuncAnimation
-from matplotlib.cm import get_cmap
 from scipy.interpolate import interpn
-from scipy.stats import binned_statistic as bs1d
 
 # Set the limits of the figure.
-density_bounds = [1e-3, 1e3]  # in nh/cm^3
-temperature_bounds = [10 ** (0), 10 ** (9.5)]  # in K
+density_bounds = [10 ** (-5), 10 ** (6.0)]  # nh/cm^3
 dustfracs_bounds = [-4, -1]  # In metal mass fraction
 min_dustfracs = 10 ** dustfracs_bounds[0]
 bins = 64
@@ -128,7 +122,6 @@ def get_data(filename, tables, prefix_rho, prefix_T):
 def make_hist(
     filename,
     density_bounds,
-    temperature_bounds,
     bins,
     tables,
     prefix_rho="",
@@ -143,9 +136,6 @@ def make_hist(
 
     density_bins = np.logspace(
         np.log10(density_bounds[0]), np.log10(density_bounds[1]), bins
-    )
-    temperature_bins = np.logspace(
-        np.log10(temperature_bounds[0]), np.log10(temperature_bounds[1]), bins
     )
 
     ret_tuple = get_data(filename, tables, prefix_rho, prefix_T)
@@ -202,7 +192,11 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -232,7 +226,6 @@ def make_single_image(
     names,
     number_of_simulations,
     density_bounds,
-    temperature_bounds,
     bins,
     output_path,
     prop_type,
@@ -263,7 +256,6 @@ def make_single_image(
         hh2, hhi, hhii, hd2z, hdi2z, d = make_hist(
             filename,
             density_bounds,
-            temperature_bounds,
             bins,
             tables,
             prefix_rho,
@@ -275,14 +267,12 @@ def make_single_image(
         hist_d2z.append(hd2z)
         hist_di2z.append(hdi2z)
 
-    ncols = 20
-    collist = []
     binmids = np.log10(d)[:-1] + 0.5 * np.diff(np.log10(d))
 
     for hist_h2, hist_hi, hist_hii, hist_d2z, hist_di2z, name, axis in zip(
         hist_h2, hist_hi, hist_hii, hist_d2z, hist_di2z, names, ax.flat
     ):
-        # mappable = axis.pcolormesh(d, T, np.log10(hist), cmap=cmap, norm=norm)
+
         axis.plot(binmids, np.clip(hist_h2, 0, 1), label="molecular")
         axis.plot(binmids, np.clip(hist_hi, 0, 1), label="atomic")
         axis.plot(binmids, np.clip(hist_hii, 0, 1), label="ionised")
@@ -292,6 +282,7 @@ def make_single_image(
         axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
         axis.legend(frameon=False, loc=6)
         axis.set_ylim(0, 1.1)
+        axis.set_xlim(np.log10(density_bounds[0]), np.log10(density_bounds[1]))
         axis2 = axis.twinx()
         axis2.plot(binmids, hist_d2z, c="C5", label="Model dust")
         axis2.plot(binmids, hist_di2z, c="C5", ls="--", label="Table dust")
@@ -306,7 +297,7 @@ if __name__ == "__main__":
     from swiftpipeline.argumentparser import ScriptArgumentParser
 
     arguments = ScriptArgumentParser(
-        description="Basic density-temperature figure.",
+        description="Hydrogen species figure.",
         additional_arguments={
             "quantity_type": "hydro",
             "cooling_tables": "UV_dust1_CR1_G1_shield1.hdf5",
@@ -327,7 +318,6 @@ if __name__ == "__main__":
         names=arguments.name_list,
         number_of_simulations=arguments.number_of_inputs,
         density_bounds=density_bounds,
-        temperature_bounds=temperature_bounds,
         bins=bins,
         output_path=arguments.output_directory,
         prop_type=arguments.quantity_type,

--- a/colibre-zooms/scripts/density_temperature.py
+++ b/colibre-zooms/scripts/density_temperature.py
@@ -12,7 +12,7 @@ from matplotlib.colors import LogNorm
 from matplotlib.animation import FuncAnimation
 
 # Set the limits of the figure.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** (0), 10 ** (9.5)]  # in K
 bins = 256
 
@@ -64,7 +64,11 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/density_temperature_dust.py
+++ b/colibre-zooms/scripts/density_temperature_dust.py
@@ -10,7 +10,7 @@ from unyt import mh, cm, unyt_array
 from matplotlib.colors import Normalize
 
 # Set the limits of the figure.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 dustfracs_bounds = [-5, -1]  # dimensionless (dust mass / gas mass)
 min_dustfracs = dustfracs_bounds[0]
@@ -84,7 +84,11 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -205,7 +209,9 @@ def make_single_image(
         axis.set_ylim(*temperature_bounds)
 
     fig.colorbar(
-        mappable, ax=ax.ravel().tolist(), label="Mean (Logarithmic) Dust Mass Fraction",
+        mappable,
+        ax=ax.ravel().tolist(),
+        label="Mean (Logarithmic) Dust Mass Fraction",
     )
 
     fig.savefig(f"{output_path}/{prefix_T}density_temperature_dust.png")

--- a/colibre-zooms/scripts/density_temperature_dust2metal.py
+++ b/colibre-zooms/scripts/density_temperature_dust2metal.py
@@ -13,7 +13,7 @@ from matplotlib.colors import LogNorm
 from matplotlib.animation import FuncAnimation
 
 # Set the limits of the figure.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** (0), 10 ** (9.5)]  # in K
 DTMs_bounds = [2e-2, 1]  # In metal mass fraction
 min_DTMs = DTMs_bounds[0]
@@ -91,7 +91,11 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/density_temperature_dust_to_metals.py
+++ b/colibre-zooms/scripts/density_temperature_dust_to_metals.py
@@ -11,7 +11,7 @@ from unyt import mh, cm, unyt_array
 from matplotlib.colors import LogNorm
 
 # Constants; these could be put in the parameter file but are rarely changed.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 dtm_bounds = [1e-3, 1e-1]
 min_metallicity = 1e-8
@@ -93,7 +93,11 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -183,7 +187,10 @@ def make_single_image(
 
     for filename, hist, name, axis in zip(filenames, hists, names, ax.flat):
         mappable = axis.pcolormesh(
-            d, T, hist, norm=LogNorm(vmin=dtm_bounds[0], vmax=dtm_bounds[1]),
+            d,
+            T,
+            hist,
+            norm=LogNorm(vmin=dtm_bounds[0], vmax=dtm_bounds[1]),
         )
         axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
         metadata = load(filename).metadata
@@ -192,7 +199,9 @@ def make_single_image(
         axis.set_ylim(*temperature_bounds)
 
     fig.colorbar(
-        mappable, ax=ax.ravel().tolist(), label="Mean Dust / Metals Ratio []",
+        mappable,
+        ax=ax.ravel().tolist(),
+        label="Mean Dust / Metals Ratio []",
     )
 
     fig.savefig(f"{output_path}/density_temperature_dust_to_metals.png")

--- a/colibre-zooms/scripts/density_temperature_metals.py
+++ b/colibre-zooms/scripts/density_temperature_metals.py
@@ -11,7 +11,7 @@ from unyt import mh, cm, unyt_array
 from matplotlib.colors import Normalize
 
 # Constants; these could be put in the parameter file but are rarely changed.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 metallicity_bounds = [-6, -1]  # In metal mass fraction
 min_metallicity = 1e-8
@@ -76,7 +76,11 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/density_temperature_sf_fraction.py
+++ b/colibre-zooms/scripts/density_temperature_sf_fraction.py
@@ -12,7 +12,7 @@ from unyt import mh, cm, unyt_array
 from matplotlib.colors import Normalize
 
 # Constants; these could be put in the parameter file but are rarely changed.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 sf_mass_fraction_bounds = [-2.5, 0]  # log mass fraction of star-forming gas
 min_sf_mass_fraction = 1e-6  # Minimal mass fraction of star-forming gas

--- a/colibre-zooms/scripts/density_temperature_species.py
+++ b/colibre-zooms/scripts/density_temperature_species.py
@@ -11,7 +11,7 @@ from unyt import mh, cm, unyt_array
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 specfracs_bounds = [1e-2, 1]  # dimensionless
 min_specfracs = specfracs_bounds[0]
@@ -92,7 +92,11 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/last_AGN_density_distribution.py
+++ b/colibre-zooms/scripts/last_AGN_density_distribution.py
@@ -87,7 +87,7 @@ data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
 number_of_bins = 256
 
 AGN_density_bins = unyt.unyt_array(
-    np.logspace(-5, 6.5, number_of_bins), units="1/cm**3"
+    np.logspace(-5.0, 7.0, number_of_bins), units="1/cm**3"
 )
 log_AGN_density_bin_width = np.log10(AGN_density_bins[1].value) - np.log10(
     AGN_density_bins[0].value
@@ -164,6 +164,9 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         T_K=AGN_heating_temperature, M_gas=M_gas.value, N_ngb=N_ngb_target, X_H=X_H
     )
 
+    # Total number of objects received AGN energy
+    Num_of_heated_parts_total = len(gas_AGN_redshifts) + len(stars_AGN_redshifts)
+
     for redshift, ax in ax_dict.items():
         data = np.concatenate(
             [
@@ -173,15 +176,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         )
 
         H, _ = np.histogram(data, bins=AGN_density_bins)
-
-        # Total number AGN-heated gas particles
-        Num_of_obj = np.sum(H)
-
-        # Check to avoid division by zero
-        if Num_of_obj:
-            y_points = H / log_AGN_density_bin_width / Num_of_obj
-        else:
-            y_points = np.zeros_like(H)
+        y_points = H / log_AGN_density_bin_width / Num_of_heated_parts_total
 
         ax.plot(
             AGN_density_centers,

--- a/colibre-zooms/scripts/last_SNII_density_distribution.py
+++ b/colibre-zooms/scripts/last_SNII_density_distribution.py
@@ -5,6 +5,7 @@ Plots the SNII density distribution (at last SNII thermal injections).
 import matplotlib.pyplot as plt
 import numpy as np
 import unyt
+import traceback
 
 from unyt import mh
 
@@ -87,7 +88,7 @@ data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
 number_of_bins = 256
 
 SNII_density_bins = unyt.unyt_array(
-    np.logspace(-5, 6.5, number_of_bins), units="1/cm**3"
+    np.logspace(-5.0, 7.0, number_of_bins), units="1/cm**3"
 )
 log_SNII_density_bin_width = np.log10(SNII_density_bins[1].value) - np.log10(
     SNII_density_bins[0].value
@@ -165,17 +166,45 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         "$z > 3$": gas_SNII_densities[gas_SNII_redshifts > 3],
     }
 
-    # Compute the critical density from DV&S2012
-    SNII_heating_temperature = float(
-        snapshot.metadata.parameters["COLIBREFeedback:SNII_delta_T_K"].decode("utf-8")
-    )  # in K
-    N_ngb_target = snapshot.metadata.hydro_scheme["Kernel target N_ngb"][0]
-    X_H = snapshot.metadata.hydro_scheme["Hydrogen mass fraction"][0]
-    M_gas = snapshot.metadata.initial_mass_table.gas.to("Msun")  # in Solar Masses
+    # Compute the critical density from DV&S201
+    try:
+        SNII_heating_temperature_min = float(
+            snapshot.metadata.parameters["COLIBREFeedback:SNII_delta_T_K_min"].decode(
+                "utf-8"
+            )
+        )  # in K
+        SNII_heating_temperature_max = float(
+            snapshot.metadata.parameters["COLIBREFeedback:SNII_delta_T_K_max"].decode(
+                "utf-8"
+            )
+        )  # in K
+        N_ngb_target = snapshot.metadata.hydro_scheme["Kernel target N_ngb"][0]
+        X_H = snapshot.metadata.hydro_scheme["Hydrogen mass fraction"][0]
+        M_gas = snapshot.metadata.initial_mass_table.gas.to("Msun")  # in Solar Masses
 
-    n_crit = critical_density_DVS2012(
-        T_K=SNII_heating_temperature, M_gas=M_gas.value, N_ngb=N_ngb_target, X_H=X_H
-    )
+        # Critical density corresponding to minimum heating temperature
+        n_crit_min = critical_density_DVS2012(
+            T_K=SNII_heating_temperature_min,
+            M_gas=M_gas.value,
+            N_ngb=N_ngb_target,
+            X_H=X_H,
+        )
+        # Critical density corresponding to maximum heating temperature
+        n_crit_max = critical_density_DVS2012(
+            T_K=SNII_heating_temperature_max,
+            M_gas=M_gas.value,
+            N_ngb=N_ngb_target,
+            X_H=X_H,
+        )
+
+    # Cannot find argument(s)
+    except KeyError:
+        print(traceback.format_exc())
+        # Default value
+        n_crit_min, n_crit_max = -1.0, -1.0
+
+    # Total number of objects received SNII thermal energy
+    Num_of_heated_parts_total = len(gas_SNII_redshifts) + len(stars_SNII_redshifts)
 
     for redshift, ax in ax_dict.items():
         data = np.concatenate(
@@ -186,15 +215,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         )
 
         H, _ = np.histogram(data, bins=SNII_density_bins)
-
-        # Total number SNII-heated gas particles
-        Num_of_obj = np.sum(H)
-
-        # Check to avoid division by zero
-        if Num_of_obj:
-            y_points = H / log_SNII_density_bin_width / Num_of_obj
-        else:
-            y_points = np.zeros_like(H)
+        y_points = H / log_SNII_density_bin_width / Num_of_heated_parts_total
 
         ax.plot(
             SNII_density_centers,
@@ -210,14 +231,16 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
             alpha=0.5,
         )
 
-        # Add the DV&S2012 line
-        ax.axvline(
-            n_crit,
-            color=f"C{color}",
-            linestyle="dotted",
-            zorder=-10,
-            alpha=0.5,
-        )
+        # Add the DV&S2012 lines corresponding to min and max heating temperatures
+        for n_crit in [n_crit_min, n_crit_max]:
+            if n_crit > 0.0:
+                ax.axvline(
+                    n_crit,
+                    color=f"C{color}",
+                    linestyle="dotted",
+                    zorder=-10,
+                    alpha=0.5,
+                )
 
 axes[0].legend(loc="upper right", markerfirst=False)
 axes[2].set_xlabel(

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -89,7 +89,7 @@ scripts:
     section: Metal Mass Fractions
     title: Metal Mass Fraction Distribution
   - filename: scripts/birth_density_distribution.py
-    caption: Distributions of stellar birth densities, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median stellar birth-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for f_t=10.
+    caption: Distributions of stellar birth densities, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median stellar birth-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for SN min and max heating temperatures with $f_t=10$.
     title: Stellar Birth Densities
     section: Stellar Birth Densities
     output_file: birth_density_distribution.png
@@ -109,12 +109,12 @@ scripts:
     section: Stellar Birth Densities
     output_file: metallicity_redshift.png
   - filename: scripts/last_SNII_density_distribution.py
-    caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles. The dashed vertical lines show the median SNII gas-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for $f_t=10$.
+    caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles. The dashed vertical lines show the median SNII gas-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for SN min and max heating temperatures with $f_t=10$.
     title: Density of the gas heated by SNII
     section: Feedback Densities
     output_file: SNII_density_distribution.png
   - filename: scripts/last_AGN_density_distribution.py
-    caption: Distributions of the gas densities recorded when the gas was last heated by AGN, split by redshift. The y axis shows the number of AGN-heated gas particles per bin divided by the bin width and by the total of AGN-heated gas particles. The dashed vertical lines show the median AGN gas-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for $f_t=10$.
+    caption: Distributions of the gas densities recorded when the gas was last heated by AGN, split by redshift. The y axis shows the number of AGN-heated gas particles per bin divided by the bin width and by the total of AGN-heated gas particles. The dashed vertical lines show the median AGN gas-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for AGN heating temperature with $f_t=10$.
     title: Density of the gas heated by AGN
     section: Feedback Densities
     output_file: AGN_density_distribution.png

--- a/colibre/scripts/density_internal_energy.py
+++ b/colibre/scripts/density_internal_energy.py
@@ -11,8 +11,8 @@ from unyt import mh, cm, s, km
 from matplotlib.colors import LogNorm
 
 # Constants; these could be put in the parameter file but are rarely changed.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
-internal_energy_bounds = [10 ** (-4), 10 ** 6]  # in
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
+internal_energy_bounds = [10 ** (-4), 10 ** 8]  # in
 bins = 256
 
 
@@ -62,7 +62,11 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_pressure.py
+++ b/colibre/scripts/density_pressure.py
@@ -12,7 +12,7 @@ from matplotlib.colors import LogNorm
 from matplotlib.animation import FuncAnimation
 
 # Constants; these could be put in the parameter file but are rarely changed.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 pressure_bounds = [10 ** (-8.0), 10 ** 8.0]  # in K/cm^3
 bins = 256
 
@@ -64,7 +64,11 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_species_interp.py
+++ b/colibre/scripts/density_species_interp.py
@@ -6,20 +6,14 @@ import matplotlib.pyplot as plt
 import numpy as np
 import glob
 
-import swiftsimio as sw
 from swiftsimio import load
 import h5py as h5
 
 from unyt import mh, cm
-from matplotlib.colors import LogNorm, ListedColormap, BoundaryNorm
-from matplotlib.animation import FuncAnimation
-from matplotlib.cm import get_cmap
 from scipy.interpolate import interpn
-from scipy.stats import binned_statistic as bs1d
 
 # Set the limits of the figure.
-density_bounds = [1e-3, 1e3]  # in nh/cm^3
-temperature_bounds = [10 ** (0), 10 ** (9.5)]  # in K
+density_bounds = [10 ** (-5), 10 ** (6.0)]  # nh/cm^3
 dustfracs_bounds = [-4, -1]  # In metal mass fraction
 min_dustfracs = 10 ** dustfracs_bounds[0]
 bins = 64
@@ -128,7 +122,6 @@ def get_data(filename, tables, prefix_rho, prefix_T):
 def make_hist(
     filename,
     density_bounds,
-    temperature_bounds,
     bins,
     tables,
     prefix_rho="",
@@ -143,9 +136,6 @@ def make_hist(
 
     density_bins = np.logspace(
         np.log10(density_bounds[0]), np.log10(density_bounds[1]), bins
-    )
-    temperature_bins = np.logspace(
-        np.log10(temperature_bounds[0]), np.log10(temperature_bounds[1]), bins
     )
 
     ret_tuple = get_data(filename, tables, prefix_rho, prefix_T)
@@ -202,7 +192,11 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -232,7 +226,6 @@ def make_single_image(
     names,
     number_of_simulations,
     density_bounds,
-    temperature_bounds,
     bins,
     output_path,
     prop_type,
@@ -263,7 +256,6 @@ def make_single_image(
         hh2, hhi, hhii, hd2z, hdi2z, d = make_hist(
             filename,
             density_bounds,
-            temperature_bounds,
             bins,
             tables,
             prefix_rho,
@@ -275,14 +267,12 @@ def make_single_image(
         hist_d2z.append(hd2z)
         hist_di2z.append(hdi2z)
 
-    ncols = 20
-    collist = []
     binmids = np.log10(d)[:-1] + 0.5 * np.diff(np.log10(d))
 
     for hist_h2, hist_hi, hist_hii, hist_d2z, hist_di2z, name, axis in zip(
         hist_h2, hist_hi, hist_hii, hist_d2z, hist_di2z, names, ax.flat
     ):
-        # mappable = axis.pcolormesh(d, T, np.log10(hist), cmap=cmap, norm=norm)
+
         axis.plot(binmids, np.clip(hist_h2, 0, 1), label="molecular")
         axis.plot(binmids, np.clip(hist_hi, 0, 1), label="atomic")
         axis.plot(binmids, np.clip(hist_hii, 0, 1), label="ionised")
@@ -292,6 +282,7 @@ def make_single_image(
         axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
         axis.legend(frameon=False, loc=6)
         axis.set_ylim(0, 1.1)
+        axis.set_xlim(np.log10(density_bounds[0]), np.log10(density_bounds[1]))
         axis2 = axis.twinx()
         axis2.plot(binmids, hist_d2z, c="C5", label="Model dust")
         axis2.plot(binmids, hist_di2z, c="C5", ls="--", label="Table dust")
@@ -306,7 +297,7 @@ if __name__ == "__main__":
     from swiftpipeline.argumentparser import ScriptArgumentParser
 
     arguments = ScriptArgumentParser(
-        description="Basic density-temperature figure.",
+        description="Hydrogen species figure.",
         additional_arguments={
             "quantity_type": "hydro",
             "cooling_tables": "UV_dust1_CR1_G1_shield1.hdf5",
@@ -327,7 +318,6 @@ if __name__ == "__main__":
         names=arguments.name_list,
         number_of_simulations=arguments.number_of_inputs,
         density_bounds=density_bounds,
-        temperature_bounds=temperature_bounds,
         bins=bins,
         output_path=arguments.output_directory,
         prop_type=arguments.quantity_type,

--- a/colibre/scripts/density_temperature.py
+++ b/colibre/scripts/density_temperature.py
@@ -12,7 +12,7 @@ from matplotlib.colors import LogNorm
 from matplotlib.animation import FuncAnimation
 
 # Set the limits of the figure.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** (0), 10 ** (9.5)]  # in K
 bins = 256
 
@@ -64,7 +64,11 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_dust.py
+++ b/colibre/scripts/density_temperature_dust.py
@@ -10,7 +10,7 @@ from unyt import mh, cm, unyt_array
 from matplotlib.colors import Normalize
 
 # Set the limits of the figure.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 dustfracs_bounds = [-5, -1]  # dimensionless (dust mass / gas mass)
 min_dustfracs = dustfracs_bounds[0]
@@ -84,7 +84,11 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -205,7 +209,9 @@ def make_single_image(
         axis.set_ylim(*temperature_bounds)
 
     fig.colorbar(
-        mappable, ax=ax.ravel().tolist(), label="Mean (Logarithmic) Dust Mass Fraction",
+        mappable,
+        ax=ax.ravel().tolist(),
+        label="Mean (Logarithmic) Dust Mass Fraction",
     )
 
     fig.savefig(f"{output_path}/{prefix_T}density_temperature_dust.png")

--- a/colibre/scripts/density_temperature_dust2metal.py
+++ b/colibre/scripts/density_temperature_dust2metal.py
@@ -13,7 +13,7 @@ from matplotlib.colors import LogNorm
 from matplotlib.animation import FuncAnimation
 
 # Set the limits of the figure.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** (0), 10 ** (9.5)]  # in K
 DTMs_bounds = [2e-2, 1]  # In metal mass fraction
 min_DTMs = DTMs_bounds[0]
@@ -91,7 +91,11 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_dust_to_metals.py
+++ b/colibre/scripts/density_temperature_dust_to_metals.py
@@ -11,7 +11,7 @@ from unyt import mh, cm, unyt_array
 from matplotlib.colors import LogNorm
 
 # Constants; these could be put in the parameter file but are rarely changed.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 dtm_bounds = [1e-3, 1e-1]
 min_metallicity = 1e-8
@@ -93,7 +93,11 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -183,7 +187,10 @@ def make_single_image(
 
     for filename, hist, name, axis in zip(filenames, hists, names, ax.flat):
         mappable = axis.pcolormesh(
-            d, T, hist, norm=LogNorm(vmin=dtm_bounds[0], vmax=dtm_bounds[1]),
+            d,
+            T,
+            hist,
+            norm=LogNorm(vmin=dtm_bounds[0], vmax=dtm_bounds[1]),
         )
         axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
         metadata = load(filename).metadata
@@ -192,7 +199,9 @@ def make_single_image(
         axis.set_ylim(*temperature_bounds)
 
     fig.colorbar(
-        mappable, ax=ax.ravel().tolist(), label="Mean Dust / Metals Ratio []",
+        mappable,
+        ax=ax.ravel().tolist(),
+        label="Mean Dust / Metals Ratio []",
     )
 
     fig.savefig(f"{output_path}/density_temperature_dust_to_metals.png")

--- a/colibre/scripts/density_temperature_metals.py
+++ b/colibre/scripts/density_temperature_metals.py
@@ -11,7 +11,7 @@ from unyt import mh, cm, unyt_array
 from matplotlib.colors import Normalize
 
 # Constants; these could be put in the parameter file but are rarely changed.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 metallicity_bounds = [-6, -1]  # In metal mass fraction
 min_metallicity = 1e-8
@@ -76,7 +76,11 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_sf_fraction.py
+++ b/colibre/scripts/density_temperature_sf_fraction.py
@@ -12,7 +12,7 @@ from unyt import mh, cm, unyt_array
 from matplotlib.colors import Normalize
 
 # Constants; these could be put in the parameter file but are rarely changed.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 sf_mass_fraction_bounds = [-2.5, 0]  # log mass fraction of star-forming gas
 min_sf_mass_fraction = 1e-6  # Minimal mass fraction of star-forming gas

--- a/colibre/scripts/density_temperature_species.py
+++ b/colibre/scripts/density_temperature_species.py
@@ -11,7 +11,7 @@ from unyt import mh, cm, unyt_array
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
 temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 specfracs_bounds = [1e-2, 1]  # dimensionless
 min_specfracs = specfracs_bounds[0]
@@ -92,7 +92,11 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/last_AGN_density_distribution.py
+++ b/colibre/scripts/last_AGN_density_distribution.py
@@ -87,7 +87,7 @@ data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
 number_of_bins = 256
 
 AGN_density_bins = unyt.unyt_array(
-    np.logspace(-5, 6.5, number_of_bins), units="1/cm**3"
+    np.logspace(-5.0, 7.0, number_of_bins), units="1/cm**3"
 )
 log_AGN_density_bin_width = np.log10(AGN_density_bins[1].value) - np.log10(
     AGN_density_bins[0].value
@@ -179,7 +179,10 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         y_points = H / log_AGN_density_bin_width / Num_of_heated_parts_total
 
         ax.plot(
-            AGN_density_centers, y_points, label=name, color=f"C{color}",
+            AGN_density_centers,
+            y_points,
+            label=name,
+            color=f"C{color}",
         )
         ax.axvline(
             np.median(data),
@@ -191,7 +194,11 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
 
         # Add the DV&S2012 line
         ax.axvline(
-            n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5,
+            n_crit,
+            color=f"C{color}",
+            linestyle="dotted",
+            zorder=-10,
+            alpha=0.5,
         )
 
 axes[0].legend(loc="upper right", markerfirst=False)

--- a/colibre/scripts/last_SNII_density_distribution.py
+++ b/colibre/scripts/last_SNII_density_distribution.py
@@ -5,6 +5,7 @@ Plots the SNII density distribution (at last SNII thermal injections).
 import matplotlib.pyplot as plt
 import numpy as np
 import unyt
+import traceback
 
 from unyt import mh
 
@@ -87,7 +88,7 @@ data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
 number_of_bins = 256
 
 SNII_density_bins = unyt.unyt_array(
-    np.logspace(-5, 6.5, number_of_bins), units="1/cm**3"
+    np.logspace(-5.0, 7.0, number_of_bins), units="1/cm**3"
 )
 log_SNII_density_bin_width = np.log10(SNII_density_bins[1].value) - np.log10(
     SNII_density_bins[0].value
@@ -165,17 +166,42 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         "$z > 3$": gas_SNII_densities[gas_SNII_redshifts > 3],
     }
 
-    # Compute the critical density from DV&S2012
-    SNII_heating_temperature = float(
-        snapshot.metadata.parameters["COLIBREFeedback:SNII_delta_T_K"].decode("utf-8")
-    )  # in K
-    N_ngb_target = snapshot.metadata.hydro_scheme["Kernel target N_ngb"][0]
-    X_H = snapshot.metadata.hydro_scheme["Hydrogen mass fraction"][0]
-    M_gas = snapshot.metadata.initial_mass_table.gas.to("Msun")  # in Solar Masses
+    # Compute the critical density from DV&S201
+    try:
+        SNII_heating_temperature_min = float(
+            snapshot.metadata.parameters["COLIBREFeedback:SNII_delta_T_K_min"].decode(
+                "utf-8"
+            )
+        )  # in K
+        SNII_heating_temperature_max = float(
+            snapshot.metadata.parameters["COLIBREFeedback:SNII_delta_T_K_max"].decode(
+                "utf-8"
+            )
+        )  # in K
+        N_ngb_target = snapshot.metadata.hydro_scheme["Kernel target N_ngb"][0]
+        X_H = snapshot.metadata.hydro_scheme["Hydrogen mass fraction"][0]
+        M_gas = snapshot.metadata.initial_mass_table.gas.to("Msun")  # in Solar Masses
 
-    n_crit = critical_density_DVS2012(
-        T_K=SNII_heating_temperature, M_gas=M_gas.value, N_ngb=N_ngb_target, X_H=X_H
-    )
+        # Critical density corresponding to minimum heating temperature
+        n_crit_min = critical_density_DVS2012(
+            T_K=SNII_heating_temperature_min,
+            M_gas=M_gas.value,
+            N_ngb=N_ngb_target,
+            X_H=X_H,
+        )
+        # Critical density corresponding to maximum heating temperature
+        n_crit_max = critical_density_DVS2012(
+            T_K=SNII_heating_temperature_max,
+            M_gas=M_gas.value,
+            N_ngb=N_ngb_target,
+            X_H=X_H,
+        )
+
+    # Cannot find argument(s)
+    except KeyError:
+        print(traceback.format_exc())
+        # Default value
+        n_crit_min, n_crit_max = -1.0, -1.0
 
     # Total number of objects received SNII thermal energy
     Num_of_heated_parts_total = len(gas_SNII_redshifts) + len(stars_SNII_redshifts)
@@ -192,7 +218,10 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         y_points = H / log_SNII_density_bin_width / Num_of_heated_parts_total
 
         ax.plot(
-            SNII_density_centers, y_points, label=name, color=f"C{color}",
+            SNII_density_centers,
+            y_points,
+            label=name,
+            color=f"C{color}",
         )
         ax.axvline(
             np.median(data),
@@ -202,10 +231,16 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
             alpha=0.5,
         )
 
-        # Add the DV&S2012 line
-        ax.axvline(
-            n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5,
-        )
+        # Add the DV&S2012 lines corresponding to min and max heating temperatures
+        for n_crit in [n_crit_min, n_crit_max]:
+            if n_crit > 0.0:
+                ax.axvline(
+                    n_crit,
+                    color=f"C{color}",
+                    linestyle="dotted",
+                    zorder=-10,
+                    alpha=0.5,
+                )
 
 axes[0].legend(loc="upper right", markerfirst=False)
 axes[2].set_xlabel(


### PR DESCRIPTION
- Extend plot ranges in plots with gas density
- Fix **KeyError** bug in density distribution plots (missing attribute)
- Format with `python3.8 -m black`