### PR TITLE
Replaced 100kpc apertures with 50kpc apertures in COLIBRE pipeline.

### DIFF
--- a/colibre-zooms/auto_plotter/ages.yml
+++ b/colibre-zooms/auto_plotter/ages.yml
@@ -30,7 +30,7 @@ stellar_mass_ages_30:
   observational_data:
     - filename: GalaxyStellarMassStellarAges/Gallazzi2005_Data.hdf5
 
-stellar_mass_ages_100:
+stellar_mass_ages_50:
   type: "scatter"
   legend_loc: "lower right"
   y:
@@ -39,7 +39,7 @@ stellar_mass_ages_100:
     start: 1e8
     end: 3e10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e7
     end: 1e12
@@ -55,8 +55,8 @@ stellar_mass_ages_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Stellar age relation (100 kpc aperture)"
+    title: "Stellar mass - Stellar age relation (50 kpc aperture)"
     section: Ages
-    caption: Median age of stars within the 100 kpc 3D aperture of each galaxy.
+    caption: Median age of stars within the 50 kpc 3D aperture of each galaxy.
   observational_data:
     - filename: GalaxyStellarMassStellarAges/Gallazzi2005_Data.hdf5

--- a/colibre-zooms/auto_plotter/black_holes.yml
+++ b/colibre-zooms/auto_plotter/black_holes.yml
@@ -33,11 +33,11 @@ stellar_mass_black_hole_mass_30:
     - filename: GalaxyStellarMassBlackHoleMass/McConnell2013_Fit.hdf5
 
 
-stellar_mass_black_hole_mass_100:
+stellar_mass_black_hole_mass_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
@@ -58,7 +58,7 @@ stellar_mass_black_hole_mass_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Black Hole Mass relation (100 kpc Stellar Mass)
+    title: Stellar Mass-Black Hole Mass relation (50 kpc Stellar Mass)
     caption: SMBHM relation. Note that the stellar velocity dispersion is measured in observations in a fixed 1 kpc aperture
     section: Black Holes
   observational_data:
@@ -123,7 +123,7 @@ stellar_veldisp_black_hole_mass_10:
       units: km/s
   metadata:
     title: LOS Stellar Velocity Dispersion-Black Hole Mass relation (10 kpc)
-    caption: The 3D stellar velocity dispersion is converted into a LOS velocity dispersion using a $1/\sqrt{3}$ correction factor. Note that the stellar velocity dispersion is measured in observations in a fixed 1 kpc aperture
+    caption: The 3D stellar velocity dispersion is converted into a LOS velocity dispersion using a $1/\sqrt{3}$ correction factor. Note that the stellar velocity dispersion in observations is measured in a fixed 1 kpc aperture.
     section: Black Holes
   observational_data:
     - filename: StellarVelocityDispersionBlackHoleMass/Sahu2019.hdf5
@@ -155,7 +155,7 @@ stellar_veldisp_black_hole_mass_30:
       units: km/s
   metadata:
     title: LOS Stellar Velocity Dispersion-Black Hole Mass relation (30 kpc)
-    caption: The 3D stellar velocity dispersion is converted into a LOS velocity dispersion using a $1/\sqrt{3}$ correction factor. Note that the stellar velocity dispersion is measured in observations in a fixed 1 kpc aperture
+    caption: The 3D stellar velocity dispersion is converted into a LOS velocity dispersion using a $1/\sqrt{3}$ correction factor. Note that the stellar velocity dispersion in observations is measured in a fixed 1 kpc aperture.
     section: Black Holes
     show_on_webpage: false
   observational_data:

--- a/colibre-zooms/auto_plotter/cold_gas_relations.yml
+++ b/colibre-zooms/auto_plotter/cold_gas_relations.yml
@@ -1,7 +1,7 @@
 stellar_mass_molecular_to_neutral_fraction_30:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
@@ -60,16 +60,16 @@ stellar_mass_neutral_to_stellar_fraction_30:
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
 
-stellar_mass_neutral_to_stellar_fraction_100:
+stellar_mass_neutral_to_stellar_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_neutral_H_to_stellar_fraction_100_kpc"
+    quantity: "derived_quantities.gas_neutral_H_to_stellar_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 3.
@@ -85,8 +85,8 @@ stellar_mass_neutral_to_stellar_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Neutral To Stellar Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Gas fraction is HI + H$_2$ mass divided by stellar mass in a 100 kpc aperture.
+    title: Stellar Mass-Neutral To Stellar Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Gas fraction is HI + H$_2$ mass divided by stellar mass in a 50 kpc aperture.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
 
@@ -120,16 +120,16 @@ stellar_mass_molecular_to_stellar_plus_molecular_fraction_30:
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
 
-stellar_mass_molecular_to_stellar_plus_molecular_fraction_100:
+stellar_mass_molecular_to_stellar_plus_molecular_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_molecular_H_to_molecular_plus_stellar_fraction_100_kpc"
+    quantity: "derived_quantities.gas_molecular_H_to_molecular_plus_stellar_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 3.
@@ -145,8 +145,8 @@ stellar_mass_molecular_to_stellar_plus_molecular_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Molecular Gas To Molecular Plus Stellar Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Gas fraction is H$_2$ mass divided by H$_2$ mass + stellar mass in a 100 kpc aperture.
+    title: Stellar Mass-Molecular Gas To Molecular Plus Stellar Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Gas fraction is H$_2$ mass divided by H$_2$ mass + stellar mass in a 50 kpc aperture.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
 
@@ -180,17 +180,17 @@ stellar_mass_H2_mass_30:
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
 
-stellar_mass_H2_mass_100:
+stellar_mass_H2_mass_50:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_H2_mass_100_kpc"
+    quantity: "derived_quantities.gas_H2_mass_50_kpc"
     units: "Solar_Mass"
     start: 1e5
     end: 1e11
@@ -206,7 +206,7 @@ stellar_mass_H2_mass_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-H$_2$ Gas Mass (100 kpc aperture)
+    title: Stellar Mass-H$_2$ Gas Mass (50 kpc aperture)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -214,7 +214,7 @@ stellar_mass_H2_mass_100:
 stellar_mass_HI_mass_30:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
@@ -242,17 +242,17 @@ stellar_mass_HI_mass_30:
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
 
-stellar_mass_HI_mass_100:
+stellar_mass_HI_mass_50:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_HI_mass_100_kpc"
+    quantity: "derived_quantities.gas_HI_mass_50_kpc"
     units: "Solar_Mass"
     start: 1e5
     end: 1e11
@@ -268,7 +268,7 @@ stellar_mass_HI_mass_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-HI Gas Mass (100 kpc aperture)
+    title: Stellar Mass-HI Gas Mass (50 kpc aperture)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -276,7 +276,7 @@ stellar_mass_HI_mass_100:
 H2_mass_star_formation_rate_30:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
     quantity: "derived_quantities.gas_H2_mass_30_kpc"
     units: "Solar_Mass"
@@ -286,7 +286,7 @@ H2_mass_star_formation_rate_30:
     quantity: "derived_quantities.specific_sfr_gas_30_kpc"
     units: 1 / gigayear
     start: 0.01
-    end: 100
+    end: 50
   median:
     plot: true
     log: true
@@ -304,20 +304,20 @@ H2_mass_star_formation_rate_30:
     section: Cold Gas Relations (Gas Mass)
     show_on_webpage: false
 
-H2_mass_star_formation_rate_100:
+H2_mass_star_formation_rate_50:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.gas_H2_mass_100_kpc"
+    quantity: "derived_quantities.gas_H2_mass_50_kpc"
     units: "Solar_Mass"
     start: 1e5
     end: 1e11
   y:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 0.01
-    end: 100
+    end: 50
   median:
     plot: true
     log: true
@@ -330,21 +330,21 @@ H2_mass_star_formation_rate_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: H$_2$ Gas Mass - Star Formation Rate (100 kpc)
+    title: H$_2$ Gas Mass - Star Formation Rate (50 kpc)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Gas Mass)
     show_on_webpage: false
 
-stellar_mass_neutral_H_to_baryonic_fraction_100:
+stellar_mass_neutral_H_to_baryonic_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_neutral_H_to_baryonic_fraction_100_kpc"
+    quantity: "derived_quantities.gas_neutral_H_to_baryonic_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -366,21 +366,21 @@ stellar_mass_neutral_H_to_baryonic_fraction_100:
       value: 1e99
       units: "dimensionless"
   metadata:
-    title: Stellar Mass-Neutral Gas to Baryonic Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI + H$_2$ mass over total baryonic mass in a 100 kpc aperture.
+    title: Stellar Mass-Neutral Gas to Baryonic Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI + H$_2$ mass over total baryonic mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
 
-stellar_mass_HI_to_neutral_H_fraction_100:
+stellar_mass_HI_to_neutral_H_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_HI_to_neutral_H_fraction_100_kpc"
+    quantity: "derived_quantities.gas_HI_to_neutral_H_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-1
     end: 1.1
@@ -396,21 +396,21 @@ stellar_mass_HI_to_neutral_H_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-HI to Neutral Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI mass over HI + H$_2$ mass in a 100 kpc aperture.
+    title: Stellar Mass-HI to Neutral Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI mass over HI + H$_2$ mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
 
-stellar_mass_H2_to_neutral_H_fraction_100:
+stellar_mass_H2_to_neutral_H_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_100_kpc"
+    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -426,20 +426,20 @@ stellar_mass_H2_to_neutral_H_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-H$_2$ to Neutral Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is H$_2$ mass over HI + H$_2$ mass in a 100 kpc aperture.
+    title: Stellar Mass-H$_2$ to Neutral Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is H$_2$ mass over HI + H$_2$ mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
 
-stellar_mass_sf_to_sf_plus_stellar_fraction_100:
+stellar_mass_sf_to_sf_plus_stellar_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_sf_to_sf_plus_stellar_fraction_100_kpc"
+    quantity: "derived_quantities.gas_sf_to_sf_plus_stellar_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -455,53 +455,22 @@ stellar_mass_sf_to_sf_plus_stellar_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-SF gas to SF Gas + Stellar Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is star-forming gas mass over SF gas + stellar mass in a 100 kpc aperture.
+    title: Stellar Mass-SF gas to SF Gas + Stellar Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is star-forming gas mass over SF gas + stellar mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
     show_on_webpage: false
 
-stellar_mass_neutral_H_to_sf_fraction_100:
+stellar_mass_neutral_H_to_sf_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_neutral_H_to_sf_fraction_100_kpc"
-    units: "dimensionless"
-    start: 1e-1
-    end: 10.
-  median:
-    plot: true
-    log: true
-    adaptive: true
-    number_of_bins: 35
-    start:
-      value: 1e5
-      units: Solar_Mass
-    end:
-      value: 1e12
-      units: Solar_Mass
-  metadata:
-    title: Stellar Mass-Neutral to SF Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI + H$_2$ gas mass over SF gas in a 100 kpc aperture.
-    section: Cold Gas Fractions (Stellar Mass)
-    show_on_webpage: false
-
-stellar_mass_HI_to_sf_fraction_100:
-  type: "scatter"
-  legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
-  x:
-    quantity: "apertures.mass_star_100_kpc"
-    units: Solar_Mass
-    start: 1e5
-    end: 1e12
-  y:
-    quantity: "derived_quantities.gas_HI_to_sf_fraction_100_kpc"
+    quantity: "derived_quantities.gas_neutral_H_to_sf_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-1
     end: 10.
@@ -517,22 +486,53 @@ stellar_mass_HI_to_sf_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-HI to SF Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI gas mass over SF gas in a 100 kpc aperture.
+    title: Stellar Mass-Neutral to SF Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI + H$_2$ gas mass over SF gas in a 50 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
     show_on_webpage: false
 
-stellar_mass_H2_to_sf_fraction_100:
+stellar_mass_HI_to_sf_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_H2_to_sf_fraction_100_kpc"
+    quantity: "derived_quantities.gas_HI_to_sf_fraction_50_kpc"
+    units: "dimensionless"
+    start: 1e-1
+    end: 10.
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 35
+    start:
+      value: 1e5
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-HI to SF Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI gas mass over SF gas in a 50 kpc aperture.
+    section: Cold Gas Fractions (Stellar Mass)
+    show_on_webpage: false
+
+stellar_mass_H2_to_sf_fraction_50:
+  type: "scatter"
+  legend_loc: "upper right"
+  selection_mask: "derived_quantities.is_active_50_kpc"
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 1e5
+    end: 1e12
+  y:
+    quantity: "derived_quantities.gas_H2_to_sf_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 10.
@@ -548,21 +548,21 @@ stellar_mass_H2_to_sf_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-H$_2$ to SF Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is H$_2$ gas mass over SF gas in a 100 kpc aperture.
+    title: Stellar Mass-H$_2$ to SF Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is H$_2$ gas mass over SF gas in a 50 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
 
-sfr_neutral_to_stellar_mass_100_kpc_100:
+sfr_neutral_to_stellar_mass_50_kpc_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-3
     end: 10
   y:
-    quantity: "derived_quantities.neutral_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.neutral_to_stellar_mass_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 10
@@ -578,21 +578,21 @@ sfr_neutral_to_stellar_mass_100_kpc_100:
       value: 10
       units: 1 / gigayear
   metadata:
-    title: sSFR-Neutral Gas to SF Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI + H$_2$ mass over stellar mass in a 100 kpc aperture.
+    title: sSFR-Neutral Gas to SF Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI + H$_2$ mass over stellar mass in a 50 kpc aperture.
     section: Cold Gas Fractions (sSFR)
 
-sfr_hi_to_stellar_mass_100_kpc_100:
+sfr_hi_to_stellar_mass_50_kpc_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-3
     end: 10
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 10
@@ -608,21 +608,21 @@ sfr_hi_to_stellar_mass_100_kpc_100:
       value: 10
       units: 1 / gigayear
   metadata:
-    title: sSFR-HI Gas to SF Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI mass over stellar mass in a 100 kpc aperture.
+    title: sSFR-HI Gas to SF Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI mass over stellar mass in a 50 kpc aperture.
     section: Cold Gas Fractions (sSFR)
 
-sfr_h2_to_stellar_mass_100_kpc_100:
+sfr_h2_to_stellar_mass_50_kpc_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-3
     end: 10
   y:
-    quantity: "derived_quantities.h2_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_to_stellar_mass_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -638,22 +638,22 @@ sfr_h2_to_stellar_mass_100_kpc_100:
       value: 10
       units: 1 / gigayear
   metadata:
-    title: sSFR-H$_2$ Gas to SF Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is H$_2$ mass over stellar mass in a 100 kpc aperture.
+    title: sSFR-H$_2$ Gas to SF Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is H$_2$ mass over stellar mass in a 50 kpc aperture.
     section: Cold Gas Fractions (sSFR)
 
 
-sfr_sf_to_stellar_fraction_kpc_100:
+sfr_sf_to_stellar_fraction_kpc_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-3
     end: 10
   y:
-    quantity: "derived_quantities.gas_sf_to_stellar_fraction_100_kpc"
+    quantity: "derived_quantities.gas_sf_to_stellar_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 10
@@ -669,21 +669,21 @@ sfr_sf_to_stellar_fraction_kpc_100:
       value: 10
       units: 1 / gigayear
   metadata:
-    title: sSFR-SF Gas to Stellar Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is SF gas mass over stellar mass in a 100 kpc aperture.
+    title: sSFR-SF Gas to Stellar Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is SF gas mass over stellar mass in a 50 kpc aperture.
     section: Cold Gas Fractions (sSFR)
     show_on_webpage: false
 
-sigma_neutral_H_to_baryonic_fraction_100:
+sigma_neutral_H_to_baryonic_fraction_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "derived_quantities.mu_star_100_kpc"
+    quantity: "derived_quantities.mu_star_50_kpc"
     units: "Solar_Mass / kpc**2"
     start: 1e5
     end: 1e10
   y:
-    quantity: "derived_quantities.gas_neutral_H_to_baryonic_fraction_100_kpc"
+    quantity: "derived_quantities.gas_neutral_H_to_baryonic_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -699,23 +699,23 @@ sigma_neutral_H_to_baryonic_fraction_100:
       value: 1e10
       units: "Solar_Mass / kpc**2"
   metadata:
-    title: Surface Density-Neutral Gas to Baryonic Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is neutral gas mass over baryonic mass in a 100 kpc aperture.
+    title: Surface Density-Neutral Gas to Baryonic Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is neutral gas mass over baryonic mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
     show_on_webpage: false
 
 
-sigma_hi_to_neutral_H_fraction_100:
+sigma_hi_to_neutral_H_fraction_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.mu_star_100_kpc"
+    quantity: "derived_quantities.mu_star_50_kpc"
     units: "Solar_Mass / kpc**2"
     start: 1e5
     end: 1e10
   y:
-    quantity: "derived_quantities.gas_HI_to_neutral_H_fraction_100_kpc"
+    quantity: "derived_quantities.gas_HI_to_neutral_H_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-1
     end: 1.1
@@ -731,22 +731,22 @@ sigma_hi_to_neutral_H_fraction_100:
       value: 1e10
       units: "Solar_Mass / kpc**2"
   metadata:
-    title: Surface Density-HI Gas to Neutral Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI gas mass over neutral gas mass in a 100 kpc aperture.
+    title: Surface Density-HI Gas to Neutral Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI gas mass over neutral gas mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
     show_on_webpage: false
 
-sigma_h2_to_neutral_H_fraction_100:
+sigma_h2_to_neutral_H_fraction_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.mu_star_100_kpc"
+    quantity: "derived_quantities.mu_star_50_kpc"
     units: "Solar_Mass / kpc**2"
     start: 1e5
     end: 1e10
   y:
-    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_100_kpc"
+    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -762,21 +762,21 @@ sigma_h2_to_neutral_H_fraction_100:
       value: 1e10
       units: "Solar_Mass / kpc**2"
   metadata:
-    title: Surface Density-H$_2$ Gas to Neutral Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is H$_2$ gas mass over neutral gas mass in a 100 kpc aperture.
+    title: Surface Density-H$_2$ Gas to Neutral Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is H$_2$ gas mass over neutral gas mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
     show_on_webpage: false
 
-sigma_sf_to_sf_plus_stellar_fraction_100:
+sigma_sf_to_sf_plus_stellar_fraction_50:
   type: "scatter"
   legend_loc: "upper left"  
   x:
-    quantity: "derived_quantities.mu_star_100_kpc"
+    quantity: "derived_quantities.mu_star_50_kpc"
     units: "Solar_Mass / kpc**2"
     start: 1e5
     end: 1e10
   y:
-    quantity: "derived_quantities.gas_sf_to_sf_plus_stellar_fraction_100_kpc"
+    quantity: "derived_quantities.gas_sf_to_sf_plus_stellar_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -792,7 +792,7 @@ sigma_sf_to_sf_plus_stellar_fraction_100:
       value: 1e10
       units: "Solar_Mass / kpc**2"
   metadata:
-    title: Surface Density-SF Gas to SF Gas + Stellar Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is SF gas mass over SF gas mass + Stellar mass in a 100 kpc aperture.
+    title: Surface Density-SF Gas to SF Gas + Stellar Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is SF gas mass over SF gas mass + Stellar mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
     show_on_webpage: false

--- a/colibre-zooms/auto_plotter/depletion_relations.yml
+++ b/colibre-zooms/auto_plotter/depletion_relations.yml
@@ -1,15 +1,15 @@
 oxygen_abundance_v_dust_to_gas:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.gas_o_abundance_avglog_low_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_avglog_low_50_kpc"
     units: "dimensionless"
     start: 6.8
     end: 9.2
     log: false
   y:
-    quantity: "derived_quantities.dust_to_gas_ratio_100_kpc"
+    quantity: "derived_quantities.dust_to_gas_ratio_50_kpc"
     units: "dimensionless"
     start: 1e-7
     end: 0.01
@@ -31,7 +31,7 @@ oxygen_abundance_v_dust_to_gas:
       value: 1
       units: "dimensionless"
   metadata:
-    title:  Oxygen abundance vs dust-to-gas ratio (100 kpc aperture)
+    title:  Oxygen abundance vs dust-to-gas ratio (50 kpc aperture)
     caption: Dust-to-gas mass ratio as a function of oxygen number density abundance.
     section: Dust Depletion Relations
     show_on_webpage: true

--- a/colibre-zooms/auto_plotter/dust_scaling_relations.yml
+++ b/colibre-zooms/auto_plotter/dust_scaling_relations.yml
@@ -1,15 +1,15 @@
 hi_stellar_fraction_dust_to_metal_ratio:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.dust_to_metal_ratio_100_kpc"
+    quantity: "derived_quantities.dust_to_metal_ratio_50_kpc"
     units: "dimensionless"
     start: 1e-3
     end: 5
     log: true
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "dimensionless"
     start: 3e-2
     end: 5
@@ -27,7 +27,7 @@ hi_stellar_fraction_dust_to_metal_ratio:
       units: "dimensionless"
   metadata:
     title: HI-to-stellar mass ratio vs dust-to-metal ratio
-    caption: HI to stellar mass ratio as a function of the dust-to-metal ratio measured in 100kpc apertures
+    caption: HI to stellar mass ratio as a function of the dust-to-metal ratio measured in 50kpc apertures
     section: Dust Scaling Relations
     show_on_webpage: true
   observational_data:
@@ -36,15 +36,15 @@ hi_stellar_fraction_dust_to_metal_ratio:
 hi_stellar_fraction_dust_to_stellar_ratio:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.dust_to_stellar_ratio_100_kpc"
+    quantity: "derived_quantities.dust_to_stellar_ratio_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1e-2
     log: true
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "dimensionless"
     start: 3e-2
     end: 5
@@ -62,7 +62,7 @@ hi_stellar_fraction_dust_to_stellar_ratio:
       units: "dimensionless"
   metadata:
     title: HI-to-stellar mass ratio vs dust-to-stellar mass ratio
-    caption: HI to stellar mass ratio as a function of the dust-to-stellar mass ratio measured in 100kpc apertures
+    caption: HI to stellar mass ratio as a function of the dust-to-stellar mass ratio measured in 50kpc apertures
     section: Dust Scaling Relations
     show_on_webpage: true
   observational_data:
@@ -71,15 +71,15 @@ hi_stellar_fraction_dust_to_stellar_ratio:
 hi_stellar_fraction_o_abundance:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.gas_o_abundance_avglog_low_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_avglog_low_50_kpc"
     units: "dimensionless"
     start: 6.8
     end: 9.2
     log: false
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "dimensionless"
     start: 3e-2
     end: 5
@@ -97,7 +97,7 @@ hi_stellar_fraction_o_abundance:
       units: "dimensionless"
   metadata:
     title: HI-to-stellar mass ratio vs Oxygen abundance
-    caption: HI to stellar mass ratio as a function of the gas-phase Oxygen abundance measured in 100 kpc apertures
+    caption: HI to stellar mass ratio as a function of the gas-phase Oxygen abundance measured in 50 kpc apertures
     section: Dust Scaling Relations
     show_on_webpage: true
   observational_data:

--- a/colibre-zooms/auto_plotter/feedback_densities.yml
+++ b/colibre-zooms/auto_plotter/feedback_densities.yml
@@ -27,11 +27,11 @@ snii_thermal_feedback_density_halo_mass_max_all:
     caption: Includes all haloes, including subhaloes.
     section: Feedback Densities
 
-snii_thermal_feedback_density_stellar_mass_max_all_100:
+snii_thermal_feedback_density_stellar_mass_max_all_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e4
     end: 1e12

--- a/colibre-zooms/auto_plotter/galaxy_sizes.yml
+++ b/colibre-zooms/auto_plotter/galaxy_sizes.yml
@@ -1,13 +1,13 @@
-stellar_mass_galaxy_size_100:
+stellar_mass_galaxy_size_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "apertures.rhalfmass_star_100_kpc"
+    quantity: "apertures.rhalfmass_star_50_kpc"
     units: kpc
     start: 3e-1
     end: 3e1
@@ -23,8 +23,8 @@ stellar_mass_galaxy_size_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Galaxy Size relation (100 kpc aperture)
-    caption: Uses a 100 kpc 3D aperture.
+    title: Stellar Mass-Galaxy Size relation (50 kpc aperture)
+    caption: Uses a 50 kpc 3D aperture.
     section: Sizes
   observational_data:
     - filename: GalaxyStellarMassGalaxySize/Trujillo2020.hdf5
@@ -63,16 +63,16 @@ stellar_mass_galaxy_size_30:
     - filename: GalaxyStellarMassGalaxySize/Trujillo2020.hdf5
     - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p1.hdf5
 
-stellar_mass_projected_galaxy_size_100:
+stellar_mass_projected_galaxy_size_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "projected_apertures.projected_1_rhalfmass_star_100_kpc"
+    quantity: "projected_apertures.projected_1_rhalfmass_star_50_kpc"
     units: kpc
     start: 1e-1
     end: 3e1
@@ -88,8 +88,8 @@ stellar_mass_projected_galaxy_size_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-(Projected) Galaxy Size relation (100 kpc aperture)
-    caption: Uses stellar sizes calculated from a projected distribution within a 100 kpc aperture.
+    title: Stellar Mass-(Projected) Galaxy Size relation (50 kpc aperture)
+    caption: Uses stellar sizes calculated from a projected distribution within a 50 kpc aperture.
     section: Sizes
   observational_data:
     - filename: GalaxyStellarMassGalaxySize/Lange2015HBand.hdf5
@@ -122,7 +122,7 @@ stellar_mass_projected_galaxy_size_30:
       units: Solar_Mass
   metadata:
     title: Stellar Mass-(Projected) Galaxy Size relation (30 kpc aperture)
-    caption: Uses stellar sizes calculated from a projected distribution within a 100 kpc aperture.
+    caption: Uses stellar sizes calculated from a projected distribution within a 50 kpc aperture.
     section: Sizes
     show_on_webpage: false
   observational_data:
@@ -130,19 +130,19 @@ stellar_mass_projected_galaxy_size_30:
     - filename: GalaxyStellarMassGalaxySize/Lange2015rBand.hdf5
     - filename: GalaxyStellarMassGalaxySize/xGASS.hdf5
 
-stellar_mass_projected_galaxy_size_active_only_100:
+stellar_mass_projected_galaxy_size_active_only_50:
   type: "scatter"
   comment: "Active only"
   comment_loc: "lower left"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "projected_apertures.projected_1_rhalfmass_star_100_kpc"
+    quantity: "projected_apertures.projected_1_rhalfmass_star_50_kpc"
     units: kpc
     start: 1e-1
     end: 3e1
@@ -158,13 +158,12 @@ stellar_mass_projected_galaxy_size_active_only_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-(Projected) Galaxy Size relation (100 kpc aperture)
+    title: Stellar Mass-(Projected) Galaxy Size relation (50 kpc aperture)
     caption: Only shows active galaxies defined based on their sSFRs.
     section: Sizes
   observational_data:
-    - filename: GalaxyStellarMassGalaxySize/Lange2015HBand.hdf5
-    - filename: GalaxyStellarMassGalaxySize/Lange2015rBand.hdf5
-    - filename: GalaxyStellarMassGalaxySize/xGASS.hdf5
+    - filename: GalaxyStellarMassGalaxySize/VanDerWel_blue.hdf5
+    - filename: GalaxyStellarMassGalaxySize/Lange2015HBand_blue.hdf5
     - filename: GalaxyStellarMassGalaxySize/Mosleh2020_SF.hdf5
 
 stellar_mass_projected_galaxy_size_active_only_30:
@@ -200,24 +199,23 @@ stellar_mass_projected_galaxy_size_active_only_30:
     section: Sizes
     show_on_webpage: false
   observational_data:
-    - filename: GalaxyStellarMassGalaxySize/Lange2015HBand.hdf5
-    - filename: GalaxyStellarMassGalaxySize/Lange2015rBand.hdf5
-    - filename: GalaxyStellarMassGalaxySize/xGASS.hdf5
+    - filename: GalaxyStellarMassGalaxySize/VanDerWel_blue.hdf5
+    - filename: GalaxyStellarMassGalaxySize/Lange2015HBand_blue.hdf5
     - filename: GalaxyStellarMassGalaxySize/Mosleh2020_SF.hdf5
 
-stellar_mass_projected_galaxy_size_passive_only_100:
+stellar_mass_projected_galaxy_size_passive_only_50:
   type: "scatter"
   comment: "Passive only"
   comment_loc: "lower left"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_passive_100_kpc"
+  selection_mask: "derived_quantities.is_passive_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "projected_apertures.projected_1_rhalfmass_star_100_kpc"
+    quantity: "projected_apertures.projected_1_rhalfmass_star_50_kpc"
     units: kpc
     start: 1e-1
     end: 3e1
@@ -233,13 +231,12 @@ stellar_mass_projected_galaxy_size_passive_only_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-(Projected) Galaxy Size relation (100 kpc aperture)
+    title: Stellar Mass-(Projected) Galaxy Size relation (50 kpc aperture)
     caption: Only shows passive galaxies defined based on their sSFRs.
     section: Sizes
   observational_data:
-    - filename: GalaxyStellarMassGalaxySize/Lange2015HBand.hdf5
-    - filename: GalaxyStellarMassGalaxySize/Lange2015rBand.hdf5
-    - filename: GalaxyStellarMassGalaxySize/xGASS.hdf5
+    - filename: GalaxyStellarMassGalaxySize/VanDerWel_red.hdf5
+    - filename: GalaxyStellarMassGalaxySize/Lange2015HBand_red.hdf5
     - filename: GalaxyStellarMassGalaxySize/Mosleh2020_Q.hdf5
 
 stellar_mass_projected_galaxy_size_passive_only_30:
@@ -275,8 +272,7 @@ stellar_mass_projected_galaxy_size_passive_only_30:
     section: Sizes
     show_on_webpage: false
   observational_data:
-    - filename: GalaxyStellarMassGalaxySize/Lange2015HBand.hdf5
-    - filename: GalaxyStellarMassGalaxySize/Lange2015rBand.hdf5
-    - filename: GalaxyStellarMassGalaxySize/xGASS.hdf5
+    - filename: GalaxyStellarMassGalaxySize/VanDerWel_red.hdf5
+    - filename: GalaxyStellarMassGalaxySize/Lange2015HBand_red.hdf5
     - filename: GalaxyStellarMassGalaxySize/Mosleh2020_Q.hdf5
 

--- a/colibre-zooms/auto_plotter/gas_fraction_plots.yml
+++ b/colibre-zooms/auto_plotter/gas_fraction_plots.yml
@@ -4,12 +4,12 @@ h2_frac_func_stellar_mass_xgass_selection:
   selection_mask: "derived_quantities.xcoldgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e9
     end: 1e12
   y:
-    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -27,7 +27,7 @@ h2_frac_func_stellar_mass_xgass_selection:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 50 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
     show_on_webpage: false
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
@@ -38,12 +38,12 @@ h2_frac_func_ssfr:
   selection_mask: "derived_quantities.xcoldgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-4
     end: 1e4
   y:
-    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -61,7 +61,7 @@ h2_frac_func_ssfr:
   metadata:
     title: sSFR-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 50 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_sSFR.hdf5
 
@@ -71,12 +71,12 @@ h2_frac_func_stellar_surface_density_xgass_selection:
   selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "derived_quantities.mu_star_100_kpc"
+    quantity: "derived_quantities.mu_star_50_kpc"
     units: "Solar_Mass / (kpc**2)"
     start: 1e7
     end: 1e11
   y:
-    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -94,7 +94,7 @@ h2_frac_func_stellar_surface_density_xgass_selection:
   metadata:
     title: Stellar Mass Surface Density-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 50 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_mu_star.hdf5
 
@@ -104,12 +104,12 @@ hi_frac_func_stellar_mass_xgass_selection:
   selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e9
     end: 1e12
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -127,7 +127,7 @@ hi_frac_func_stellar_mass_xgass_selection:
   metadata:
     title: Stellar Mass-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures.
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 50 kpc apertures.
     show_on_webpage: false
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_M_star.hdf5
@@ -138,12 +138,12 @@ hi_frac_func_ssfr:
   selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-4
     end: 1e4
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -161,7 +161,7 @@ hi_frac_func_ssfr:
   metadata:
     title: sSFR-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy HI mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 50 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -171,12 +171,12 @@ hi_frac_func_stellar_surface_density:
   selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "derived_quantities.mu_star_100_kpc"
+    quantity: "derived_quantities.mu_star_50_kpc"
     units: "Solar_Mass / (kpc**2)"
     start: 1e7
     end: 1e11
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -194,7 +194,7 @@ hi_frac_func_stellar_surface_density:
   metadata:
     title: Stellar Mass Surface Density-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass surface density in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass surface density in 0.2 dex bins, measured in 50 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_mu_star.hdf5
 
@@ -202,12 +202,12 @@ h2_frac_func_stellar_mass:
   type: "scatter"
   legend_loc: "lower left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -225,7 +225,7 @@ h2_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 50 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
     - filename: GalaxyH2Fractions/Hunt2020_Data.hdf5
@@ -237,12 +237,12 @@ hi_frac_func_stellar_mass:
   type: "scatter"
   legend_loc: "lower left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -260,7 +260,7 @@ hi_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. LITTLE THINGS galaxies are dIrrs selected to be within 10 Mpc, with 50$\%$ of galaxies within 3.6 Mpc, and detected in HI. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 50 kpc apertures. LITTLE THINGS galaxies are dIrrs selected to be within 10 Mpc, with 50$\%$ of galaxies within 3.6 Mpc, and detected in HI. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_M_star.hdf5
     - filename: GalaxyHIFractions/Hunt2020_Data.hdf5
@@ -274,12 +274,12 @@ cold_gas_frac_func_ssfr:
   selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-4
     end: 6e1
   y:
-    quantity: "derived_quantities.neutral_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.neutral_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -297,7 +297,7 @@ cold_gas_frac_func_ssfr:
   metadata:
     title: sSFR-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy neutral gas mass over stellar mass as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy neutral gas mass over stellar mass as a function of specific star formation rate, with adaptive binning, measured in 50 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyColdGasFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -305,12 +305,12 @@ h2_to_neutral_gas_frac_func_stellar_mass:
   type: "scatter"
   legend_loc: "lower left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_100_kpc"
+    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-6
     end: 1
@@ -328,7 +328,7 @@ h2_to_neutral_gas_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass over neutral gas (HI+H$_2$) mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS and XCOLDGASS samples are uniform in mass in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$ and $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$ and plotting those above the CO detection limit ($M_{\rm H2}/M_*$ > $1.5\%$). 
+    caption: Galaxy H$_2$ mass over neutral gas (HI+H$_2$) mass as a function of stellar mass in 0.2 dex bins, measured in 50 kpc apertures. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS and XCOLDGASS samples are uniform in mass in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$ and $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$ and plotting those above the CO detection limit ($M_{\rm H2}/M_*$ > $1.5\%$).
   observational_data:
     - filename: GalaxyColdGasFractions/CatinellaSaintongeComposite_abcissa_M_star.hdf5
     - filename: GalaxyColdGasFractions/Hunt2020_Data.hdf5
@@ -341,12 +341,12 @@ h2_to_neutral_gas_frac_func_ssfr:
   selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-4
     end: 6e1
   y:
-    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_100_kpc"
+    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 1
@@ -364,7 +364,7 @@ h2_to_neutral_gas_frac_func_ssfr:
   metadata:
     title: sSFR-Neutral Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass over neutral gas mass (HI+H$_2$) as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XCOLDGASS (Saintonge+17) and XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy H$_2$ mass over neutral gas mass (HI+H$_2$) as a function of specific star formation rate, with adaptive binning, measured in 50 kpc apertures. XCOLDGASS (Saintonge+17) and XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyColdGasFractions/CatinellaSaintongeComposite_abcissa_sSFR.hdf5
 

--- a/colibre-zooms/auto_plotter/histograms.yml
+++ b/colibre-zooms/auto_plotter/histograms.yml
@@ -58,60 +58,60 @@ stellar_mass_cumulative_histogram_passive_only_30:
     section: Histograms
     show_on_webpage: false
 
-stellar_mass_cumulative_histogram_100:
+stellar_mass_cumulative_histogram_50:
   type: "cumulative_histogram"
   reverse_cumsum: true
   legend_loc: "upper right"
   number_of_bins: 120
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   histogram:
     scatter: "none"
   metadata:
-    title: Stellar Mass Histogram (100 kpc aperture)
+    title: Stellar Mass Histogram (50 kpc aperture)
     caption: Cumulative histogram of stellar masses using the same bins as the mass function.
     section: Histograms
 
-stellar_mass_cumulative_histogram_active_only_100:
+stellar_mass_cumulative_histogram_active_only_50:
   type: "cumulative_histogram"
   reverse_cumsum: true
   legend_loc: "upper right"
   comment: "Active only"
   comment_loc: "upper center"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   number_of_bins: 120
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   histogram:
     scatter: "none"
   metadata:
-    title: Stellar Mass Histogram (100 kpc aperture, active)
+    title: Stellar Mass Histogram (50 kpc aperture, active)
     caption: Only for active galaxies.
     section: Histograms
 
-stellar_mass_cumulative_histogram_passive_only_100:
+stellar_mass_cumulative_histogram_passive_only_50:
   type: "cumulative_histogram"
   reverse_cumsum: true
   legend_loc: "upper right"
   comment: "Passive only"
   comment_loc: "upper center"
-  selection_mask: "derived_quantities.is_passive_100_kpc"
+  selection_mask: "derived_quantities.is_passive_50_kpc"
   number_of_bins: 120
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   histogram:
     scatter: "none"
   metadata:
-    title: Stellar Mass Histogram (100 kpc aperture, passive)
+    title: Stellar Mass Histogram (50 kpc aperture, passive)
     caption: Only for passive galaxies.
     section: Histograms
 
@@ -150,20 +150,20 @@ star_formation_rate_cumulative_histogram_30:
     section: Histograms
     show_on_webpage: false
 
-star_formation_rate_cumulative_histogram_100:
+star_formation_rate_cumulative_histogram_50:
   type: "cumulative_histogram"
   reverse_cumsum: true
   legend_loc: "upper right"
   number_of_bins: 120
   x:
-    quantity: "apertures.sfr_gas_100_kpc"
+    quantity: "apertures.sfr_gas_50_kpc"
     units: "Solar_Mass / year"
     start: 1e-3
     end: 1e3
   histogram:
     scatter: "none"
   metadata:
-    title: Star Formation Rate Histogram (100 kpc aperture)
+    title: Star Formation Rate Histogram (50 kpc aperture)
     caption: Cumulative histogram of star formation rates using the same bins as the star formation rates function.
     section: Histograms
 
@@ -241,59 +241,59 @@ stellar_mass_histogram_passive_only_30:
     section: Histograms
     show_on_webpage: false
 
-stellar_mass_histogram_100:
+stellar_mass_histogram_50:
   type: "histogram"
   legend_loc: "upper right"
   number_of_bins: 120
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   histogram:
     scatter: "none"
   metadata:
-    title: Stellar Mass Histogram (100 kpc aperture)
+    title: Stellar Mass Histogram (50 kpc aperture)
     caption: Histogram of stellar masses using the same bins as the mass function.
     section: Histograms
     show_on_webpage: false
 
-stellar_mass_histogram_active_only_100:
+stellar_mass_histogram_active_only_50:
   type: "histogram"
   legend_loc: "upper right"
   comment: "Active only"
   comment_loc: "upper center"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   number_of_bins: 120
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   histogram:
     scatter: "none"
   metadata:
-    title: Stellar Mass Histogram (100 kpc aperture, active)
+    title: Stellar Mass Histogram (50 kpc aperture, active)
     caption: Only for active galaxies.
     section: Histograms
     show_on_webpage: false
 
-stellar_mass_histogram_passive_only_100:
+stellar_mass_histogram_passive_only_50:
   type: "histogram"
   legend_loc: "upper right"
   comment: "Passive only"
   comment_loc: "upper center"
-  selection_mask: "derived_quantities.is_passive_100_kpc"
+  selection_mask: "derived_quantities.is_passive_50_kpc"
   number_of_bins: 120
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   histogram:
     scatter: "none"
   metadata:
-    title: Stellar Mass Histogram (100 kpc aperture, passive)
+    title: Stellar Mass Histogram (50 kpc aperture, passive)
     caption: Only for passive galaxies.
     section: Histograms
     show_on_webpage: false
@@ -332,19 +332,19 @@ star_formation_rate_histogram_30:
     section: Histograms
     show_on_webpage: false
 
-star_formation_rate_histogram_100:
+star_formation_rate_histogram_50:
   type: "histogram"
   legend_loc: "upper right"
   number_of_bins: 120
   x:
-    quantity: "apertures.sfr_gas_100_kpc"
+    quantity: "apertures.sfr_gas_50_kpc"
     units: "Solar_Mass / year"
     start: 1e-3
     end: 1e3
   histogram:
     scatter: "none"
   metadata:
-    title: Star Formation Rate Histogram (100 kpc aperture)
+    title: Star Formation Rate Histogram (50 kpc aperture)
     caption: Histogram of star formation rates using the same bins as the star formation rates function.
     section: Histograms
     show_on_webpage: false

--- a/colibre-zooms/auto_plotter/metallicity.yml
+++ b/colibre-zooms/auto_plotter/metallicity.yml
@@ -36,19 +36,19 @@ stellar_mass_gas_sf_metallicity_fromz_lom_30:
     - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
-stellar_mass_gas_sf_metallicity_fromz_lom_100:
+stellar_mass_gas_sf_metallicity_fromz_lom_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only, LoM, Diffuse, from Z"
   y:
-    quantity: "derived_quantities.gas_o_abundance_fromz_avglin_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_fromz_avglin_50_kpc"
     log: false
     units: "dimensionless"
     start: 7
     end: 10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -64,7 +64,7 @@ stellar_mass_gas_sf_metallicity_fromz_lom_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, from Z, 100 kpc aperture)"
+    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, from Z, 50 kpc aperture)"
     caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (converted to 12 + $\log_{10}$ O/H by assuming solar abundance patterns) of cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Gas Metallicity
     show_on_webpage: true
@@ -112,19 +112,19 @@ stellar_mass_gas_sf_metallicity_lom_30:
     - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
-stellar_mass_gas_sf_metallicity_lom_100:
+stellar_mass_gas_sf_metallicity_lom_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only, LoM, Diffuse, from O"
   y:
-    quantity: "derived_quantities.gas_o_abundance_avglin_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_avglin_50_kpc"
     log: false
     units: "dimensionless"
     start: 7
     end: 10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -140,7 +140,7 @@ stellar_mass_gas_sf_metallicity_lom_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, 100 kpc aperture)"
+    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, 50 kpc aperture)"
     caption: Only shown for star forming galaxies. Represented by 12 + $\log_{10}$ O/H (where O/H is linearly averaged for diffuse O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Gas Metallicity
     show_on_webpage: true
@@ -188,19 +188,19 @@ stellar_mass_gas_sf_metallicity_total_lom_30:
     - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
-stellar_mass_gas_sf_metallicity_total_lom_100:
+stellar_mass_gas_sf_metallicity_total_lom_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only, LoM, Total (Diffuse + Dust), from O"
   y:
-    quantity: "derived_quantities.gas_o_abundance_total_avglin_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_total_avglin_50_kpc"
     log: false
     units: "dimensionless"
     start: 7
     end: 10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -216,7 +216,7 @@ stellar_mass_gas_sf_metallicity_total_lom_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Gas (Diffuse + Dust) metallicity relation (log-of-mean, 100 kpc aperture)"
+    title: "Stellar mass - Gas (Diffuse + Dust) metallicity relation (log-of-mean, 50 kpc aperture)"
     caption: Only shown for star forming galaxies. Represented by 12 + $\log_{10}$ O/H (where O/H is linearly averaged for total O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses undepleted gas metallicity, i.e. it includes metals that are present in dust.
     section: Gas Metallicity
     show_on_webpage: true
@@ -264,19 +264,19 @@ stellar_mass_gas_sf_metallicity_mol_lowfloor_30:
     - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
-stellar_mass_gas_sf_metallicity_mol_lowfloor_100:
+stellar_mass_gas_sf_metallicity_mol_lowfloor_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only, MoL w. [O/H]=-4 floor, Diffuse, from O"
   y:
-    quantity: "derived_quantities.gas_o_abundance_avglog_low_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_avglog_low_50_kpc"
     log: false
     units: "dimensionless"
     start: 7
     end: 10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -292,7 +292,7 @@ stellar_mass_gas_sf_metallicity_mol_lowfloor_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Gas diffuse metallicity relation (mean-of-log, 100 kpc aperture)"
+    title: "Stellar mass - Gas diffuse metallicity relation (mean-of-log, 50 kpc aperture)"
     caption: Only shown for star forming galaxies. Represented by 12 + $\log_{10}$ O/H (where $\log_{10}$ O/H is averaged between gas particles with a [O/H]=-4 floor and diffuse O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Gas Metallicity
     show_on_webpage: true
@@ -340,19 +340,19 @@ stellar_mass_gas_sf_metallicity_mol_hifloor_30:
     - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
-stellar_mass_gas_sf_metallicity_mol_hifloor_100:
+stellar_mass_gas_sf_metallicity_mol_hifloor_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only, MoL w. [O/H]=-3 floor, Diffuse, from O"
   y:
-    quantity: "derived_quantities.gas_o_abundance_avglog_high_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_avglog_high_50_kpc"
     log: false
     units: "dimensionless"
     start: 7
     end: 10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -368,7 +368,7 @@ stellar_mass_gas_sf_metallicity_mol_hifloor_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Gas diffuse metallicity relation (mean-of-log, 100 kpc aperture)"
+    title: "Stellar mass - Gas diffuse metallicity relation (mean-of-log, 50 kpc aperture)"
     caption: Only shown for star forming galaxies. Represented by 12 + $\log_{10}$ O/H (where $\log_{10}$ O/H is averaged between gas particles with a [O/H]=-3 floor for diffuse O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Gas Metallicity
     show_on_webpage: true
@@ -416,19 +416,19 @@ stellar_mass_gas_sf_metallicity_lom_allgals_30:
     - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
-stellar_mass_gas_sf_metallicity_lom_allgals_100:
+stellar_mass_gas_sf_metallicity_lom_allgals_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.has_cold_dense_gas_100_kpc"
+  selection_mask: "derived_quantities.has_cold_dense_gas_50_kpc"
   comment: "All galaxies, LoM, Diffuse, from O"
   y:
-    quantity: "derived_quantities.gas_o_abundance_avglin_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_avglin_50_kpc"
     log: false
     units: "dimensionless"
     start: 7
     end: 10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -444,7 +444,7 @@ stellar_mass_gas_sf_metallicity_lom_allgals_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, 100 kpc aperture)"
+    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, 50 kpc aperture)"
     caption: Only shown for galaxies with cold, dense gas. Represented by 12 + $\log_{10}$ O/H (where O/H is linearly averaged for diffuse O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Gas Metallicity
     show_on_webpage: true
@@ -455,16 +455,16 @@ stellar_mass_gas_sf_metallicity_lom_allgals_100:
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
 
-stellar_mass_star_metallicity_100:
+stellar_mass_star_metallicity_50:
   type: "scatter"
   legend_loc: "upper left"
   y:
-    quantity: "derived_quantities.star_metallicity_in_solar_100_kpc"
+    quantity: "derived_quantities.star_metallicity_in_solar_50_kpc"
     units: "dimensionless"
     start: 1e-2
     end: 1e1
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -480,7 +480,7 @@ stellar_mass_star_metallicity_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Star metallicity relation (100 kpc aperture)"
+    title: "Stellar mass - Star metallicity relation (50 kpc aperture)"
     caption: Average stellar metallicity measured in the same aperture as the stellar mass. Gallazzi data is corrected from their choice of solar metallicity (0.02) to ours (0.0126).
     section: Stellar Metallicity
     show_on_webpage: true
@@ -523,17 +523,17 @@ stellar_mass_star_metallicity_30:
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Fraser-McKelvie_2021.hdf5 
 
-stellar_mass_star_fe_over_h_mol_lofloor_100:
+stellar_mass_star_fe_over_h_mol_lofloor_50:
   type: "scatter"
   legend_loc: "upper left"
   comment: "MoL w. [F/H]=-4 floor"
   y:
-    quantity: "derived_quantities.star_fe_abundance_avglog_low_100_kpc"
+    quantity: "derived_quantities.star_fe_abundance_avglog_low_50_kpc"
     units: "dimensionless"
     start: 1e-2
     end: 1e1
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -549,7 +549,7 @@ stellar_mass_star_fe_over_h_mol_lofloor_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: 'Stellar mass - [Fe/H]$_*$ relation (mean-of-log, 100 kpc aperture)'
+    title: 'Stellar mass - [Fe/H]$_*$ relation (mean-of-log, 50 kpc aperture)'
     section: Stellar Metallicity
     caption: 'Computed as the mass-weighted average of log [Fe/H]$_*$. The floor value is set to [Fe/H]=-4. All haloes are plotted, including subhaloes.'
   observational_data:
@@ -557,17 +557,17 @@ stellar_mass_star_fe_over_h_mol_lofloor_100:
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Fraser-McKelvie_2021.hdf5 
 
-stellar_mass_star_fe_over_h_mol_hifloor_100:
+stellar_mass_star_fe_over_h_mol_hifloor_50:
   type: "scatter"
   legend_loc: "upper left"
   comment: "MoL w. [F/H]=-3 floor"
   y:
-    quantity: "derived_quantities.star_fe_abundance_avglog_high_100_kpc"
+    quantity: "derived_quantities.star_fe_abundance_avglog_high_50_kpc"
     units: "dimensionless"
     start: 1e-2
     end: 1e1
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -583,7 +583,7 @@ stellar_mass_star_fe_over_h_mol_hifloor_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: 'Stellar mass - [Fe/H]$_*$ relation (mean-of-log, 100 kpc aperture)'
+    title: 'Stellar mass - [Fe/H]$_*$ relation (mean-of-log, 50 kpc aperture)'
     section: Stellar Metallicity
     caption: 'Computed as the mass-weighted average of log [Fe/H]$_*$. The floor value is set to [Fe/H]=-3. All haloes are plotted, including subhaloes.'
   observational_data:
@@ -591,17 +591,17 @@ stellar_mass_star_fe_over_h_mol_hifloor_100:
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Fraser-McKelvie_2021.hdf5 
 
-stellar_mass_star_fe_over_h_lom_100:
+stellar_mass_star_fe_over_h_lom_50:
   type: "scatter"
   legend_loc: "upper left"
   comment: "LoM"
   y:
-    quantity: "derived_quantities.star_fe_abundance_avglin_100_kpc"
+    quantity: "derived_quantities.star_fe_abundance_avglin_50_kpc"
     units: "dimensionless"
     start: 1e-2
     end: 1e1
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -617,7 +617,7 @@ stellar_mass_star_fe_over_h_lom_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: 'Stellar mass - [Fe/H]$_*$ relation (100 kpc aperture)'
+    title: 'Stellar mass - [Fe/H]$_*$ relation (50 kpc aperture)'
     section: Stellar Metallicity
     caption: 'Computed as the mass-weighted average of [Fe/H]$_*$. All haloes are plotted, including subhaloes.'
   observational_data:
@@ -626,17 +626,17 @@ stellar_mass_star_fe_over_h_lom_100:
     - filename: GalaxyStellarMassStellarMetallicity/Fraser-McKelvie_2021.hdf5 
 
 
-stellar_mass_star_mg_over_fe_100:
+stellar_mass_star_mg_over_fe_50:
   type: "scatter"
   legend_loc: "lower left"
   y:
-    quantity: "derived_quantities.star_magnesium_over_iron_100_kpc"
+    quantity: "derived_quantities.star_magnesium_over_iron_50_kpc"
     units: "dimensionless"
     start: -0.2
     end: 0.7
     log: false
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e8
     end: 1e12
@@ -652,23 +652,23 @@ stellar_mass_star_mg_over_fe_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: 'Stellar mass - [Mg/Fe]$_*$ relation (100 kpc aperture)'
+    title: 'Stellar mass - [Mg/Fe]$_*$ relation (50 kpc aperture)'
     section: Stellar Metallicity
-    caption: '[Mg/Fe] versus stellar mass, both computed in 100-kpc apertures. The values of [Mg/Fe] are obtained by computing the (log10 of) ratio between the total Magnesium mass in stars and total Iron mass in stars, and then normalising it by the corresponding solar abundances. The solar abundances are taken from Asplund et al. (2009). All haloes are plotted, including subhaloes.'
+    caption: '[Mg/Fe] versus stellar mass, both computed in 50-kpc apertures. The values of [Mg/Fe] are obtained by computing the (log10 of) ratio between the total Magnesium mass in stars and total Iron mass in stars, and then normalising it by the corresponding solar abundances. The solar abundances are taken from Asplund et al. (2009). All haloes are plotted, including subhaloes.'
   observational_data:
     - filename: GalaxyStellarMassAlphatoIron/Gallazzi2021_Data.hdf5
 
-stellar_mass_star_o_over_fe_100:
+stellar_mass_star_o_over_fe_50:
   type: "scatter"
   legend_loc: "lower left"
   y:
-    quantity: "derived_quantities.star_oxygen_over_iron_100_kpc"
+    quantity: "derived_quantities.star_oxygen_over_iron_50_kpc"
     units: "dimensionless"
     start: -0.2
     end: 0.7
     log: false
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e8
     end: 1e12
@@ -684,8 +684,8 @@ stellar_mass_star_o_over_fe_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: 'Stellar mass - [O/Fe]$_*$ relation (100 kpc aperture)'
+    title: 'Stellar mass - [O/Fe]$_*$ relation (50 kpc aperture)'
     section: Stellar Metallicity
-    caption: '[O/Fe] versus stellar mass, both computed in 100-kpc apertures. The values of [O/Fe] are obtained by computing the (log10 of) ratio between the total Oxygen mass in stars and total Iron mass in stars, and then normalising it by the corresponding solar abundances. The solar abundances are taken from Asplund et al. (2009). All haloes are plotted, including subhaloes.'
+    caption: '[O/Fe] versus stellar mass, both computed in 50-kpc apertures. The values of [O/Fe] are obtained by computing the (log10 of) ratio between the total Oxygen mass in stars and total Iron mass in stars, and then normalising it by the corresponding solar abundances. The solar abundances are taken from Asplund et al. (2009). All haloes are plotted, including subhaloes.'
   observational_data:
     - filename: GalaxyStellarMassAlphatoIron/Gallazzi2021_Data.hdf5

--- a/colibre-zooms/auto_plotter/star_formation_rates.yml
+++ b/colibre-zooms/auto_plotter/star_formation_rates.yml
@@ -37,40 +37,9 @@ stellar_mass_sfr_50:
     quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
-    end: 2e12
-  y:
-    quantity: "apertures.sfr_gas_50_kpc"
-    units: "Solar_Mass / year"
-    start: 1e-3
-    end: 1e3
-  median:
-    plot: true
-    log: true
-    adaptive: true
-    number_of_bins: 30
-    start:
-      value: 1e6
-      units: Solar_Mass
-    end:
-      value: 2e12
-      units: Solar_Mass
-  metadata:
-    title: Stellar Mass-Star Formation Rate (50 kpc aperture)
-    caption: All galaxies, including those deemed to be passive (below 0.01 / Gyr sSFR), are included in the median line.
-    section: Star Formation Rates
-    show_on_webpage: true
-
-
-stellar_mass_sfr_100:
-  type: "scatter"
-  legend_loc: "upper left"
-  x:
-    quantity: "apertures.mass_star_100_kpc"
-    units: Solar_Mass
-    start: 1e6
     end: 1e12
   y:
-    quantity: "apertures.sfr_gas_100_kpc"
+    quantity: "apertures.sfr_gas_50_kpc"
     units: "Solar_Mass / year"
     start: 1e-3
     end: 1e3
@@ -86,23 +55,23 @@ stellar_mass_sfr_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Star Formation Rate (100 kpc aperture)
+    title: Stellar Mass-Star Formation Rate (50 kpc aperture)
     caption: All galaxies, including those deemed to be passive (below 0.01 / Gyr sSFR), are included in the median line.
     section: Star Formation Rates
     show_on_webpage: false
   observational_data:
     - filename: GalaxyStellarMassStarFormationRate/Davies2016_z0p1.hdf5
 
-stellar_mass_specific_sfr_all_100:
+stellar_mass_specific_sfr_all_50:
   type: "scatter"
   legend_loc: "lower left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 0.5e-3
     end: 3e0
@@ -118,7 +87,7 @@ stellar_mass_specific_sfr_all_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: Specific Star Formation Rate - Stellar Mass (100 kpc aperture)
+    title: Specific Star Formation Rate - Stellar Mass (50 kpc aperture)
     caption: All galaxies, including those deemed to be passive (below 0.01 / Gyr sSFR), are included in the median line.
     section: Star Formation Rates
   observational_data:
@@ -158,49 +127,19 @@ stellar_mass_specific_sfr_all_30:
     - filename: GalaxyStellarMassSpecificStarFormationRate/Bauer2013_StarForming.hdf5
     - filename: GalaxyStellarMassSpecificStarFormationRate/Chang2015.hdf5
 
-stellar_mass_specific_sfr_all_50:
+stellar_mass_specific_sfr_active_50:
   type: "scatter"
+  selection_mask: "derived_quantities.is_active_50_kpc"
+  comment: "Active only"
+  comment_loc: "lower right"
   legend_loc: "lower left"
   x:
     quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
-    end: 2e12
-  y:
-    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
-    units: 1 / gigayear
-    start: 0.5e-3
-    end: 3e0
-  median:
-    plot: true
-    log: true
-    adaptive: true
-    number_of_bins: 30
-    start:
-      value: 1e6
-      units: solar_mass
-    end:
-      value: 2e12
-      units: solar_mass
-  metadata:
-    title: Specific Star Formation Rate - Stellar Mass (50 kpc aperture)
-    caption: All galaxies, including those deemed to be passive (below 0.01 / Gyr sSFR), are included in the median line.
-    section: Star Formation Rates
-    show_on_webpage: true
-
-stellar_mass_specific_sfr_active_100:
-  type: "scatter"
-  selection_mask: "derived_quantities.is_active_100_kpc"
-  comment: "Active only"
-  comment_loc: "lower right"
-  legend_loc: "lower left"
-  x:
-    quantity: "apertures.mass_star_100_kpc"
-    units: solar_mass
-    start: 1e6
     end: 1e12
   y:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 0.5e-2
     end: 3e0
@@ -216,7 +155,7 @@ stellar_mass_specific_sfr_active_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: Specific Star Formation Rate - Stellar Mass (100 kpc aperture, active only)
+    title: Specific Star Formation Rate - Stellar Mass (50 kpc aperture, active only)
     caption: Only active galaxies (threshold is above 0.01 / Gyr sSFR) are included in the median line.
     section: Star Formation Rates
   observational_data:
@@ -292,9 +231,9 @@ halo_mass_specific_sfr_30:
     section: Star Formation Rates
     show_on_webpage: false
 
-halo_mass_specific_sfr_100:
+halo_mass_specific_sfr_50:
   type: "scatter"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only"
   comment_loc: "lower right"
   legend_loc: "lower left"
@@ -304,7 +243,7 @@ halo_mass_specific_sfr_100:
     start: 1e8
     end: 1e13
   y:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 0.5e-2
     end: 3e0
@@ -320,7 +259,7 @@ halo_mass_specific_sfr_100:
       value: 1e13
       units: solar_mass
   metadata:
-    title: Specific Star Formation Rate (100 kpc aperture) - Halo Mass
+    title: Specific Star Formation Rate (50 kpc aperture) - Halo Mass
     caption: Only active galaxies (threshold is above 0.01 / Gyr sSFR) are included in the median line.
     section: Star Formation Rates
     show_on_webpage: false
@@ -358,9 +297,9 @@ halo_mass_sfr_30_halo_mass:
     section: Star Formation Rates
     show_on_webpage: false
 
-halo_mass_sfr_100_halo_mass:
+halo_mass_sfr_50_halo_mass:
   type: "scatter"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only"
   comment_loc: "lower right"
   legend_loc: "lower left"
@@ -370,7 +309,7 @@ halo_mass_sfr_100_halo_mass:
     start: 1e8
     end: 1e13
   y:
-    quantity: "derived_quantities.sfr_halo_mass_100_kpc"
+    quantity: "derived_quantities.sfr_halo_mass_50_kpc"
     units: 1 / gigayear
     start: 0.5e-5
     end: 1e-2
@@ -386,7 +325,7 @@ halo_mass_sfr_100_halo_mass:
       value: 1e13
       units: solar_mass
   metadata:
-    title: Star Formation Rate divided by Halo Mass (100 kpc aperture) - Halo Mass
+    title: Star Formation Rate divided by Halo Mass (50 kpc aperture) - Halo Mass
     caption: Only active galaxies (threshold is above 0.01 / Gyr sSFR) are included in the median line
     section: Star Formation Rates
     show_on_webpage: false
@@ -429,18 +368,18 @@ stellar_mass_passive_fraction_30:
     - filename: GalaxyStellarMassPassiveFraction/Moustakas2013.hdf5
     - filename: GalaxyStellarMassPassiveFraction/Behroozi2019.hdf5
 
-stellar_mass_passive_fraction_100:
+stellar_mass_passive_fraction_50:
   type: "scatter"
   legend_loc: "lower left"
   redshift_loc: "upper center"
   min_num_points_highlight: 0
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "derived_quantities.is_passive_100_kpc"
+    quantity: "derived_quantities.is_passive_50_kpc"
     units: "dimensionless"
     log: false
     start: 0
@@ -458,7 +397,7 @@ stellar_mass_passive_fraction_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: Passive Fraction - Stellar Mass (100 kpc aperture)
+    title: Passive Fraction - Stellar Mass (50 kpc aperture)
     caption: A galaxy is determined as being passive if it has a sSFR below 0.01 / Gyr.
     section: Star Formation Rates
   observational_data:
@@ -506,7 +445,7 @@ stellar_mass_passive_fraction_centrals_30:
     - filename: GalaxyStellarMassPassiveFraction/Moustakas2013.hdf5
     - filename: GalaxyStellarMassPassiveFraction/Behroozi2019_centrals.hdf5
 
-stellar_mass_passive_fraction_centrals_100:
+stellar_mass_passive_fraction_centrals_50:
   type: "scatter"
   select_structure_type: 10
   comment: "Centrals only"
@@ -514,12 +453,12 @@ stellar_mass_passive_fraction_centrals_100:
   redshift_loc: "upper center"
   min_num_points_highlight: 0
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "derived_quantities.is_passive_100_kpc"
+    quantity: "derived_quantities.is_passive_50_kpc"
     units: "dimensionless"
     log: false
     start: 0
@@ -537,7 +476,7 @@ stellar_mass_passive_fraction_centrals_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: Passive Fraction - Stellar Mass (100 kpc aperture, centrals)
+    title: Passive Fraction - Stellar Mass (50 kpc aperture, centrals)
     caption: A galaxy is determined as being passive if it has a sSFR below 0.01 / Gyr. This figure shows only the central galaxies (structure type 10).
     section: Star Formation Rates
   observational_data:

--- a/colibre-zooms/auto_plotter/stellar_birth_densities.yml
+++ b/colibre-zooms/auto_plotter/stellar_birth_densities.yml
@@ -58,11 +58,11 @@ stellar_birth_density_halo_mass_max_all:
     section: Stellar Birth Densities
     show_on_webpage: false
 
-stellar_birth_density_stellar_mass_average_of_log_all_100:
+stellar_birth_density_stellar_mass_average_of_log_all_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e4
     end: 1e12
@@ -87,11 +87,11 @@ stellar_birth_density_stellar_mass_average_of_log_all_100:
     caption: Includes all haloes, including subhaloes.
     section: Stellar Birth Densities
 
-stellar_birth_density_stellar_mass_max_all_100:
+stellar_birth_density_stellar_mass_max_all_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e4
     end: 1e12

--- a/colibre-zooms/auto_plotter/tully_fisher.yml
+++ b/colibre-zooms/auto_plotter/tully_fisher.yml
@@ -1,8 +1,8 @@
-tully_fisher_100:
+tully_fisher_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -23,7 +23,7 @@ tully_fisher_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: Tully-Fisher (stellar mass, 100 kpc)
+    title: Tully-Fisher (stellar mass, 50 kpc)
     caption: The Tully-Fisher relation based on stellar mass.
     section: Tully-Fisher
   observational_data:
@@ -55,7 +55,7 @@ tully_fisher_30:
       value: 1e12
       units: solar_mass
   metadata:
-    title: Tully-Fisher (stellar mass, 100 kpc)
+    title: Tully-Fisher (stellar mass, 50 kpc)
     caption: The Tully-Fisher relation based on stellar mass.
     section: Tully-Fisher
     show_on_webpage: false

--- a/colibre-zooms/registration.py
+++ b/colibre-zooms/registration.py
@@ -28,7 +28,6 @@ This file calculates:
 """
 
 # Define aperture size in kpc
-aperture_sizes_30_100_kpc = {30, 100}
 aperture_sizes_30_50_100_kpc = {30, 50, 100}
 
 # Solar metal mass fraction used in Plöckinger S. & Schaye J. (2020)
@@ -885,30 +884,30 @@ def register_los_star_veldisp(self, catalogue):
 
 
 # Register derived fields
-register_spesific_star_formation_rates(self, catalogue, aperture_sizes_30_100_kpc)
+register_spesific_star_formation_rates(self, catalogue, aperture_sizes_30_50_100_kpc)
 register_star_metallicities(
-    self, catalogue, aperture_sizes_30_100_kpc, solar_metal_mass_fraction
+    self, catalogue, aperture_sizes_30_50_100_kpc, solar_metal_mass_fraction
 )
 register_stellar_to_halo_mass_ratios(self, catalogue, aperture_sizes_30_50_100_kpc)
-register_dust(self, catalogue, aperture_sizes_30_100_kpc)
-register_oxygen_to_hydrogen(self, catalogue, aperture_sizes_30_100_kpc)
+register_dust(self, catalogue, aperture_sizes_30_50_100_kpc)
+register_oxygen_to_hydrogen(self, catalogue, aperture_sizes_30_50_100_kpc)
 register_cold_dense_gas_metallicity(
     self,
     catalogue,
-    aperture_sizes_30_100_kpc,
+    aperture_sizes_30_50_100_kpc,
     solar_metal_mass_fraction,
     twelve_plus_log_OH_solar,
 )
 register_iron_to_hydrogen(
-    self, catalogue, aperture_sizes_30_100_kpc, solar_fe_abundance
+    self, catalogue, aperture_sizes_30_50_100_kpc, solar_fe_abundance
 )
-register_hi_masses(self, catalogue, aperture_sizes_30_100_kpc)
-register_h2_masses(self, catalogue, aperture_sizes_30_100_kpc)
-register_dust_to_hi_ratio(self, catalogue, aperture_sizes_30_100_kpc)
-register_cold_gas_mass_ratios(self, catalogue, aperture_sizes_30_100_kpc)
-register_species_fractions(self, catalogue, aperture_sizes_30_100_kpc)
+register_hi_masses(self, catalogue, aperture_sizes_30_50_100_kpc)
+register_h2_masses(self, catalogue, aperture_sizes_30_50_100_kpc)
+register_dust_to_hi_ratio(self, catalogue, aperture_sizes_30_50_100_kpc)
+register_cold_gas_mass_ratios(self, catalogue, aperture_sizes_30_50_100_kpc)
+register_species_fractions(self, catalogue, aperture_sizes_30_50_100_kpc)
 register_stellar_birth_densities(self, catalogue)
 register_global_mask(self, catalogue)
 register_los_star_veldisp(self, catalogue)
-register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes_30_100_kpc)
+register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes_30_50_100_kpc)
 register_gas_fraction(self, catalogue)

--- a/colibre/auto_plotter/ages.yml
+++ b/colibre/auto_plotter/ages.yml
@@ -30,7 +30,7 @@ stellar_mass_ages_30:
   observational_data:
     - filename: GalaxyStellarMassStellarAges/Gallazzi2005_Data.hdf5
 
-stellar_mass_ages_100:
+stellar_mass_ages_50:
   type: "scatter"
   legend_loc: "lower right"
   y:
@@ -39,7 +39,7 @@ stellar_mass_ages_100:
     start: 1e8
     end: 3e10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e7
     end: 1e12
@@ -55,8 +55,8 @@ stellar_mass_ages_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Stellar age relation (100 kpc aperture)"
+    title: "Stellar mass - Stellar age relation (50 kpc aperture)"
     section: Ages
-    caption: Median age of stars within the 100 kpc 3D aperture of each galaxy.
+    caption: Median age of stars within the 50 kpc 3D aperture of each galaxy.
   observational_data:
     - filename: GalaxyStellarMassStellarAges/Gallazzi2005_Data.hdf5

--- a/colibre/auto_plotter/black_holes.yml
+++ b/colibre/auto_plotter/black_holes.yml
@@ -33,11 +33,11 @@ stellar_mass_black_hole_mass_30:
     - filename: GalaxyStellarMassBlackHoleMass/McConnell2013_Fit.hdf5
 
 
-stellar_mass_black_hole_mass_100:
+stellar_mass_black_hole_mass_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
@@ -58,7 +58,7 @@ stellar_mass_black_hole_mass_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Black Hole Mass relation (100 kpc Stellar Mass)
+    title: Stellar Mass-Black Hole Mass relation (50 kpc Stellar Mass)
     caption: SMBHM relation. Note that the stellar velocity dispersion is measured in observations in a fixed 1 kpc aperture
     section: Black Holes
   observational_data:

--- a/colibre/auto_plotter/cold_gas_relations.yml
+++ b/colibre/auto_plotter/cold_gas_relations.yml
@@ -1,7 +1,7 @@
 stellar_mass_molecular_to_neutral_fraction_30:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
@@ -60,16 +60,16 @@ stellar_mass_neutral_to_stellar_fraction_30:
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
 
-stellar_mass_neutral_to_stellar_fraction_100:
+stellar_mass_neutral_to_stellar_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_neutral_H_to_stellar_fraction_100_kpc"
+    quantity: "derived_quantities.gas_neutral_H_to_stellar_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 3.
@@ -85,8 +85,8 @@ stellar_mass_neutral_to_stellar_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Neutral To Stellar Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Gas fraction is HI + H$_2$ mass divided by stellar mass in a 100 kpc aperture.
+    title: Stellar Mass-Neutral To Stellar Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Gas fraction is HI + H$_2$ mass divided by stellar mass in a 50 kpc aperture.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
 
@@ -120,16 +120,16 @@ stellar_mass_molecular_to_stellar_plus_molecular_fraction_30:
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
 
-stellar_mass_molecular_to_stellar_plus_molecular_fraction_100:
+stellar_mass_molecular_to_stellar_plus_molecular_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_molecular_H_to_molecular_plus_stellar_fraction_100_kpc"
+    quantity: "derived_quantities.gas_molecular_H_to_molecular_plus_stellar_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 3.
@@ -145,8 +145,8 @@ stellar_mass_molecular_to_stellar_plus_molecular_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Molecular Gas To Molecular Plus Stellar Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Gas fraction is H$_2$ mass divided by H$_2$ mass + stellar mass in a 100 kpc aperture.
+    title: Stellar Mass-Molecular Gas To Molecular Plus Stellar Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Gas fraction is H$_2$ mass divided by H$_2$ mass + stellar mass in a 50 kpc aperture.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
 
@@ -180,17 +180,17 @@ stellar_mass_H2_mass_30:
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
 
-stellar_mass_H2_mass_100:
+stellar_mass_H2_mass_50:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_H2_mass_100_kpc"
+    quantity: "derived_quantities.gas_H2_mass_50_kpc"
     units: "Solar_Mass"
     start: 1e5
     end: 1e11
@@ -206,7 +206,7 @@ stellar_mass_H2_mass_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-H$_2$ Gas Mass (100 kpc aperture)
+    title: Stellar Mass-H$_2$ Gas Mass (50 kpc aperture)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -214,7 +214,7 @@ stellar_mass_H2_mass_100:
 stellar_mass_HI_mass_30:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
     quantity: "apertures.mass_star_30_kpc"
     units: Solar_Mass
@@ -242,17 +242,17 @@ stellar_mass_HI_mass_30:
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
 
-stellar_mass_HI_mass_100:
+stellar_mass_HI_mass_50:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_HI_mass_100_kpc"
+    quantity: "derived_quantities.gas_HI_mass_50_kpc"
     units: "Solar_Mass"
     start: 1e5
     end: 1e11
@@ -268,7 +268,7 @@ stellar_mass_HI_mass_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-HI Gas Mass (100 kpc aperture)
+    title: Stellar Mass-HI Gas Mass (50 kpc aperture)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Stellar Mass)
     show_on_webpage: false
@@ -276,7 +276,7 @@ stellar_mass_HI_mass_100:
 H2_mass_star_formation_rate_30:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
     quantity: "derived_quantities.gas_H2_mass_30_kpc"
     units: "Solar_Mass"
@@ -286,7 +286,7 @@ H2_mass_star_formation_rate_30:
     quantity: "derived_quantities.specific_sfr_gas_30_kpc"
     units: 1 / gigayear
     start: 0.01
-    end: 100
+    end: 50
   median:
     plot: true
     log: true
@@ -304,20 +304,20 @@ H2_mass_star_formation_rate_30:
     section: Cold Gas Relations (Gas Mass)
     show_on_webpage: false
 
-H2_mass_star_formation_rate_100:
+H2_mass_star_formation_rate_50:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.gas_H2_mass_100_kpc"
+    quantity: "derived_quantities.gas_H2_mass_50_kpc"
     units: "Solar_Mass"
     start: 1e5
     end: 1e11
   y:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 0.01
-    end: 100
+    end: 50
   median:
     plot: true
     log: true
@@ -330,21 +330,21 @@ H2_mass_star_formation_rate_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: H$_2$ Gas Mass - Star Formation Rate (100 kpc)
+    title: H$_2$ Gas Mass - Star Formation Rate (50 kpc)
     caption: All galaxies are included in the median line.
     section: Cold Gas Relations (Gas Mass)
     show_on_webpage: false
 
-stellar_mass_neutral_H_to_baryonic_fraction_100:
+stellar_mass_neutral_H_to_baryonic_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_neutral_H_to_baryonic_fraction_100_kpc"
+    quantity: "derived_quantities.gas_neutral_H_to_baryonic_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -366,21 +366,21 @@ stellar_mass_neutral_H_to_baryonic_fraction_100:
       value: 1e99
       units: "dimensionless"
   metadata:
-    title: Stellar Mass-Neutral Gas to Baryonic Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI + H$_2$ mass over total baryonic mass in a 100 kpc aperture.
+    title: Stellar Mass-Neutral Gas to Baryonic Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI + H$_2$ mass over total baryonic mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
 
-stellar_mass_HI_to_neutral_H_fraction_100:
+stellar_mass_HI_to_neutral_H_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_HI_to_neutral_H_fraction_100_kpc"
+    quantity: "derived_quantities.gas_HI_to_neutral_H_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-1
     end: 1.1
@@ -396,21 +396,21 @@ stellar_mass_HI_to_neutral_H_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-HI to Neutral Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI mass over HI + H$_2$ mass in a 100 kpc aperture.
+    title: Stellar Mass-HI to Neutral Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI mass over HI + H$_2$ mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
 
-stellar_mass_H2_to_neutral_H_fraction_100:
+stellar_mass_H2_to_neutral_H_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_100_kpc"
+    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -426,20 +426,20 @@ stellar_mass_H2_to_neutral_H_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-H$_2$ to Neutral Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is H$_2$ mass over HI + H$_2$ mass in a 100 kpc aperture.
+    title: Stellar Mass-H$_2$ to Neutral Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is H$_2$ mass over HI + H$_2$ mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
 
-stellar_mass_sf_to_sf_plus_stellar_fraction_100:
+stellar_mass_sf_to_sf_plus_stellar_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_sf_to_sf_plus_stellar_fraction_100_kpc"
+    quantity: "derived_quantities.gas_sf_to_sf_plus_stellar_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -455,53 +455,22 @@ stellar_mass_sf_to_sf_plus_stellar_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-SF gas to SF Gas + Stellar Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is star-forming gas mass over SF gas + stellar mass in a 100 kpc aperture.
+    title: Stellar Mass-SF gas to SF Gas + Stellar Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is star-forming gas mass over SF gas + stellar mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
     show_on_webpage: false
 
-stellar_mass_neutral_H_to_sf_fraction_100:
+stellar_mass_neutral_H_to_sf_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_neutral_H_to_sf_fraction_100_kpc"
-    units: "dimensionless"
-    start: 1e-1
-    end: 10.
-  median:
-    plot: true
-    log: true
-    adaptive: true
-    number_of_bins: 35
-    start:
-      value: 1e5
-      units: Solar_Mass
-    end:
-      value: 1e12
-      units: Solar_Mass
-  metadata:
-    title: Stellar Mass-Neutral to SF Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI + H$_2$ gas mass over SF gas in a 100 kpc aperture.
-    section: Cold Gas Fractions (Stellar Mass)
-    show_on_webpage: false
-
-stellar_mass_HI_to_sf_fraction_100:
-  type: "scatter"
-  legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
-  x:
-    quantity: "apertures.mass_star_100_kpc"
-    units: Solar_Mass
-    start: 1e5
-    end: 1e12
-  y:
-    quantity: "derived_quantities.gas_HI_to_sf_fraction_100_kpc"
+    quantity: "derived_quantities.gas_neutral_H_to_sf_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-1
     end: 10.
@@ -517,22 +486,53 @@ stellar_mass_HI_to_sf_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-HI to SF Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI gas mass over SF gas in a 100 kpc aperture.
+    title: Stellar Mass-Neutral to SF Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI + H$_2$ gas mass over SF gas in a 50 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
     show_on_webpage: false
 
-stellar_mass_H2_to_sf_fraction_100:
+stellar_mass_HI_to_sf_fraction_50:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_H2_to_sf_fraction_100_kpc"
+    quantity: "derived_quantities.gas_HI_to_sf_fraction_50_kpc"
+    units: "dimensionless"
+    start: 1e-1
+    end: 10.
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 35
+    start:
+      value: 1e5
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-HI to SF Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI gas mass over SF gas in a 50 kpc aperture.
+    section: Cold Gas Fractions (Stellar Mass)
+    show_on_webpage: false
+
+stellar_mass_H2_to_sf_fraction_50:
+  type: "scatter"
+  legend_loc: "upper right"
+  selection_mask: "derived_quantities.is_active_50_kpc"
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 1e5
+    end: 1e12
+  y:
+    quantity: "derived_quantities.gas_H2_to_sf_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 10.
@@ -548,21 +548,21 @@ stellar_mass_H2_to_sf_fraction_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-H$_2$ to SF Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is H$_2$ gas mass over SF gas in a 100 kpc aperture.
+    title: Stellar Mass-H$_2$ to SF Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is H$_2$ gas mass over SF gas in a 50 kpc aperture.
     section: Cold Gas Fractions (Stellar Mass)
 
-sfr_neutral_to_stellar_mass_100_kpc_100:
+sfr_neutral_to_stellar_mass_50_kpc_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-3
     end: 10
   y:
-    quantity: "derived_quantities.neutral_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.neutral_to_stellar_mass_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 10
@@ -578,21 +578,21 @@ sfr_neutral_to_stellar_mass_100_kpc_100:
       value: 10
       units: 1 / gigayear
   metadata:
-    title: sSFR-Neutral Gas to SF Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI + H$_2$ mass over stellar mass in a 100 kpc aperture.
+    title: sSFR-Neutral Gas to SF Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI + H$_2$ mass over stellar mass in a 50 kpc aperture.
     section: Cold Gas Fractions (sSFR)
 
-sfr_hi_to_stellar_mass_100_kpc_100:
+sfr_hi_to_stellar_mass_50_kpc_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-3
     end: 10
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 10
@@ -608,21 +608,21 @@ sfr_hi_to_stellar_mass_100_kpc_100:
       value: 10
       units: 1 / gigayear
   metadata:
-    title: sSFR-HI Gas to SF Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI mass over stellar mass in a 100 kpc aperture.
+    title: sSFR-HI Gas to SF Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI mass over stellar mass in a 50 kpc aperture.
     section: Cold Gas Fractions (sSFR)
 
-sfr_h2_to_stellar_mass_100_kpc_100:
+sfr_h2_to_stellar_mass_50_kpc_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-3
     end: 10
   y:
-    quantity: "derived_quantities.h2_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_to_stellar_mass_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -638,22 +638,22 @@ sfr_h2_to_stellar_mass_100_kpc_100:
       value: 10
       units: 1 / gigayear
   metadata:
-    title: sSFR-H$_2$ Gas to SF Gas Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is H$_2$ mass over stellar mass in a 100 kpc aperture.
+    title: sSFR-H$_2$ Gas to SF Gas Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is H$_2$ mass over stellar mass in a 50 kpc aperture.
     section: Cold Gas Fractions (sSFR)
 
 
-sfr_sf_to_stellar_fraction_kpc_100:
+sfr_sf_to_stellar_fraction_kpc_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-3
     end: 10
   y:
-    quantity: "derived_quantities.gas_sf_to_stellar_fraction_100_kpc"
+    quantity: "derived_quantities.gas_sf_to_stellar_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 10
@@ -669,21 +669,21 @@ sfr_sf_to_stellar_fraction_kpc_100:
       value: 10
       units: 1 / gigayear
   metadata:
-    title: sSFR-SF Gas to Stellar Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is SF gas mass over stellar mass in a 100 kpc aperture.
+    title: sSFR-SF Gas to Stellar Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is SF gas mass over stellar mass in a 50 kpc aperture.
     section: Cold Gas Fractions (sSFR)
     show_on_webpage: false
 
-sigma_neutral_H_to_baryonic_fraction_100:
+sigma_neutral_H_to_baryonic_fraction_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "derived_quantities.mu_star_100_kpc"
+    quantity: "derived_quantities.mu_star_50_kpc"
     units: "Solar_Mass / kpc**2"
     start: 1e5
     end: 1e10
   y:
-    quantity: "derived_quantities.gas_neutral_H_to_baryonic_fraction_100_kpc"
+    quantity: "derived_quantities.gas_neutral_H_to_baryonic_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -699,23 +699,23 @@ sigma_neutral_H_to_baryonic_fraction_100:
       value: 1e10
       units: "Solar_Mass / kpc**2"
   metadata:
-    title: Surface Density-Neutral Gas to Baryonic Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is neutral gas mass over baryonic mass in a 100 kpc aperture.
+    title: Surface Density-Neutral Gas to Baryonic Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is neutral gas mass over baryonic mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
     show_on_webpage: false
 
 
-sigma_hi_to_neutral_H_fraction_100:
+sigma_hi_to_neutral_H_fraction_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.mu_star_100_kpc"
+    quantity: "derived_quantities.mu_star_50_kpc"
     units: "Solar_Mass / kpc**2"
     start: 1e5
     end: 1e10
   y:
-    quantity: "derived_quantities.gas_HI_to_neutral_H_fraction_100_kpc"
+    quantity: "derived_quantities.gas_HI_to_neutral_H_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-1
     end: 1.1
@@ -731,22 +731,22 @@ sigma_hi_to_neutral_H_fraction_100:
       value: 1e10
       units: "Solar_Mass / kpc**2"
   metadata:
-    title: Surface Density-HI Gas to Neutral Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is HI gas mass over neutral gas mass in a 100 kpc aperture.
+    title: Surface Density-HI Gas to Neutral Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is HI gas mass over neutral gas mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
     show_on_webpage: false
 
-sigma_h2_to_neutral_H_fraction_100:
+sigma_h2_to_neutral_H_fraction_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.mu_star_100_kpc"
+    quantity: "derived_quantities.mu_star_50_kpc"
     units: "Solar_Mass / kpc**2"
     start: 1e5
     end: 1e10
   y:
-    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_100_kpc"
+    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -762,21 +762,21 @@ sigma_h2_to_neutral_H_fraction_100:
       value: 1e10
       units: "Solar_Mass / kpc**2"
   metadata:
-    title: Surface Density-H$_2$ Gas to Neutral Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is H$_2$ gas mass over neutral gas mass in a 100 kpc aperture.
+    title: Surface Density-H$_2$ Gas to Neutral Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is H$_2$ gas mass over neutral gas mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
     show_on_webpage: false
 
-sigma_sf_to_sf_plus_stellar_fraction_100:
+sigma_sf_to_sf_plus_stellar_fraction_50:
   type: "scatter"
   legend_loc: "upper left"  
   x:
-    quantity: "derived_quantities.mu_star_100_kpc"
+    quantity: "derived_quantities.mu_star_50_kpc"
     units: "Solar_Mass / kpc**2"
     start: 1e5
     end: 1e10
   y:
-    quantity: "derived_quantities.gas_sf_to_sf_plus_stellar_fraction_100_kpc"
+    quantity: "derived_quantities.gas_sf_to_sf_plus_stellar_fraction_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1.1
@@ -792,7 +792,7 @@ sigma_sf_to_sf_plus_stellar_fraction_100:
       value: 1e10
       units: "Solar_Mass / kpc**2"
   metadata:
-    title: Surface Density-SF Gas to SF Gas + Stellar Fraction (100 kpc aperture)
-    caption: All galaxies are included in the median line. Fraction is SF gas mass over SF gas mass + Stellar mass in a 100 kpc aperture.
+    title: Surface Density-SF Gas to SF Gas + Stellar Fraction (50 kpc aperture)
+    caption: All galaxies are included in the median line. Fraction is SF gas mass over SF gas mass + Stellar mass in a 50 kpc aperture.
     section: Cold Gas Fractions (Surface Density)
     show_on_webpage: false

--- a/colibre/auto_plotter/depletion_relations.yml
+++ b/colibre/auto_plotter/depletion_relations.yml
@@ -1,15 +1,15 @@
 oxygen_abundance_v_dust_to_gas:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.gas_o_abundance_avglog_low_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_avglog_low_50_kpc"
     units: "dimensionless"
     start: 6.8
     end: 9.2
     log: false
   y:
-    quantity: "derived_quantities.dust_to_gas_ratio_100_kpc"
+    quantity: "derived_quantities.dust_to_gas_ratio_50_kpc"
     units: "dimensionless"
     start: 1e-7
     end: 0.01
@@ -31,7 +31,7 @@ oxygen_abundance_v_dust_to_gas:
       value: 1
       units: "dimensionless"
   metadata:
-    title:  Oxygen abundance vs dust-to-gas ratio (100 kpc aperture)
+    title:  Oxygen abundance vs dust-to-gas ratio (50 kpc aperture)
     caption: Dust-to-gas mass ratio as a function of oxygen number density abundance.
     section: Dust Depletion Relations
     show_on_webpage: true

--- a/colibre/auto_plotter/dust_mass_function.yml
+++ b/colibre/auto_plotter/dust_mass_function.yml
@@ -3,7 +3,7 @@ dust_mass_function:
   legend_loc: "lower left"
   number_of_bins: 30
   x:
-    quantity: "derived_quantities.total_dust_masses_100_kpc"
+    quantity: "derived_quantities.total_dust_masses_50_kpc"
     units: Solar_Mass
     start: 1e4
     end: 1e10
@@ -14,7 +14,7 @@ dust_mass_function:
   metadata:
     section: Dust Mass Functions
     title: Dust Mass Function
-    caption: 100 kpc aperture Galaxy Dust Mass Function, showing all galaxies with a fixed bin-width of 0.2 dex.
+    caption: 50 kpc aperture Galaxy Dust Mass Function, showing all galaxies with a fixed bin-width of 0.2 dex.
   observational_data:
     - filename: GalaxyDustMassFunction/Pozzi2020_z000p100.hdf5
     - filename: GalaxyDustMassFunction/Pozzi2020_z001p800.hdf5
@@ -25,7 +25,7 @@ adaptive_dust_mass_function:
   legend_loc: "lower left"
   number_of_bins: 30
   x:
-    quantity: "derived_quantities.total_dust_masses_100_kpc"
+    quantity: "derived_quantities.total_dust_masses_50_kpc"
     units: Solar_Mass
     start: 1e4
     end: 1e10
@@ -36,7 +36,7 @@ adaptive_dust_mass_function:
   metadata:
     section: Dust Mass Functions
     title: Dust Mass Function
-    caption: 100 kpc aperture Galaxy Dust Mass Function, showing all galaxies with an adaptive bin-width.
+    caption: 50 kpc aperture Galaxy Dust Mass Function, showing all galaxies with an adaptive bin-width.
   observational_data:
     - filename: GalaxyDustMassFunction/Pozzi2020_z000p100.hdf5
     - filename: GalaxyDustMassFunction/Pozzi2020_z001p800.hdf5

--- a/colibre/auto_plotter/dust_scaling_relations.yml
+++ b/colibre/auto_plotter/dust_scaling_relations.yml
@@ -1,15 +1,15 @@
 hi_stellar_fraction_dust_to_metal_ratio:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.dust_to_metal_ratio_100_kpc"
+    quantity: "derived_quantities.dust_to_metal_ratio_50_kpc"
     units: "dimensionless"
     start: 1e-3
     end: 5
     log: true
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "dimensionless"
     start: 3e-2
     end: 5
@@ -27,7 +27,7 @@ hi_stellar_fraction_dust_to_metal_ratio:
       units: "dimensionless"
   metadata:
     title: HI-to-stellar mass ratio vs dust-to-metal ratio
-    caption: HI to stellar mass ratio as a function of the dust-to-metal ratio measured in 100kpc apertures
+    caption: HI to stellar mass ratio as a function of the dust-to-metal ratio measured in 50kpc apertures
     section: Dust Scaling Relations
     show_on_webpage: true
   observational_data:
@@ -36,15 +36,15 @@ hi_stellar_fraction_dust_to_metal_ratio:
 hi_stellar_fraction_dust_to_stellar_ratio:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.dust_to_stellar_ratio_100_kpc"
+    quantity: "derived_quantities.dust_to_stellar_ratio_50_kpc"
     units: "dimensionless"
     start: 1e-4
     end: 1e-2
     log: true
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "dimensionless"
     start: 3e-2
     end: 5
@@ -62,7 +62,7 @@ hi_stellar_fraction_dust_to_stellar_ratio:
       units: "dimensionless"
   metadata:
     title: HI-to-stellar mass ratio vs dust-to-stellar mass ratio
-    caption: HI to stellar mass ratio as a function of the dust-to-stellar mass ratio measured in 100kpc apertures
+    caption: HI to stellar mass ratio as a function of the dust-to-stellar mass ratio measured in 50kpc apertures
     section: Dust Scaling Relations
     show_on_webpage: true
   observational_data:
@@ -71,15 +71,15 @@ hi_stellar_fraction_dust_to_stellar_ratio:
 hi_stellar_fraction_o_abundance:
   type: "scatter"
   legend_loc: "upper right"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "derived_quantities.gas_o_abundance_avglog_low_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_avglog_low_50_kpc"
     units: "dimensionless"
     start: 6.8
     end: 9.2
     log: false
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "dimensionless"
     start: 3e-2
     end: 5
@@ -97,7 +97,7 @@ hi_stellar_fraction_o_abundance:
       units: "dimensionless"
   metadata:
     title: HI-to-stellar mass ratio vs Oxygen abundance
-    caption: HI to stellar mass ratio as a function of the gas-phase Oxygen abundance measured in 100 kpc apertures
+    caption: HI to stellar mass ratio as a function of the gas-phase Oxygen abundance measured in 50 kpc apertures
     section: Dust Scaling Relations
     show_on_webpage: true
   observational_data:

--- a/colibre/auto_plotter/feedback_densities.yml
+++ b/colibre/auto_plotter/feedback_densities.yml
@@ -27,11 +27,11 @@ snii_thermal_feedback_density_halo_mass_max_all:
     caption: Includes all haloes, including subhaloes.
     section: Feedback Densities
 
-snii_thermal_feedback_density_stellar_mass_max_all_100:
+snii_thermal_feedback_density_stellar_mass_max_all_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e4
     end: 1e12

--- a/colibre/auto_plotter/galaxy_sizes.yml
+++ b/colibre/auto_plotter/galaxy_sizes.yml
@@ -1,13 +1,13 @@
-stellar_mass_galaxy_size_100:
+stellar_mass_galaxy_size_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "apertures.rhalfmass_star_100_kpc"
+    quantity: "apertures.rhalfmass_star_50_kpc"
     units: kpc
     start: 3e-1
     end: 3e1
@@ -23,8 +23,8 @@ stellar_mass_galaxy_size_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Galaxy Size relation (100 kpc aperture)
-    caption: Uses a 100 kpc 3D aperture.
+    title: Stellar Mass-Galaxy Size relation (50 kpc aperture)
+    caption: Uses a 50 kpc 3D aperture.
     section: Sizes
   observational_data:
     - filename: GalaxyStellarMassGalaxySize/Trujillo2020.hdf5
@@ -63,16 +63,16 @@ stellar_mass_galaxy_size_30:
     - filename: GalaxyStellarMassGalaxySize/Trujillo2020.hdf5
     - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p1.hdf5
 
-stellar_mass_projected_galaxy_size_100:
+stellar_mass_projected_galaxy_size_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "projected_apertures.projected_1_rhalfmass_star_100_kpc"
+    quantity: "projected_apertures.projected_1_rhalfmass_star_50_kpc"
     units: kpc
     start: 1e-1
     end: 3e1
@@ -88,8 +88,8 @@ stellar_mass_projected_galaxy_size_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-(Projected) Galaxy Size relation (100 kpc aperture)
-    caption: Uses stellar sizes calculated from a projected distribution within a 100 kpc aperture.
+    title: Stellar Mass-(Projected) Galaxy Size relation (50 kpc aperture)
+    caption: Uses stellar sizes calculated from a projected distribution within a 50 kpc aperture.
     section: Sizes
   observational_data:
     - filename: GalaxyStellarMassGalaxySize/Lange2015HBand.hdf5
@@ -122,7 +122,7 @@ stellar_mass_projected_galaxy_size_30:
       units: Solar_Mass
   metadata:
     title: Stellar Mass-(Projected) Galaxy Size relation (30 kpc aperture)
-    caption: Uses stellar sizes calculated from a projected distribution within a 100 kpc aperture.
+    caption: Uses stellar sizes calculated from a projected distribution within a 50 kpc aperture.
     section: Sizes
     show_on_webpage: false
   observational_data:
@@ -130,19 +130,19 @@ stellar_mass_projected_galaxy_size_30:
     - filename: GalaxyStellarMassGalaxySize/Lange2015rBand.hdf5
     - filename: GalaxyStellarMassGalaxySize/xGASS.hdf5
 
-stellar_mass_projected_galaxy_size_active_only_100:
+stellar_mass_projected_galaxy_size_active_only_50:
   type: "scatter"
   comment: "Active only"
   comment_loc: "lower left"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "projected_apertures.projected_1_rhalfmass_star_100_kpc"
+    quantity: "projected_apertures.projected_1_rhalfmass_star_50_kpc"
     units: kpc
     start: 1e-1
     end: 3e1
@@ -158,7 +158,7 @@ stellar_mass_projected_galaxy_size_active_only_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-(Projected) Galaxy Size relation (100 kpc aperture)
+    title: Stellar Mass-(Projected) Galaxy Size relation (50 kpc aperture)
     caption: Only shows active galaxies defined based on their sSFRs.
     section: Sizes
   observational_data:
@@ -203,19 +203,19 @@ stellar_mass_projected_galaxy_size_active_only_30:
     - filename: GalaxyStellarMassGalaxySize/Lange2015HBand_blue.hdf5
     - filename: GalaxyStellarMassGalaxySize/Mosleh2020_SF.hdf5
 
-stellar_mass_projected_galaxy_size_passive_only_100:
+stellar_mass_projected_galaxy_size_passive_only_50:
   type: "scatter"
   comment: "Passive only"
   comment_loc: "lower left"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_passive_100_kpc"
+  selection_mask: "derived_quantities.is_passive_50_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "projected_apertures.projected_1_rhalfmass_star_100_kpc"
+    quantity: "projected_apertures.projected_1_rhalfmass_star_50_kpc"
     units: kpc
     start: 1e-1
     end: 3e1
@@ -231,7 +231,7 @@ stellar_mass_projected_galaxy_size_passive_only_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-(Projected) Galaxy Size relation (100 kpc aperture)
+    title: Stellar Mass-(Projected) Galaxy Size relation (50 kpc aperture)
     caption: Only shows passive galaxies defined based on their sSFRs.
     section: Sizes
   observational_data:

--- a/colibre/auto_plotter/gas_fraction_plots.yml
+++ b/colibre/auto_plotter/gas_fraction_plots.yml
@@ -4,12 +4,12 @@ h2_frac_func_stellar_mass_xgass_selection:
   selection_mask: "derived_quantities.xcoldgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e9
     end: 1e12
   y:
-    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -27,7 +27,7 @@ h2_frac_func_stellar_mass_xgass_selection:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 50 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
     show_on_webpage: false
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
@@ -38,12 +38,12 @@ h2_frac_func_ssfr:
   selection_mask: "derived_quantities.xcoldgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-4
     end: 1e4
   y:
-    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -61,7 +61,7 @@ h2_frac_func_ssfr:
   metadata:
     title: sSFR-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 50 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_sSFR.hdf5
 
@@ -71,12 +71,12 @@ h2_frac_func_stellar_surface_density_xgass_selection:
   selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "derived_quantities.mu_star_100_kpc"
+    quantity: "derived_quantities.mu_star_50_kpc"
     units: "Solar_Mass / (kpc**2)"
     start: 1e7
     end: 1e11
   y:
-    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -94,7 +94,7 @@ h2_frac_func_stellar_surface_density_xgass_selection:
   metadata:
     title: Stellar Mass Surface Density-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass surfaced density in 0.2 dex bins, measured in 50 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_mu_star.hdf5
 
@@ -104,12 +104,12 @@ hi_frac_func_stellar_mass_xgass_selection:
   selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e9
     end: 1e12
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -127,7 +127,7 @@ hi_frac_func_stellar_mass_xgass_selection:
   metadata:
     title: Stellar Mass-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures.
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 50 kpc apertures.
     show_on_webpage: false
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_M_star.hdf5
@@ -138,12 +138,12 @@ hi_frac_func_ssfr:
   selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-4
     end: 1e4
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -161,7 +161,7 @@ hi_frac_func_ssfr:
   metadata:
     title: sSFR-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy HI mass over stellar mass as a function of specific star formation rate in 0.2 dex bins, measured in 50 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -171,12 +171,12 @@ hi_frac_func_stellar_surface_density:
   selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "derived_quantities.mu_star_100_kpc"
+    quantity: "derived_quantities.mu_star_50_kpc"
     units: "Solar_Mass / (kpc**2)"
     start: 1e7
     end: 1e11
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -194,7 +194,7 @@ hi_frac_func_stellar_surface_density:
   metadata:
     title: Stellar Mass Surface Density-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass surface density in 0.2 dex bins, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass surface density in 0.2 dex bins, measured in 50 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_mu_star.hdf5
 
@@ -202,12 +202,12 @@ h2_frac_func_stellar_mass:
   type: "scatter"
   legend_loc: "lower left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.h2_plus_he_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -225,7 +225,7 @@ h2_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-H$_2$ Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
+    caption: Galaxy H$_2$ mass (including Helium following the observations) over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 50 kpc apertures. To include Helium we multiply $M_{\rm H_2}/M_{\rm star}$ by $(1+M_{\rm He}/M_{\rm H})$. The median values are shown. In Saintonge2017+ data, all galaxies with $10^9 < M_{\rm star} / \mathrm{M_\odot} < 10^{10}$ have $M_{\rm H_2}/M_{\rm star}$ fractions that cannot be lower than $0.025$, and for galaxies with $M_{\rm star} / \mathrm{M_\odot} > 10^{10}$ the floor value is $0.015$.
   observational_data:
     - filename: GalaxyH2Fractions/Saintonge2017_abcissa_M_star.hdf5
     - filename: GalaxyH2Fractions/Hunt2020_Data.hdf5
@@ -237,12 +237,12 @@ hi_frac_func_stellar_mass:
   type: "scatter"
   legend_loc: "lower left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.hi_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.hi_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -260,7 +260,7 @@ hi_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-HI Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. LITTLE THINGS galaxies are dIrrs selected to be within 10 Mpc, with 50$\%$ of galaxies within 3.6 Mpc, and detected in HI. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy HI mass over stellar mass as a function of stellar mass in 0.2 dex bins, measured in 50 kpc apertures. LITTLE THINGS galaxies are dIrrs selected to be within 10 Mpc, with 50$\%$ of galaxies within 3.6 Mpc, and detected in HI. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyHIFractions/Catinella2018_abcissa_M_star.hdf5
     - filename: GalaxyHIFractions/Hunt2020_Data.hdf5
@@ -274,12 +274,12 @@ cold_gas_frac_func_ssfr:
   selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-4
     end: 6e1
   y:
-    quantity: "derived_quantities.neutral_to_stellar_mass_100_kpc"
+    quantity: "derived_quantities.neutral_to_stellar_mass_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 100
@@ -297,7 +297,7 @@ cold_gas_frac_func_ssfr:
   metadata:
     title: sSFR-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy neutral gas mass over stellar mass as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy neutral gas mass over stellar mass as a function of specific star formation rate, with adaptive binning, measured in 50 kpc apertures. XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyColdGasFractions/Catinella2018_abcissa_sSFR.hdf5
 
@@ -305,12 +305,12 @@ h2_to_neutral_gas_frac_func_stellar_mass:
   type: "scatter"
   legend_loc: "lower left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e5
     end: 1e12
   y:
-    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_100_kpc"
+    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-6
     end: 1
@@ -328,7 +328,7 @@ h2_to_neutral_gas_frac_func_stellar_mass:
   metadata:
     title: Stellar Mass-Cold gas Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass over neutral gas (HI+H$_2$) mass as a function of stellar mass in 0.2 dex bins, measured in 100 kpc apertures. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS and XCOLDGASS samples are uniform in mass in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$ and $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$ and plotting those above the CO detection limit ($M_{\rm H2}/M_*$ > $1.5\%$). 
+    caption: Galaxy H$_2$ mass over neutral gas (HI+H$_2$) mass as a function of stellar mass in 0.2 dex bins, measured in 50 kpc apertures. MAGMA (Hunt+20) are selected on both CO and HI detecions, but find the galaxies down to $10^7 \; {\rm M_\odot}$ consistent with the extrapolated SFMS (i.e. typical star-forming galaxies). XGASS and XCOLDGASS samples are uniform in mass in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$ and $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$ and plotting those above the CO detection limit ($M_{\rm H2}/M_*$ > $1.5\%$).
   observational_data:
     - filename: GalaxyColdGasFractions/CatinellaSaintongeComposite_abcissa_M_star.hdf5
     - filename: GalaxyColdGasFractions/Hunt2020_Data.hdf5
@@ -341,12 +341,12 @@ h2_to_neutral_gas_frac_func_ssfr:
   selection_mask: "derived_quantities.xgass_galaxy_selection"
   comment: "$10^9 M_{\\odot} < M_{\\ast} < 10^{11.5} M_{\\odot}$"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 1e-4
     end: 6e1
   y:
-    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_100_kpc"
+    quantity: "derived_quantities.gas_H2_to_neutral_H_fraction_50_kpc"
     units: "Solar_Mass / Solar_Mass"
     start: 1e-4
     end: 1
@@ -364,7 +364,7 @@ h2_to_neutral_gas_frac_func_ssfr:
   metadata:
     title: sSFR-Neutral Fraction
     section: Cold Gas Data Comparison
-    caption: Galaxy H$_2$ mass over neutral gas mass (HI+H$_2$) as a function of specific star formation rate, with adaptive binning, measured in 100 kpc apertures. XCOLDGASS (Saintonge+17) and XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
+    caption: Galaxy H$_2$ mass over neutral gas mass (HI+H$_2$) as a function of specific star formation rate, with adaptive binning, measured in 50 kpc apertures. XCOLDGASS (Saintonge+17) and XGASS (Catinella+18) galaxies are selected to have a flat $M_\star$ distribution in the range $10^9 \; {\rm M_\odot} > M_\star > 10^{10} \; {\rm M_\odot}$, and a higher normalised uniform in the range $10^{10} \; {\rm M_\odot} > M_\star > 10^{11} \; {\rm M_\odot}$.
   observational_data:
     - filename: GalaxyColdGasFractions/CatinellaSaintongeComposite_abcissa_sSFR.hdf5
 

--- a/colibre/auto_plotter/gas_mass_functions.yml
+++ b/colibre/auto_plotter/gas_mass_functions.yml
@@ -3,7 +3,7 @@ gas_HI_mass_function:
   legend_loc: "lower left"
   number_of_bins: 25
   x:
-    quantity: "derived_quantities.gas_HI_mass_100_kpc"
+    quantity: "derived_quantities.gas_HI_mass_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e11
@@ -13,7 +13,7 @@ gas_HI_mass_function:
     end: 0.316 # (1e-0.5)
   metadata:
     title: HI Mass Function
-    caption: HIMF, showing all galaxies with a fixed bin-width of 0.2 dex (HI masses 100 kpc).
+    caption: HIMF, showing all galaxies with a fixed bin-width of 0.2 dex (HI masses 50 kpc).
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyHIMassFunction/Zwaan2003.hdf5
@@ -25,7 +25,7 @@ adaptive_gas_HI_mass_function:
   legend_loc: "lower left"
   number_of_bins: 25
   x:
-    quantity: "derived_quantities.gas_HI_mass_100_kpc"
+    quantity: "derived_quantities.gas_HI_mass_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e11
@@ -35,7 +35,7 @@ adaptive_gas_HI_mass_function:
     end: 0.316 # (1e-0.5)
   metadata:
     title: HI Mass Function
-    caption: HIMF, showing all galaxies with an adaptive bin-width (HI masses 100 kpc).
+    caption: HIMF, showing all galaxies with an adaptive bin-width (HI masses 50 kpc).
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyHIMassFunction/Zwaan2003.hdf5
@@ -47,7 +47,7 @@ gas_H2_mass_function:
   legend_loc: "lower left"
   number_of_bins: 25
   x:
-    quantity: "derived_quantities.gas_H2_plus_He_mass_100_kpc"
+    quantity: "derived_quantities.gas_H2_plus_He_mass_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e11
@@ -57,7 +57,7 @@ gas_H2_mass_function:
     end: 0.316 # (1e-0.5)
   metadata:
     title: H$_2$ Mass Function
-    caption: H$_2$ MF, showing all galaxies with a fixed bin-width of 0.2 dex. H$_2$ mass corrected for Helium (uses H$_2$ masses in 100 kpc apertures)
+    caption: H$_2$ MF, showing all galaxies with a fixed bin-width of 0.2 dex. H$_2$ mass corrected for Helium (uses H$_2$ masses in 50 kpc apertures)
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyH2MassFunction/Fletcher2020.hdf5
@@ -67,7 +67,7 @@ adaptive_gas_H2_mass_function:
   legend_loc: "lower left"
   number_of_bins: 25
   x:
-    quantity: "derived_quantities.gas_H2_plus_He_mass_100_kpc"
+    quantity: "derived_quantities.gas_H2_plus_He_mass_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e11
@@ -77,7 +77,7 @@ adaptive_gas_H2_mass_function:
     end: 0.316 # (1e-0.5)
   metadata:
     title: H$_2$ Mass Function
-    caption: H$_2$ MF, showing all galaxies with an adaptive bin-width. H$_2$ mass corrected for Helium (uses H$_2$ masses in 100 kpc apertures)
+    caption: H$_2$ MF, showing all galaxies with an adaptive bin-width. H$_2$ mass corrected for Helium (uses H$_2$ masses in 50 kpc apertures)
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyH2MassFunction/Fletcher2020.hdf5

--- a/colibre/auto_plotter/histograms.yml
+++ b/colibre/auto_plotter/histograms.yml
@@ -58,60 +58,60 @@ stellar_mass_cumulative_histogram_passive_only_30:
     section: Histograms
     show_on_webpage: false
 
-stellar_mass_cumulative_histogram_100:
+stellar_mass_cumulative_histogram_50:
   type: "cumulative_histogram"
   reverse_cumsum: true
   legend_loc: "upper right"
   number_of_bins: 120
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   histogram:
     scatter: "none"
   metadata:
-    title: Stellar Mass Histogram (100 kpc aperture)
+    title: Stellar Mass Histogram (50 kpc aperture)
     caption: Cumulative histogram of stellar masses using the same bins as the mass function.
     section: Histograms
 
-stellar_mass_cumulative_histogram_active_only_100:
+stellar_mass_cumulative_histogram_active_only_50:
   type: "cumulative_histogram"
   reverse_cumsum: true
   legend_loc: "upper right"
   comment: "Active only"
   comment_loc: "upper center"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   number_of_bins: 120
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   histogram:
     scatter: "none"
   metadata:
-    title: Stellar Mass Histogram (100 kpc aperture, active)
+    title: Stellar Mass Histogram (50 kpc aperture, active)
     caption: Only for active galaxies.
     section: Histograms
 
-stellar_mass_cumulative_histogram_passive_only_100:
+stellar_mass_cumulative_histogram_passive_only_50:
   type: "cumulative_histogram"
   reverse_cumsum: true
   legend_loc: "upper right"
   comment: "Passive only"
   comment_loc: "upper center"
-  selection_mask: "derived_quantities.is_passive_100_kpc"
+  selection_mask: "derived_quantities.is_passive_50_kpc"
   number_of_bins: 120
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   histogram:
     scatter: "none"
   metadata:
-    title: Stellar Mass Histogram (100 kpc aperture, passive)
+    title: Stellar Mass Histogram (50 kpc aperture, passive)
     caption: Only for passive galaxies.
     section: Histograms
 
@@ -150,20 +150,20 @@ star_formation_rate_cumulative_histogram_30:
     section: Histograms
     show_on_webpage: false
 
-star_formation_rate_cumulative_histogram_100:
+star_formation_rate_cumulative_histogram_50:
   type: "cumulative_histogram"
   reverse_cumsum: true
   legend_loc: "upper right"
   number_of_bins: 120
   x:
-    quantity: "apertures.sfr_gas_100_kpc"
+    quantity: "apertures.sfr_gas_50_kpc"
     units: "Solar_Mass / year"
     start: 1e-3
     end: 1e3
   histogram:
     scatter: "none"
   metadata:
-    title: Star Formation Rate Histogram (100 kpc aperture)
+    title: Star Formation Rate Histogram (50 kpc aperture)
     caption: Cumulative histogram of star formation rates using the same bins as the star formation rates function.
     section: Histograms
 
@@ -241,59 +241,59 @@ stellar_mass_histogram_passive_only_30:
     section: Histograms
     show_on_webpage: false
 
-stellar_mass_histogram_100:
+stellar_mass_histogram_50:
   type: "histogram"
   legend_loc: "upper right"
   number_of_bins: 120
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   histogram:
     scatter: "none"
   metadata:
-    title: Stellar Mass Histogram (100 kpc aperture)
+    title: Stellar Mass Histogram (50 kpc aperture)
     caption: Histogram of stellar masses using the same bins as the mass function.
     section: Histograms
     show_on_webpage: false
 
-stellar_mass_histogram_active_only_100:
+stellar_mass_histogram_active_only_50:
   type: "histogram"
   legend_loc: "upper right"
   comment: "Active only"
   comment_loc: "upper center"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   number_of_bins: 120
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   histogram:
     scatter: "none"
   metadata:
-    title: Stellar Mass Histogram (100 kpc aperture, active)
+    title: Stellar Mass Histogram (50 kpc aperture, active)
     caption: Only for active galaxies.
     section: Histograms
     show_on_webpage: false
 
-stellar_mass_histogram_passive_only_100:
+stellar_mass_histogram_passive_only_50:
   type: "histogram"
   legend_loc: "upper right"
   comment: "Passive only"
   comment_loc: "upper center"
-  selection_mask: "derived_quantities.is_passive_100_kpc"
+  selection_mask: "derived_quantities.is_passive_50_kpc"
   number_of_bins: 120
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   histogram:
     scatter: "none"
   metadata:
-    title: Stellar Mass Histogram (100 kpc aperture, passive)
+    title: Stellar Mass Histogram (50 kpc aperture, passive)
     caption: Only for passive galaxies.
     section: Histograms
     show_on_webpage: false
@@ -332,19 +332,19 @@ star_formation_rate_histogram_30:
     section: Histograms
     show_on_webpage: false
 
-star_formation_rate_histogram_100:
+star_formation_rate_histogram_50:
   type: "histogram"
   legend_loc: "upper right"
   number_of_bins: 120
   x:
-    quantity: "apertures.sfr_gas_100_kpc"
+    quantity: "apertures.sfr_gas_50_kpc"
     units: "Solar_Mass / year"
     start: 1e-3
     end: 1e3
   histogram:
     scatter: "none"
   metadata:
-    title: Star Formation Rate Histogram (100 kpc aperture)
+    title: Star Formation Rate Histogram (50 kpc aperture)
     caption: Histogram of star formation rates using the same bins as the star formation rates function.
     section: Histograms
     show_on_webpage: false

--- a/colibre/auto_plotter/mass_functions.yml
+++ b/colibre/auto_plotter/mass_functions.yml
@@ -110,12 +110,12 @@ adaptive_stellar_mass_function_passive_only_30:
     - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
 
-stellar_mass_function_100:
+stellar_mass_function_50:
   type: "massfunction"
   legend_loc: "lower left"
   number_of_bins: 30
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
@@ -124,8 +124,8 @@ stellar_mass_function_100:
     start: 1e-6
     end: 1e0
   metadata:
-    title: Stellar Mass Function (100 kpc aperture)
-    caption: 100 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex.
+    title: Stellar Mass Function (50 kpc aperture)
+    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex.
     section: Stellar Mass Function
   observational_data:
     - filename: GalaxyStellarMassFunction/LiWhite2009.hdf5
@@ -136,12 +136,12 @@ stellar_mass_function_100:
     - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
     - filename: GalaxyStellarMassFunction/Driver2021.hdf5
 
-adaptive_stellar_mass_function_100:
+adaptive_stellar_mass_function_50:
   type: "adaptivemassfunction"
   legend_loc: "lower left"
   number_of_bins: 30
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
@@ -150,8 +150,8 @@ adaptive_stellar_mass_function_100:
     start: 1e-6
     end: 1e0
   metadata:
-    title: Stellar Mass Function (100 kpc aperture, adaptive)
-    caption: 100 kpc aperture GSMF, showing all galaxies with an adaptive bin-width.
+    title: Stellar Mass Function (50 kpc aperture, adaptive)
+    caption: 50 kpc aperture GSMF, showing all galaxies with an adaptive bin-width.
     section: Stellar Mass Function
   observational_data:
     - filename: GalaxyStellarMassFunction/LiWhite2009.hdf5
@@ -162,7 +162,7 @@ adaptive_stellar_mass_function_100:
     - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
     - filename: GalaxyStellarMassFunction/Driver2021.hdf5
 
-adaptive_stellar_mass_function_passive_only_100:
+adaptive_stellar_mass_function_passive_only_50:
   type: "massfunction"
   number_of_bins: 30
   legend_loc: "lower left"
@@ -170,7 +170,7 @@ adaptive_stellar_mass_function_passive_only_100:
   comment_loc: "lower right"
   selection_mask: "derived_quantities.is_passive_30_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
@@ -179,7 +179,7 @@ adaptive_stellar_mass_function_passive_only_100:
     start: 1e-6
     end: 1e0
   metadata:
-    title: Stellar Mass Function (100 kpc aperture)
+    title: Stellar Mass Function (50 kpc aperture)
     caption: Only for passive galaxies, using an adaptive bin width.
     section: Stellar Mass Function
   observational_data:
@@ -190,7 +190,7 @@ adaptive_stellar_mass_function_passive_only_100:
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
     - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
-adaptive_stellar_mass_function_active_only_100:
+adaptive_stellar_mass_function_active_only_50:
   type: "adaptivemassfunction"
   number_of_bins: 30
   legend_loc: "lower left"
@@ -198,7 +198,7 @@ adaptive_stellar_mass_function_active_only_100:
   comment_loc: "lower right"
   selection_mask: "derived_quantities.is_active_30_kpc"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
@@ -207,7 +207,7 @@ adaptive_stellar_mass_function_active_only_100:
     start: 1e-6
     end: 1e0
   metadata:
-    title: Stellar Mass Function (100 kpc aperture)
+    title: Stellar Mass Function (50 kpc aperture)
     caption: Only for active galaxies, using an adaptive bin width.
     section: Stellar Mass Function
   observational_data:

--- a/colibre/auto_plotter/metallicity.yml
+++ b/colibre/auto_plotter/metallicity.yml
@@ -36,19 +36,19 @@ stellar_mass_gas_sf_metallicity_fromz_lom_30:
     - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
-stellar_mass_gas_sf_metallicity_fromz_lom_100:
+stellar_mass_gas_sf_metallicity_fromz_lom_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only, LoM, Diffuse, from Z"
   y:
-    quantity: "derived_quantities.gas_o_abundance_fromz_avglin_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_fromz_avglin_50_kpc"
     log: false
     units: "dimensionless"
     start: 7
     end: 10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -64,7 +64,7 @@ stellar_mass_gas_sf_metallicity_fromz_lom_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, from Z, 100 kpc aperture)"
+    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, from Z, 50 kpc aperture)"
     caption: Only shown for star forming galaxies. Computed as the average mass-weighted metal mass fraction (converted to 12 + $\log_{10}$ O/H by assuming solar abundance patterns) of cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Gas Metallicity
     show_on_webpage: true
@@ -112,19 +112,19 @@ stellar_mass_gas_sf_metallicity_lom_30:
     - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
-stellar_mass_gas_sf_metallicity_lom_100:
+stellar_mass_gas_sf_metallicity_lom_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only, LoM, Diffuse, from O"
   y:
-    quantity: "derived_quantities.gas_o_abundance_avglin_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_avglin_50_kpc"
     log: false
     units: "dimensionless"
     start: 7
     end: 10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -140,7 +140,7 @@ stellar_mass_gas_sf_metallicity_lom_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, 100 kpc aperture)"
+    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, 50 kpc aperture)"
     caption: Only shown for star forming galaxies. Represented by 12 + $\log_{10}$ O/H (where O/H is linearly averaged for diffuse O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Gas Metallicity
     show_on_webpage: true
@@ -188,19 +188,19 @@ stellar_mass_gas_sf_metallicity_total_lom_30:
     - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
-stellar_mass_gas_sf_metallicity_total_lom_100:
+stellar_mass_gas_sf_metallicity_total_lom_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only, LoM, Total (Diffuse + Dust), from O"
   y:
-    quantity: "derived_quantities.gas_o_abundance_total_avglin_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_total_avglin_50_kpc"
     log: false
     units: "dimensionless"
     start: 7
     end: 10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -216,7 +216,7 @@ stellar_mass_gas_sf_metallicity_total_lom_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Gas (Diffuse + Dust) metallicity relation (log-of-mean, 100 kpc aperture)"
+    title: "Stellar mass - Gas (Diffuse + Dust) metallicity relation (log-of-mean, 50 kpc aperture)"
     caption: Only shown for star forming galaxies. Represented by 12 + $\log_{10}$ O/H (where O/H is linearly averaged for total O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses undepleted gas metallicity, i.e. it includes metals that are present in dust.
     section: Gas Metallicity
     show_on_webpage: true
@@ -264,19 +264,19 @@ stellar_mass_gas_sf_metallicity_mol_lowfloor_30:
     - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
-stellar_mass_gas_sf_metallicity_mol_lowfloor_100:
+stellar_mass_gas_sf_metallicity_mol_lowfloor_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only, MoL w. [O/H]=-4 floor, Diffuse, from O"
   y:
-    quantity: "derived_quantities.gas_o_abundance_avglog_low_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_avglog_low_50_kpc"
     log: false
     units: "dimensionless"
     start: 7
     end: 10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -292,7 +292,7 @@ stellar_mass_gas_sf_metallicity_mol_lowfloor_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Gas diffuse metallicity relation (mean-of-log, 100 kpc aperture)"
+    title: "Stellar mass - Gas diffuse metallicity relation (mean-of-log, 50 kpc aperture)"
     caption: Only shown for star forming galaxies. Represented by 12 + $\log_{10}$ O/H (where $\log_{10}$ O/H is averaged between gas particles with a [O/H]=-4 floor and diffuse O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Gas Metallicity
     show_on_webpage: true
@@ -340,19 +340,19 @@ stellar_mass_gas_sf_metallicity_mol_hifloor_30:
     - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
-stellar_mass_gas_sf_metallicity_mol_hifloor_100:
+stellar_mass_gas_sf_metallicity_mol_hifloor_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only, MoL w. [O/H]=-3 floor, Diffuse, from O"
   y:
-    quantity: "derived_quantities.gas_o_abundance_avglog_high_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_avglog_high_50_kpc"
     log: false
     units: "dimensionless"
     start: 7
     end: 10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -368,7 +368,7 @@ stellar_mass_gas_sf_metallicity_mol_hifloor_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Gas diffuse metallicity relation (mean-of-log, 100 kpc aperture)"
+    title: "Stellar mass - Gas diffuse metallicity relation (mean-of-log, 50 kpc aperture)"
     caption: Only shown for star forming galaxies. Represented by 12 + $\log_{10}$ O/H (where $\log_{10}$ O/H is averaged between gas particles with a [O/H]=-3 floor for diffuse O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Gas Metallicity
     show_on_webpage: true
@@ -416,19 +416,19 @@ stellar_mass_gas_sf_metallicity_lom_allgals_30:
     - filename: GalaxyStellarMassGasMetallicity/Andrews2013_Data.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
-stellar_mass_gas_sf_metallicity_lom_allgals_100:
+stellar_mass_gas_sf_metallicity_lom_allgals_50:
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.has_cold_dense_gas_100_kpc"
+  selection_mask: "derived_quantities.has_cold_dense_gas_50_kpc"
   comment: "All galaxies, LoM, Diffuse, from O"
   y:
-    quantity: "derived_quantities.gas_o_abundance_avglin_100_kpc"
+    quantity: "derived_quantities.gas_o_abundance_avglin_50_kpc"
     log: false
     units: "dimensionless"
     start: 7
     end: 10
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -444,7 +444,7 @@ stellar_mass_gas_sf_metallicity_lom_allgals_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, 100 kpc aperture)"
+    title: "Stellar mass - Gas diffuse metallicity relation (log-of-mean, 50 kpc aperture)"
     caption: Only shown for galaxies with cold, dense gas. Represented by 12 + $\log_{10}$ O/H (where O/H is linearly averaged for diffuse O) of the cold, dense gas ($T < 10^{4.5}\;{\rm K}$,  $n_{\rm H} > 0.1 \; {\rm cm^{-3}}$). No minimum metallicity is imposed. All haloes are plotted, including subhaloes. This uses depleted gas metallicity, i.e. it does not include metals that are present in dust.
     section: Gas Metallicity
     show_on_webpage: true
@@ -455,16 +455,16 @@ stellar_mass_gas_sf_metallicity_lom_allgals_100:
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
 
 
-stellar_mass_star_metallicity_100:
+stellar_mass_star_metallicity_50:
   type: "scatter"
   legend_loc: "upper left"
   y:
-    quantity: "derived_quantities.star_metallicity_in_solar_100_kpc"
+    quantity: "derived_quantities.star_metallicity_in_solar_50_kpc"
     units: "dimensionless"
     start: 1e-2
     end: 1e1
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -480,7 +480,7 @@ stellar_mass_star_metallicity_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: "Stellar mass - Star metallicity relation (100 kpc aperture)"
+    title: "Stellar mass - Star metallicity relation (50 kpc aperture)"
     caption: Average stellar metallicity measured in the same aperture as the stellar mass. Gallazzi data is corrected from their choice of solar metallicity (0.02) to ours (0.0126).
     section: Stellar Metallicity
     show_on_webpage: true
@@ -523,17 +523,17 @@ stellar_mass_star_metallicity_30:
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Fraser-McKelvie_2021.hdf5 
 
-stellar_mass_star_fe_over_h_mol_lofloor_100:
+stellar_mass_star_fe_over_h_mol_lofloor_50:
   type: "scatter"
   legend_loc: "upper left"
   comment: "MoL w. [F/H]=-4 floor"
   y:
-    quantity: "derived_quantities.star_fe_abundance_avglog_low_100_kpc"
+    quantity: "derived_quantities.star_fe_abundance_avglog_low_50_kpc"
     units: "dimensionless"
     start: 1e-2
     end: 1e1
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -549,7 +549,7 @@ stellar_mass_star_fe_over_h_mol_lofloor_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: 'Stellar mass - [Fe/H]$_*$ relation (mean-of-log, 100 kpc aperture)'
+    title: 'Stellar mass - [Fe/H]$_*$ relation (mean-of-log, 50 kpc aperture)'
     section: Stellar Metallicity
     caption: 'Computed as the mass-weighted average of log [Fe/H]$_*$. The floor value is set to [Fe/H]=-4. All haloes are plotted, including subhaloes.'
   observational_data:
@@ -557,17 +557,17 @@ stellar_mass_star_fe_over_h_mol_lofloor_100:
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Fraser-McKelvie_2021.hdf5 
 
-stellar_mass_star_fe_over_h_mol_hifloor_100:
+stellar_mass_star_fe_over_h_mol_hifloor_50:
   type: "scatter"
   legend_loc: "upper left"
   comment: "MoL w. [F/H]=-3 floor"
   y:
-    quantity: "derived_quantities.star_fe_abundance_avglog_high_100_kpc"
+    quantity: "derived_quantities.star_fe_abundance_avglog_high_50_kpc"
     units: "dimensionless"
     start: 1e-2
     end: 1e1
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -583,7 +583,7 @@ stellar_mass_star_fe_over_h_mol_hifloor_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: 'Stellar mass - [Fe/H]$_*$ relation (mean-of-log, 100 kpc aperture)'
+    title: 'Stellar mass - [Fe/H]$_*$ relation (mean-of-log, 50 kpc aperture)'
     section: Stellar Metallicity
     caption: 'Computed as the mass-weighted average of log [Fe/H]$_*$. The floor value is set to [Fe/H]=-3. All haloes are plotted, including subhaloes.'
   observational_data:
@@ -591,17 +591,17 @@ stellar_mass_star_fe_over_h_mol_hifloor_100:
     - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Fraser-McKelvie_2021.hdf5 
 
-stellar_mass_star_fe_over_h_lom_100:
+stellar_mass_star_fe_over_h_lom_50:
   type: "scatter"
   legend_loc: "upper left"
   comment: "LoM"
   y:
-    quantity: "derived_quantities.star_fe_abundance_avglin_100_kpc"
+    quantity: "derived_quantities.star_fe_abundance_avglin_50_kpc"
     units: "dimensionless"
     start: 1e-2
     end: 1e1
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -617,7 +617,7 @@ stellar_mass_star_fe_over_h_lom_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: 'Stellar mass - [Fe/H]$_*$ relation (100 kpc aperture)'
+    title: 'Stellar mass - [Fe/H]$_*$ relation (50 kpc aperture)'
     section: Stellar Metallicity
     caption: 'Computed as the mass-weighted average of [Fe/H]$_*$. All haloes are plotted, including subhaloes.'
   observational_data:
@@ -626,17 +626,17 @@ stellar_mass_star_fe_over_h_lom_100:
     - filename: GalaxyStellarMassStellarMetallicity/Fraser-McKelvie_2021.hdf5 
 
 
-stellar_mass_star_mg_over_fe_100:
+stellar_mass_star_mg_over_fe_50:
   type: "scatter"
   legend_loc: "lower left"
   y:
-    quantity: "derived_quantities.star_magnesium_over_iron_100_kpc"
+    quantity: "derived_quantities.star_magnesium_over_iron_50_kpc"
     units: "dimensionless"
     start: -0.2
     end: 0.7
     log: false
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e8
     end: 1e12
@@ -652,23 +652,23 @@ stellar_mass_star_mg_over_fe_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: 'Stellar mass - [Mg/Fe]$_*$ relation (100 kpc aperture)'
+    title: 'Stellar mass - [Mg/Fe]$_*$ relation (50 kpc aperture)'
     section: Stellar Metallicity
-    caption: '[Mg/Fe] versus stellar mass, both computed in 100-kpc apertures. The values of [Mg/Fe] are obtained by computing the (log10 of) ratio between the total Magnesium mass in stars and total Iron mass in stars, and then normalising it by the corresponding solar abundances. The solar abundances are taken from Asplund et al. (2009). All haloes are plotted, including subhaloes.'
+    caption: '[Mg/Fe] versus stellar mass, both computed in 50-kpc apertures. The values of [Mg/Fe] are obtained by computing the (log10 of) ratio between the total Magnesium mass in stars and total Iron mass in stars, and then normalising it by the corresponding solar abundances. The solar abundances are taken from Asplund et al. (2009). All haloes are plotted, including subhaloes.'
   observational_data:
     - filename: GalaxyStellarMassAlphatoIron/Gallazzi2021_Data.hdf5
 
-stellar_mass_star_o_over_fe_100:
+stellar_mass_star_o_over_fe_50:
   type: "scatter"
   legend_loc: "lower left"
   y:
-    quantity: "derived_quantities.star_oxygen_over_iron_100_kpc"
+    quantity: "derived_quantities.star_oxygen_over_iron_50_kpc"
     units: "dimensionless"
     start: -0.2
     end: 0.7
     log: false
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e8
     end: 1e12
@@ -684,8 +684,8 @@ stellar_mass_star_o_over_fe_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: 'Stellar mass - [O/Fe]$_*$ relation (100 kpc aperture)'
+    title: 'Stellar mass - [O/Fe]$_*$ relation (50 kpc aperture)'
     section: Stellar Metallicity
-    caption: '[O/Fe] versus stellar mass, both computed in 100-kpc apertures. The values of [O/Fe] are obtained by computing the (log10 of) ratio between the total Oxygen mass in stars and total Iron mass in stars, and then normalising it by the corresponding solar abundances. The solar abundances are taken from Asplund et al. (2009). All haloes are plotted, including subhaloes.'
+    caption: '[O/Fe] versus stellar mass, both computed in 50-kpc apertures. The values of [O/Fe] are obtained by computing the (log10 of) ratio between the total Oxygen mass in stars and total Iron mass in stars, and then normalising it by the corresponding solar abundances. The solar abundances are taken from Asplund et al. (2009). All haloes are plotted, including subhaloes.'
   observational_data:
     - filename: GalaxyStellarMassAlphatoIron/Gallazzi2021_Data.hdf5

--- a/colibre/auto_plotter/star_formation_rates.yml
+++ b/colibre/auto_plotter/star_formation_rates.yml
@@ -30,16 +30,16 @@ stellar_mass_sfr_30:
   observational_data:
     - filename: GalaxyStellarMassStarFormationRate/Davies2016_z0p1.hdf5
 
-stellar_mass_sfr_100:
+stellar_mass_sfr_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "apertures.sfr_gas_100_kpc"
+    quantity: "apertures.sfr_gas_50_kpc"
     units: "Solar_Mass / year"
     start: 1e-3
     end: 1e3
@@ -55,23 +55,23 @@ stellar_mass_sfr_100:
       value: 1e12
       units: Solar_Mass
   metadata:
-    title: Stellar Mass-Star Formation Rate (100 kpc aperture)
+    title: Stellar Mass-Star Formation Rate (50 kpc aperture)
     caption: All galaxies, including those deemed to be passive (below 0.01 / Gyr sSFR), are included in the median line.
     section: Star Formation Rates
     show_on_webpage: false
   observational_data:
     - filename: GalaxyStellarMassStarFormationRate/Davies2016_z0p1.hdf5
 
-stellar_mass_specific_sfr_all_100:
+stellar_mass_specific_sfr_all_50:
   type: "scatter"
   legend_loc: "lower left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 0.5e-3
     end: 3e0
@@ -87,7 +87,7 @@ stellar_mass_specific_sfr_all_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: Specific Star Formation Rate - Stellar Mass (100 kpc aperture)
+    title: Specific Star Formation Rate - Stellar Mass (50 kpc aperture)
     caption: All galaxies, including those deemed to be passive (below 0.01 / Gyr sSFR), are included in the median line.
     section: Star Formation Rates
   observational_data:
@@ -127,19 +127,19 @@ stellar_mass_specific_sfr_all_30:
     - filename: GalaxyStellarMassSpecificStarFormationRate/Bauer2013_StarForming.hdf5
     - filename: GalaxyStellarMassSpecificStarFormationRate/Chang2015.hdf5
 
-stellar_mass_specific_sfr_active_100:
+stellar_mass_specific_sfr_active_50:
   type: "scatter"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only"
   comment_loc: "lower right"
   legend_loc: "lower left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 0.5e-2
     end: 3e0
@@ -155,7 +155,7 @@ stellar_mass_specific_sfr_active_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: Specific Star Formation Rate - Stellar Mass (100 kpc aperture, active only)
+    title: Specific Star Formation Rate - Stellar Mass (50 kpc aperture, active only)
     caption: Only active galaxies (threshold is above 0.01 / Gyr sSFR) are included in the median line.
     section: Star Formation Rates
   observational_data:
@@ -231,9 +231,9 @@ halo_mass_specific_sfr_30:
     section: Star Formation Rates
     show_on_webpage: false
 
-halo_mass_specific_sfr_100:
+halo_mass_specific_sfr_50:
   type: "scatter"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only"
   comment_loc: "lower right"
   legend_loc: "lower left"
@@ -243,7 +243,7 @@ halo_mass_specific_sfr_100:
     start: 1e8
     end: 1e13
   y:
-    quantity: "derived_quantities.specific_sfr_gas_100_kpc"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
     units: 1 / gigayear
     start: 0.5e-2
     end: 3e0
@@ -259,7 +259,7 @@ halo_mass_specific_sfr_100:
       value: 1e13
       units: solar_mass
   metadata:
-    title: Specific Star Formation Rate (100 kpc aperture) - Halo Mass
+    title: Specific Star Formation Rate (50 kpc aperture) - Halo Mass
     caption: Only active galaxies (threshold is above 0.01 / Gyr sSFR) are included in the median line.
     section: Star Formation Rates
     show_on_webpage: false
@@ -297,9 +297,9 @@ halo_mass_sfr_30_halo_mass:
     section: Star Formation Rates
     show_on_webpage: false
 
-halo_mass_sfr_100_halo_mass:
+halo_mass_sfr_50_halo_mass:
   type: "scatter"
-  selection_mask: "derived_quantities.is_active_100_kpc"
+  selection_mask: "derived_quantities.is_active_50_kpc"
   comment: "Active only"
   comment_loc: "lower right"
   legend_loc: "lower left"
@@ -309,7 +309,7 @@ halo_mass_sfr_100_halo_mass:
     start: 1e8
     end: 1e13
   y:
-    quantity: "derived_quantities.sfr_halo_mass_100_kpc"
+    quantity: "derived_quantities.sfr_halo_mass_50_kpc"
     units: 1 / gigayear
     start: 0.5e-5
     end: 1e-2
@@ -325,7 +325,7 @@ halo_mass_sfr_100_halo_mass:
       value: 1e13
       units: solar_mass
   metadata:
-    title: Star Formation Rate divided by Halo Mass (100 kpc aperture) - Halo Mass
+    title: Star Formation Rate divided by Halo Mass (50 kpc aperture) - Halo Mass
     caption: Only active galaxies (threshold is above 0.01 / Gyr sSFR) are included in the median line
     section: Star Formation Rates
     show_on_webpage: false
@@ -368,18 +368,18 @@ stellar_mass_passive_fraction_30:
     - filename: GalaxyStellarMassPassiveFraction/Moustakas2013.hdf5
     - filename: GalaxyStellarMassPassiveFraction/Behroozi2019.hdf5
 
-stellar_mass_passive_fraction_100:
+stellar_mass_passive_fraction_50:
   type: "scatter"
   legend_loc: "lower left"
   redshift_loc: "upper center"
   min_num_points_highlight: 0
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "derived_quantities.is_passive_100_kpc"
+    quantity: "derived_quantities.is_passive_50_kpc"
     units: "dimensionless"
     log: false
     start: 0
@@ -397,7 +397,7 @@ stellar_mass_passive_fraction_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: Passive Fraction - Stellar Mass (100 kpc aperture)
+    title: Passive Fraction - Stellar Mass (50 kpc aperture)
     caption: A galaxy is determined as being passive if it has a sSFR below 0.01 / Gyr.
     section: Star Formation Rates
   observational_data:
@@ -445,7 +445,7 @@ stellar_mass_passive_fraction_centrals_30:
     - filename: GalaxyStellarMassPassiveFraction/Moustakas2013.hdf5
     - filename: GalaxyStellarMassPassiveFraction/Behroozi2019_centrals.hdf5
 
-stellar_mass_passive_fraction_centrals_100:
+stellar_mass_passive_fraction_centrals_50:
   type: "scatter"
   select_structure_type: 10
   comment: "Centrals only"
@@ -453,12 +453,12 @@ stellar_mass_passive_fraction_centrals_100:
   redshift_loc: "upper center"
   min_num_points_highlight: 0
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
   y:
-    quantity: "derived_quantities.is_passive_100_kpc"
+    quantity: "derived_quantities.is_passive_50_kpc"
     units: "dimensionless"
     log: false
     start: 0
@@ -476,7 +476,7 @@ stellar_mass_passive_fraction_centrals_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: Passive Fraction - Stellar Mass (100 kpc aperture, centrals)
+    title: Passive Fraction - Stellar Mass (50 kpc aperture, centrals)
     caption: A galaxy is determined as being passive if it has a sSFR below 0.01 / Gyr. This figure shows only the central galaxies (structure type 10).
     section: Star Formation Rates
   observational_data:
@@ -484,12 +484,12 @@ stellar_mass_passive_fraction_centrals_100:
     - filename: GalaxyStellarMassPassiveFraction/Moustakas2013.hdf5
     - filename: GalaxyStellarMassPassiveFraction/Behroozi2019_centrals.hdf5
 
-star_formation_rate_function_100:
+star_formation_rate_function_50:
   type: "massfunction"
   legend_loc: "lower left"
   number_of_bins: 30
   x:
-    quantity: "apertures.sfr_gas_100_kpc"
+    quantity: "apertures.sfr_gas_50_kpc"
     units: "Solar_Mass / year"
     start: 1e-3
     end: 1e3
@@ -498,8 +498,8 @@ star_formation_rate_function_100:
     start: 1e-5
     end: 0.316 # (1e-0.5)
   metadata:
-    title: Star Formation Rate Function (100 kpc aperture)
-    caption: 100 kpc aperture galaxy star formation rate function, showing all galaxies with a fixed bin-width of 0.2 dex.
+    title: Star Formation Rate Function (50 kpc aperture)
+    caption: 50 kpc aperture galaxy star formation rate function, showing all galaxies with a fixed bin-width of 0.2 dex.
     section: Star Formation Rates
   observational_data:
     - filename: StarFormationRateFunction/Bell2007.hdf5
@@ -525,12 +525,12 @@ star_formation_rate_function_30:
   observational_data:
     - filename: StarFormationRateFunction/Bell2007.hdf5
 
-adaptive_star_formation_rate_function_100:
+adaptive_star_formation_rate_function_50:
   type: "adaptivemassfunction"
   legend_loc: "lower left"
   number_of_bins: 30
   x:
-    quantity: "apertures.sfr_gas_100_kpc"
+    quantity: "apertures.sfr_gas_50_kpc"
     units: "Solar_Mass / year"
     start: 1e-3
     end: 1e3
@@ -539,8 +539,8 @@ adaptive_star_formation_rate_function_100:
     start: 1e-5
     end: 0.316 # (1e-0.5)
   metadata:
-    title: Star Formation Rate Function (100 kpc aperture)
-    caption: 100 kpc aperture galaxy star formation rate function, showing all galaxies with an adaptive bin-width.
+    title: Star Formation Rate Function (50 kpc aperture)
+    caption: 50 kpc aperture galaxy star formation rate function, showing all galaxies with an adaptive bin-width.
     section: Star Formation Rates
   observational_data:
     - filename: StarFormationRateFunction/Bell2007.hdf5

--- a/colibre/auto_plotter/stellar_birth_densities.yml
+++ b/colibre/auto_plotter/stellar_birth_densities.yml
@@ -58,11 +58,11 @@ stellar_birth_density_halo_mass_max_all:
     section: Stellar Birth Densities
     show_on_webpage: false
 
-stellar_birth_density_stellar_mass_average_of_log_all_100:
+stellar_birth_density_stellar_mass_average_of_log_all_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e4
     end: 1e12
@@ -87,11 +87,11 @@ stellar_birth_density_stellar_mass_average_of_log_all_100:
     caption: Includes all haloes, including subhaloes.
     section: Stellar Birth Densities
 
-stellar_birth_density_stellar_mass_max_all_100:
+stellar_birth_density_stellar_mass_max_all_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: Solar_Mass
     start: 1e4
     end: 1e12

--- a/colibre/auto_plotter/tully_fisher.yml
+++ b/colibre/auto_plotter/tully_fisher.yml
@@ -1,8 +1,8 @@
-tully_fisher_100:
+tully_fisher_50:
   type: "scatter"
   legend_loc: "upper left"
   x:
-    quantity: "apertures.mass_star_100_kpc"
+    quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
     start: 1e6
     end: 1e12
@@ -23,7 +23,7 @@ tully_fisher_100:
       value: 1e12
       units: solar_mass
   metadata:
-    title: Tully-Fisher (stellar mass, 100 kpc)
+    title: Tully-Fisher (stellar mass, 50 kpc)
     caption: The Tully-Fisher relation based on stellar mass.
     section: Tully-Fisher
   observational_data:
@@ -55,7 +55,7 @@ tully_fisher_30:
       value: 1e12
       units: solar_mass
   metadata:
-    title: Tully-Fisher (stellar mass, 100 kpc)
+    title: Tully-Fisher (stellar mass, 50 kpc)
     caption: The Tully-Fisher relation based on stellar mass.
     section: Tully-Fisher
     show_on_webpage: false

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -28,7 +28,6 @@ This file calculates:
 """
 
 # Define aperture size in kpc
-aperture_sizes_30_100_kpc = {30, 100}
 aperture_sizes_30_50_100_kpc = {30, 50, 100}
 
 # Solar metal mass fraction used in Plöckinger S. & Schaye J. (2020)
@@ -870,29 +869,29 @@ def register_los_star_veldisp(self, catalogue):
 
 
 # Register derived fields
-register_spesific_star_formation_rates(self, catalogue, aperture_sizes_30_100_kpc)
+register_spesific_star_formation_rates(self, catalogue, aperture_sizes_30_50_100_kpc)
 register_star_metallicities(
-    self, catalogue, aperture_sizes_30_100_kpc, solar_metal_mass_fraction
+    self, catalogue, aperture_sizes_30_50_100_kpc, solar_metal_mass_fraction
 )
 register_stellar_to_halo_mass_ratios(self, catalogue, aperture_sizes_30_50_100_kpc)
-register_dust(self, catalogue, aperture_sizes_30_100_kpc)
-register_oxygen_to_hydrogen(self, catalogue, aperture_sizes_30_100_kpc)
+register_dust(self, catalogue, aperture_sizes_30_50_100_kpc)
+register_oxygen_to_hydrogen(self, catalogue, aperture_sizes_30_50_100_kpc)
 register_cold_dense_gas_metallicity(
     self,
     catalogue,
-    aperture_sizes_30_100_kpc,
+    aperture_sizes_30_50_100_kpc,
     solar_metal_mass_fraction,
     twelve_plus_log_OH_solar,
 )
 register_iron_to_hydrogen(
-    self, catalogue, aperture_sizes_30_100_kpc, solar_fe_abundance
+    self, catalogue, aperture_sizes_30_50_100_kpc, solar_fe_abundance
 )
-register_hi_masses(self, catalogue, aperture_sizes_30_100_kpc)
-register_h2_masses(self, catalogue, aperture_sizes_30_100_kpc)
-register_dust_to_hi_ratio(self, catalogue, aperture_sizes_30_100_kpc)
-register_cold_gas_mass_ratios(self, catalogue, aperture_sizes_30_100_kpc)
-register_species_fractions(self, catalogue, aperture_sizes_30_100_kpc)
+register_hi_masses(self, catalogue, aperture_sizes_30_50_100_kpc)
+register_h2_masses(self, catalogue, aperture_sizes_30_50_100_kpc)
+register_dust_to_hi_ratio(self, catalogue, aperture_sizes_30_50_100_kpc)
+register_cold_gas_mass_ratios(self, catalogue, aperture_sizes_30_50_100_kpc)
+register_species_fractions(self, catalogue, aperture_sizes_30_50_100_kpc)
 register_stellar_birth_densities(self, catalogue)
 register_los_star_veldisp(self, catalogue)
-register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes_30_100_kpc)
+register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes_30_50_100_kpc)
 register_gas_fraction(self, catalogue)


### PR DESCRIPTION
The old 100 kpc apertures are still there, but they are no longer shown on the web page.