### PR TITLE
Log-normal stellar mass scatter

### DIFF
--- a/colibre-zooms/auto_plotter/star_formation_rates.yml
+++ b/colibre-zooms/auto_plotter/star_formation_rates.yml
@@ -405,6 +405,43 @@ stellar_mass_passive_fraction_50:
     - filename: GalaxyStellarMassPassiveFraction/Moustakas2013.hdf5
     - filename: GalaxyStellarMassPassiveFraction/Behroozi2019.hdf5
 
+stellar_mass_with_scatter_passive_fraction_50:
+  type: "scatter"
+  legend_loc: "lower left"
+  redshift_loc: "upper center"
+  min_num_points_highlight: 0
+  x:
+    quantity: "derived_quantities.mass_star_with_scatter_50_kpc"
+    units: solar_mass
+    start: 1e6
+    end: 1e12
+  y:
+    quantity: "derived_quantities.is_passive_50_kpc"
+    units: "dimensionless"
+    log: false
+    start: 0
+    end: 1
+  mean:
+    plot: true
+    log: true
+    scatter: "none"
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+  metadata:
+    title: Passive Fraction - Stellar Mass (50 kpc aperture, with scatter)
+    caption: A galaxy is determined as being passive if it has a sSFR below 0.01 / Gyr. All stellar masses contain an additional 0.3 dex log-normal scatter.
+    section: Star Formation Rates
+  observational_data:
+    - filename: GalaxyStellarMassPassiveFraction/Gilbank2010.hdf5
+    - filename: GalaxyStellarMassPassiveFraction/Moustakas2013.hdf5
+    - filename: GalaxyStellarMassPassiveFraction/Behroozi2019.hdf5
+
 stellar_mass_passive_fraction_centrals_30:
   type: "scatter"
   select_structure_type: 10

--- a/colibre-zooms/registration.py
+++ b/colibre-zooms/registration.py
@@ -25,6 +25,8 @@ This file calculates:
     + LOS stellar velocity dispersions (10, 30 kpc) (los_veldisp_star_{x}_kpc)
         The LOS velocity dispersion, obtained by multiplying the 3D velocity
         dispersion with 1/sqrt(3).
+    + mass_star_with_scatter_50_kpc
+        Stellar mass with an additional 0.3 dex log-normal scatter.
 """
 
 # Define aperture size in kpc
@@ -38,6 +40,9 @@ twelve_plus_log_OH_solar = 8.69
 
 # Solar Fe abundance (from Wiersma et al 2009a)
 solar_fe_abundance = 2.82e-5
+
+# Additional scatter in stellar mass (in dex)
+stellar_mass_scatter_amplitude = 0.3
 
 
 def register_spesific_star_formation_rates(self, catalogue, aperture_sizes):
@@ -883,6 +888,21 @@ def register_los_star_veldisp(self, catalogue):
     return
 
 
+def register_stellar_mass_scatter(self, catalogue, stellar_mass_scatter_amplitude):
+
+    stellar_mass = catalogue.apertures.mass_star_50_kpc
+    stellar_mass_with_scatter = unyt.unyt_array(
+        np.random.lognormal(
+            np.log(stellar_mass.value), stellar_mass_scatter_amplitude * np.log(10.0)
+        ),
+        units=stellar_mass.units,
+    )
+    stellar_mass_with_scatter.name = f"Stellar mass with additional {stellar_mass_scatter_amplitude:.1f} dex log-normal scatter (50 kpc)"
+    setattr(self, f"mass_star_with_scatter_50_kpc", stellar_mass_with_scatter)
+
+    return
+
+
 # Register derived fields
 register_spesific_star_formation_rates(self, catalogue, aperture_sizes_30_50_100_kpc)
 register_star_metallicities(
@@ -911,3 +931,4 @@ register_global_mask(self, catalogue)
 register_los_star_veldisp(self, catalogue)
 register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes_30_50_100_kpc)
 register_gas_fraction(self, catalogue)
+register_stellar_mass_scatter(self, catalogue, stellar_mass_scatter_amplitude)

--- a/colibre-zooms/registration.py
+++ b/colibre-zooms/registration.py
@@ -878,7 +878,7 @@ def register_stellar_mass_scatter(self, catalogue, stellar_mass_scatter_amplitud
         ),
         units=stellar_mass.units,
     )
-    stellar_mass_with_scatter.name = f"Stellar mass with additional {stellar_mass_scatter_amplitude:.1f} dex log-normal scatter (50 kpc)"
+    stellar_mass_with_scatter.name = f"Stellar mass $M_*$ with {stellar_mass_scatter_amplitude:.1f} dex scatter (50 kpc)"
     setattr(self, f"mass_star_with_scatter_50_kpc", stellar_mass_with_scatter)
 
     return

--- a/colibre/auto_plotter/mass_functions.yml
+++ b/colibre/auto_plotter/mass_functions.yml
@@ -231,8 +231,8 @@ stellar_mass_function_with_scatter_50:
     start: 1e-6
     end: 1e0
   metadata:
-    title: Stellar Mass Function (50 kpc aperture)
-    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex, with an additional 0.3 log-normal scatter in the stellar mass.
+    title: Stellar Mass Function (50 kpc aperture, with scatter)
+    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex, with an additional 0.3 dex log-normal scatter in the stellar mass.
     section: Stellar Mass Function
   observational_data:
     - filename: GalaxyStellarMassFunction/LiWhite2009.hdf5
@@ -257,7 +257,7 @@ adaptive_stellar_mass_function_with_scatter_50:
     start: 1e-6
     end: 1e0
   metadata:
-    title: Stellar Mass Function (50 kpc aperture, adaptive)
+    title: Stellar Mass Function (50 kpc aperture, adaptive, with scatter)
     caption: 50 kpc aperture GSMF, showing all galaxies with an adaptive bin-width, with an additional 0.3 dex log-normal scatter in the stellar mass.
     section: Stellar Mass Function
   observational_data:

--- a/colibre/auto_plotter/mass_functions.yml
+++ b/colibre/auto_plotter/mass_functions.yml
@@ -216,3 +216,55 @@ adaptive_stellar_mass_function_active_only_50:
     - filename: GalaxyStellarMassFunction/Wright2017.hdf5
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
     - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+
+stellar_mass_function_with_scatter_50:
+  type: "massfunction"
+  legend_loc: "lower left"
+  number_of_bins: 30
+  x:
+    quantity: "derived_quantities.mass_star_with_scatter_50_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 1e0
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture)
+    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex, with an additional 0.3 log-normal scatter in the stellar mass.
+    section: Stellar Mass Function
+  observational_data:
+    - filename: GalaxyStellarMassFunction/LiWhite2009.hdf5
+    - filename: GalaxyStellarMassFunction/Behroozi2019_all.hdf5
+    - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
+    - filename: GalaxyStellarMassFunction/Wright2017.hdf5
+    - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+    - filename: GalaxyStellarMassFunction/Driver2021.hdf5
+
+adaptive_stellar_mass_function_with_scatter_50:
+  type: "adaptivemassfunction"
+  legend_loc: "lower left"
+  number_of_bins: 30
+  x:
+    quantity: "derived_quantities.mass_star_with_scatter_50_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 1e0
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture, adaptive)
+    caption: 50 kpc aperture GSMF, showing all galaxies with an adaptive bin-width, with an additional 0.3 dex log-normal scatter in the stellar mass.
+    section: Stellar Mass Function
+  observational_data:
+    - filename: GalaxyStellarMassFunction/LiWhite2009.hdf5
+    - filename: GalaxyStellarMassFunction/Behroozi2019_all.hdf5
+    - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
+    - filename: GalaxyStellarMassFunction/Wright2017.hdf5
+    - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+    - filename: GalaxyStellarMassFunction/Driver2021.hdf5

--- a/colibre/auto_plotter/star_formation_rates.yml
+++ b/colibre/auto_plotter/star_formation_rates.yml
@@ -405,6 +405,43 @@ stellar_mass_passive_fraction_50:
     - filename: GalaxyStellarMassPassiveFraction/Moustakas2013.hdf5
     - filename: GalaxyStellarMassPassiveFraction/Behroozi2019.hdf5
 
+stellar_mass_with_scatter_passive_fraction_50:
+  type: "scatter"
+  legend_loc: "lower left"
+  redshift_loc: "upper center"
+  min_num_points_highlight: 0
+  x:
+    quantity: "derived_quantities.mass_star_with_scatter_50_kpc"
+    units: solar_mass
+    start: 1e6
+    end: 1e12
+  y:
+    quantity: "derived_quantities.is_passive_50_kpc"
+    units: "dimensionless"
+    log: false
+    start: 0
+    end: 1
+  mean:
+    plot: true
+    log: true
+    scatter: "none"
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+  metadata:
+    title: Passive Fraction - Stellar Mass (50 kpc aperture, with scatter)
+    caption: A galaxy is determined as being passive if it has a sSFR below 0.01 / Gyr. All stellar masses contain an additional 0.3 dex log-normal scatter.
+    section: Star Formation Rates
+  observational_data:
+    - filename: GalaxyStellarMassPassiveFraction/Gilbank2010.hdf5
+    - filename: GalaxyStellarMassPassiveFraction/Moustakas2013.hdf5
+    - filename: GalaxyStellarMassPassiveFraction/Behroozi2019.hdf5
+
 stellar_mass_passive_fraction_centrals_30:
   type: "scatter"
   select_structure_type: 10

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -25,6 +25,8 @@ This file calculates:
     + LOS stellar velocity dispersions (10, 30 kpc) (los_veldisp_star_{x}_kpc)
         The LOS velocity dispersion, obtained by multiplying the 3D velocity
         dispersion with 1/sqrt(3).
+    + mass_star_with_scatter_50_kpc
+        Stellar mass with an additional 0.3 dex log-normal scatter.
 """
 
 # Define aperture size in kpc
@@ -38,6 +40,9 @@ twelve_plus_log_OH_solar = 8.69
 
 # Solar Fe abundance (from Wiersma et al 2009a)
 solar_fe_abundance = 2.82e-5
+
+# Additional scatter in stellar mass (in dex)
+stellar_mass_scatter_amplitude = 0.3
 
 
 def register_spesific_star_formation_rates(self, catalogue, aperture_sizes):
@@ -868,6 +873,21 @@ def register_los_star_veldisp(self, catalogue):
     return
 
 
+def register_stellar_mass_scatter(self, catalogue, stellar_mass_scatter_amplitude):
+
+    stellar_mass = catalogue.apertures.mass_star_50_kpc
+    stellar_mass_with_scatter = unyt.unyt_array(
+        np.random.lognormal(
+            np.log(stellar_mass.value), stellar_mass_scatter_amplitude * np.log(10.0)
+        ),
+        units=stellar_mass.units,
+    )
+    stellar_mass_with_scatter.name = f"Stellar mass with additional {stellar_mass_scatter_amplitude:.1f} dex log-normal scatter (50 kpc)"
+    setattr(self, f"mass_star_with_scatter_50_kpc", stellar_mass_with_scatter)
+
+    return
+
+
 # Register derived fields
 register_spesific_star_formation_rates(self, catalogue, aperture_sizes_30_50_100_kpc)
 register_star_metallicities(
@@ -895,3 +915,4 @@ register_stellar_birth_densities(self, catalogue)
 register_los_star_veldisp(self, catalogue)
 register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes_30_50_100_kpc)
 register_gas_fraction(self, catalogue)
+register_stellar_mass_scatter(self, catalogue, stellar_mass_scatter_amplitude)

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -867,7 +867,7 @@ def register_stellar_mass_scatter(self, catalogue, stellar_mass_scatter_amplitud
         ),
         units=stellar_mass.units,
     )
-    stellar_mass_with_scatter.name = f"Stellar mass with additional {stellar_mass_scatter_amplitude:.1f} dex log-normal scatter (50 kpc)"
+    stellar_mass_with_scatter.name = f"Stellar mass $M_*$ with {stellar_mass_scatter_amplitude:.1f} dex scatter (50 kpc)"
     setattr(self, f"mass_star_with_scatter_50_kpc", stellar_mass_with_scatter)
 
     return


### PR DESCRIPTION
This PR adds a new derived quantity to the catalogue, `mass_star_with_scatter_50_kpc`, that adds a random 0.3 dex log-normal scatter to the 50 kpc aperture stellar masses. These are then used to create alternative plots of the stellar mass function and passive fraction - stellar mass relation.

I have only tested this for a 6Mpc box, so the examples are not very illustrative.
Versions without scatter:
<img src="https://user-images.githubusercontent.com/7336967/161723429-f73b48e6-0e69-476b-99a9-2e5541169e8a.png" width="300px"><img src="https://user-images.githubusercontent.com/7336967/161723601-a3d2fdd4-961f-4a40-a015-acedb1bbea7f.png" width="300px">

Versions with scatter:
<img src="https://user-images.githubusercontent.com/7336967/161723545-39087570-b3b5-4f39-a623-4c99f67b6c39.png" width="300px"><img src="https://user-images.githubusercontent.com/7336967/161723628-c224dab6-6458-4427-b2a6-30a06938f92f.png" width="300px">
