### PR TITLE
More colours for flamingo

### DIFF
--- a/flamingo/auto_plotter/mass_functions.yml
+++ b/flamingo/auto_plotter/mass_functions.yml
@@ -1,3 +1,127 @@
+stellar_mass_function_50:
+  type: "massfunction"
+  legend_loc: "lower left"
+  number_of_bins: 25
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 1e9
+    end: 2e12
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 2e-2 #0.316 # (1e-0.5)
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture)
+    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. For 50kpc, look at D'Souza (2015) data.
+    section: Stellar Mass Function
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyStellarMassFunction/LiWhite2009.hdf5
+    - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
+    - filename: GalaxyStellarMassFunction/Wright2017.hdf5
+    - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+    - filename: GalaxyStellarMassFunction/Driver2021.hdf5
+
+adaptive_stellar_mass_function_50:
+  type: "adaptivemassfunction"
+  legend_loc: "lower left"
+  number_of_bins: 25
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 1e9
+    end: 2e12
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 2e-2 #0.316 # (1e-0.5)
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture, adaptive)
+    caption: 50 kpc aperture GSMF, showing all galaxies with an adaptive bin-width. For 50kpc, look at D'Souza (2015) data.
+    section: Stellar Mass Function
+  observational_data:
+    - filename: GalaxyStellarMassFunction/LiWhite2009.hdf5
+    - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
+    - filename: GalaxyStellarMassFunction/Wright2017.hdf5
+    - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+    - filename: GalaxyStellarMassFunction/Driver2021.hdf5
+
+stellar_mass_eddington_function_50:
+  type: "massfunction"
+  legend_loc: "lower left"
+  number_of_bins: 25
+  x:
+    quantity: "derived_quantities.stellar_mass_eddington_50_kpc"
+    units: Solar_Mass
+    start: 1e9
+    end: 2e12
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 2e-2 #0.316 # (1e-0.5)
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture) with Eddington bias
+    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Includes Eddington bias.
+    section: Stellar Mass Function
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyStellarMassFunction/LiWhite2009.hdf5
+    - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
+    - filename: GalaxyStellarMassFunction/Wright2017.hdf5
+    - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+    - filename: GalaxyStellarMassFunction/Driver2021.hdf5
+
+stellar_mass_eddington_function_extended_50:
+  type: "massfunction"
+  legend_loc: "lower left"
+  number_of_bins: 40
+  x:
+    quantity: "derived_quantities.stellar_mass_eddington_50_kpc"
+    units: Solar_Mass
+    start: 1e8
+    end: 2e13
+  y:
+    units: 1/Mpc**3
+    start: 1e-7
+    end: 0.316 # (1e-0.5)
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture) with Eddington bias with extended ranges
+    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Includes Eddington bias.
+    section: Stellar Mass Function
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyStellarMassFunction/LiWhite2009.hdf5
+    - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
+    - filename: GalaxyStellarMassFunction/Wright2017.hdf5
+    - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+    - filename: GalaxyStellarMassFunction/Driver2021.hdf5
+
+stellar_mass_eddington_function_calibration_extended_50:
+  type: "massfunction"
+  legend_loc: "lower left"
+  number_of_bins: 40
+  x:
+    quantity: "derived_quantities.stellar_mass_eddington_50_kpc"
+    units: Solar_Mass
+    start: 1e8
+    end: 2e13
+  y:
+    units: 1/Mpc**3
+    start: 1e-7
+    end: 0.316 # (1e-0.5)
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture) with Eddington bias with extended ranges
+    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Includes Eddington bias.
+    section: AAA Calibration
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyStellarMassFunction/Driver2021FLAMINGOBias.hdf5
+
 stellar_mass_function_30:
   type: "massfunction"
   legend_loc: "lower left"
@@ -210,57 +334,6 @@ stellar_mass_function_active_only_100:
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
     - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
 
-stellar_mass_function_50:
-  type: "massfunction"
-  legend_loc: "lower left"
-  number_of_bins: 25
-  x:
-    quantity: "apertures.mass_star_50_kpc"
-    units: Solar_Mass
-    start: 1e9
-    end: 2e12
-  y:
-    units: 1/Mpc**3
-    start: 1e-6
-    end: 2e-2 #0.316 # (1e-0.5)
-  metadata:
-    title: Stellar Mass Function (50 kpc aperture)
-    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. For 50kpc, look at D'Souza (2015) data.
-    section: Stellar Mass Function
-    show_on_webpage: true
-  observational_data:
-    - filename: GalaxyStellarMassFunction/LiWhite2009.hdf5
-    - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
-    - filename: GalaxyStellarMassFunction/Wright2017.hdf5
-    - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
-    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
-    - filename: GalaxyStellarMassFunction/Driver2021.hdf5
-
-adaptive_stellar_mass_function_50:
-  type: "adaptivemassfunction"
-  legend_loc: "lower left"
-  number_of_bins: 25
-  x:
-    quantity: "apertures.mass_star_50_kpc"
-    units: Solar_Mass
-    start: 1e9
-    end: 2e12
-  y:
-    units: 1/Mpc**3
-    start: 1e-6
-    end: 2e-2 #0.316 # (1e-0.5)
-  metadata:
-    title: Stellar Mass Function (50 kpc aperture, adaptive)
-    caption: 50 kpc aperture GSMF, showing all galaxies with an adaptive bin-width. For 50kpc, look at D'Souza (2015) data.
-    section: Stellar Mass Function
-  observational_data:
-    - filename: GalaxyStellarMassFunction/LiWhite2009.hdf5
-    - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
-    - filename: GalaxyStellarMassFunction/Wright2017.hdf5
-    - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
-    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
-    - filename: GalaxyStellarMassFunction/Driver2021.hdf5
-
 stellar_mass_eddington_function_30:
   type: "massfunction"
   legend_loc: "lower left"
@@ -276,33 +349,7 @@ stellar_mass_eddington_function_30:
     end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (30 kpc aperture) with Eddington bias
-    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Includes Eddington bias.
-    section: Stellar Mass Function
-    show_on_webpage: true
-  observational_data:
-    - filename: GalaxyStellarMassFunction/LiWhite2009.hdf5
-    - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
-    - filename: GalaxyStellarMassFunction/Wright2017.hdf5
-    - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
-    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
-    - filename: GalaxyStellarMassFunction/Driver2021.hdf5
-
-stellar_mass_eddington_function_50:
-  type: "massfunction"
-  legend_loc: "lower left"
-  number_of_bins: 25
-  x:
-    quantity: "derived_quantities.stellar_mass_eddington_50_kpc"
-    units: Solar_Mass
-    start: 1e9
-    end: 2e12
-  y:
-    units: 1/Mpc**3
-    start: 1e-6
-    end: 2e-2 #0.316 # (1e-0.5)
-  metadata:
-    title: Stellar Mass Function (50 kpc aperture) with Eddington bias
-    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Includes Eddington bias.
+    caption: 30 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Includes Eddington bias.
     section: Stellar Mass Function
     show_on_webpage: true
   observational_data:
@@ -328,7 +375,7 @@ stellar_mass_eddington_function_100:
     end: 2e-2 #0.316 # (1e-0.5)
   metadata:
     title: Stellar Mass Function (100 kpc aperture) with Eddington bias
-    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Includes Eddington bias.
+    caption: 100 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Includes Eddington bias.
     section: Stellar Mass Function
     show_on_webpage: true
   observational_data:
@@ -338,50 +385,3 @@ stellar_mass_eddington_function_100:
     - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
     - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
     - filename: GalaxyStellarMassFunction/Driver2021.hdf5
-
-stellar_mass_eddington_function_extended_50:
-  type: "massfunction"
-  legend_loc: "lower left"
-  number_of_bins: 40
-  x:
-    quantity: "derived_quantities.stellar_mass_eddington_50_kpc"
-    units: Solar_Mass
-    start: 1e8
-    end: 2e13
-  y:
-    units: 1/Mpc**3
-    start: 1e-7
-    end: 0.316 # (1e-0.5)
-  metadata:
-    title: Stellar Mass Function (50 kpc aperture) with Eddington bias with extended ranges
-    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Includes Eddington bias.
-    section: Stellar Mass Function
-    show_on_webpage: true
-  observational_data:
-    - filename: GalaxyStellarMassFunction/LiWhite2009.hdf5
-    - filename: GalaxyStellarMassFunction/DSouza2015.hdf5
-    - filename: GalaxyStellarMassFunction/Wright2017.hdf5
-    - filename: GalaxyStellarMassFunction/Ilbert2013.hdf5
-    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
-    - filename: GalaxyStellarMassFunction/Driver2021.hdf5
-
-stellar_mass_eddington_function_calibration_extended_50:
-  type: "massfunction"
-  legend_loc: "lower left"
-  number_of_bins: 40
-  x:
-    quantity: "derived_quantities.stellar_mass_eddington_50_kpc"
-    units: Solar_Mass
-    start: 1e8
-    end: 2e13
-  y:
-    units: 1/Mpc**3
-    start: 1e-7
-    end: 0.316 # (1e-0.5)
-  metadata:
-    title: Stellar Mass Function (50 kpc aperture) with Eddington bias with extended ranges
-    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Includes Eddington bias.
-    section: AAA Calibration
-    show_on_webpage: true
-  observational_data:
-    - filename: GalaxyStellarMassFunction/Driver2021FLAMINGOBias.hdf5

--- a/flamingo/mnras.mplstyle
+++ b/flamingo/mnras.mplstyle
@@ -34,7 +34,7 @@ xtick.top: True
 ytick.right: True
 
 # Setup Durham Colours
-axes.prop_cycle: cycler('color', ['00AEFF','FF8C40', 'CC4314', '5766B3', '68246D', '55E18E', 'A646FF'])
+axes.prop_cycle: cycler('color', ['00AEFF','FF8C40', 'CC4314', '5766B3', '68246D', '55E18E', 'A646FF', '1F1F1F', '7EFF4B', 'FFACFF'])
 
 # Use a non-clashing default colour map
 image.cmap: cividis


### PR DESCRIPTION
This MR adds more colours to the default FLAMINGO colour cycle to help avoid clashes. It also reorders the GSMF plots so that the 50 kpc aperture plots are shown first.