### PR TITLE
Fix CI issue

### DIFF
--- a/colibre-zooms/registration.py
+++ b/colibre-zooms/registration.py
@@ -103,11 +103,7 @@ def register_global_mask(self, catalogue):
     # ensure halos contribute < 10% of Mfof
     low_interloper_halos = m_bg < 0.1 * mfof
 
-    setattr(
-        self,
-        f"low_interloper_halos",
-        low_interloper_halos,
-    )
+    setattr(self, f"low_interloper_halos", low_interloper_halos)
 
 
 def register_star_metallicities(self, catalogue, aperture_sizes, Z_sun):
@@ -362,20 +358,17 @@ def register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes):
 
         # Oxygen mass
         M_O = getattr(
-            catalogue.element_masses_in_stars,
-            f"oxygen_mass_{aperture_size}_kpc",
+            catalogue.element_masses_in_stars, f"oxygen_mass_{aperture_size}_kpc"
         )
 
         # Magnesium mass
         M_Mg = getattr(
-            catalogue.element_masses_in_stars,
-            f"magnesium_mass_{aperture_size}_kpc",
+            catalogue.element_masses_in_stars, f"magnesium_mass_{aperture_size}_kpc"
         )
 
         # Iron mass
         M_Fe = getattr(
-            catalogue.element_masses_in_stars,
-            f"iron_mass_{aperture_size}_kpc",
+            catalogue.element_masses_in_stars, f"iron_mass_{aperture_size}_kpc"
         )
 
         # Avoid zeroes
@@ -401,16 +394,8 @@ def register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes):
         O_over_Fe.name = f"[O/Fe]$_*$ ({aperture_size} kpc)"
 
         # Register the field
-        setattr(
-            self,
-            f"star_magnesium_over_iron_{aperture_size}_kpc",
-            Mg_over_Fe,
-        )
-        setattr(
-            self,
-            f"star_oxygen_over_iron_{aperture_size}_kpc",
-            O_over_Fe,
-        )
+        setattr(self, f"star_magnesium_over_iron_{aperture_size}_kpc", Mg_over_Fe)
+        setattr(self, f"star_oxygen_over_iron_{aperture_size}_kpc", O_over_Fe)
 
     return
 
@@ -659,11 +644,7 @@ def register_cold_gas_mass_ratios(self, catalogue, aperture_sizes):
         sf_to_stellar_fraction.name = f"$M_{{\\rm SF}}/M_*$ ({aperture_size} kpc)"
 
         # Finally, register all the above fields
-        setattr(
-            self,
-            f"gas_neutral_H_mass_{aperture_size}_kpc",
-            neutral_H_mass,
-        )
+        setattr(self, f"gas_neutral_H_mass_{aperture_size}_kpc", neutral_H_mass)
 
         setattr(
             self,
@@ -745,11 +726,11 @@ def register_species_fractions(self, catalogue, aperture_sizes):
         # to be added for each.
 
         self.xgass_galaxy_selection = np.logical_and(
-            M_star > unyt.unyt_quantity(10**9, "Solar_Mass"),
+            M_star > unyt.unyt_quantity(10 ** 9, "Solar_Mass"),
             M_star < unyt.unyt_quantity(10 ** (11.5), "Solar_Mass"),
         )
         self.xcoldgass_galaxy_selection = np.logical_and(
-            M_star > unyt.unyt_quantity(10**9, "Solar_Mass"),
+            M_star > unyt.unyt_quantity(10 ** 9, "Solar_Mass"),
             M_star < unyt.unyt_quantity(10 ** (11.5), "Solar_Mass"),
         )
 

--- a/colibre-zooms/scripts/birth_density_distribution.py
+++ b/colibre-zooms/scripts/birth_density_distribution.py
@@ -14,7 +14,7 @@ from swiftpipeline.argumentparser import ScriptArgumentParser
 
 
 def critical_density_DVS2012(
-    T_K: float = 10.0**7.5,
+    T_K: float = 10.0 ** 7.5,
     M_gas: float = 7.0e4,
     N_ngb: float = 48.0,
     X_H: float = 0.752,
@@ -58,7 +58,7 @@ def critical_density_DVS2012(
     # Critical density
     n_Hc = (
         31.0
-        * np.power(T_K / 10.0**7.5, 3.0 / 2.0)
+        * np.power(T_K / 10.0 ** 7.5, 3.0 / 2.0)
         * np.power(f_t / 10.0, -3.0 / 2.0)
         * np.power(M_gas / 7.0e4, -1.0 / 2.0)
         * np.power(N_ngb / 48.0, -1.0 / 2.0)
@@ -99,11 +99,7 @@ birth_density_centers = 0.5 * (birth_density_bins[1:] + birth_density_bins[:-1])
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 axes = axes.flat
 
-ax_dict = {
-    "$z < 1$": axes[0],
-    "$1 < z < 3$": axes[1],
-    "$z > 3$": axes[2],
-}
+ax_dict = {"$z < 1$": axes[0], "$1 < z < 3$": axes[1], "$z > 3$": axes[2]}
 
 for label, ax in ax_dict.items():
     ax.loglog()
@@ -169,12 +165,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         H, _ = np.histogram(data, bins=birth_density_bins)
         y_points = H / log_birth_density_bin_width / Num_of_stars_total
 
-        ax.plot(
-            birth_density_centers,
-            y_points,
-            label=name,
-            color=f"C{color}",
-        )
+        ax.plot(birth_density_centers, y_points, label=name, color=f"C{color}")
 
         # Add the median stellar birth-density line
         ax.axvline(
@@ -189,11 +180,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         for n_crit in [n_crit_min, n_crit_max]:
             if n_crit > 0.0:
                 ax.axvline(
-                    n_crit,
-                    color=f"C{color}",
-                    linestyle="dotted",
-                    zorder=-10,
-                    alpha=0.5,
+                    n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5
                 )
 
 axes[0].legend(loc="upper right", markerfirst=False)

--- a/colibre-zooms/scripts/birth_density_metallicity.py
+++ b/colibre-zooms/scripts/birth_density_metallicity.py
@@ -11,7 +11,7 @@ from unyt import mh
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-density_bounds = [0.01, 10**7.0]  # in nh/cm^3
+density_bounds = [0.01, 10 ** 7.0]  # in nh/cm^3
 metal_mass_fraction_bounds = [1e-4, 0.5]  # dimensionless
 bins = 128
 
@@ -75,11 +75,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/birth_density_redshift.py
+++ b/colibre-zooms/scripts/birth_density_redshift.py
@@ -11,7 +11,7 @@ from unyt import mh
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-density_bounds = [0.01, 10**7.0]  # in nh/cm^3
+density_bounds = [0.01, 10 ** 7.0]  # in nh/cm^3
 redshift_bounds = [-1.5, 12]  # dimensionless
 bins = 128
 
@@ -61,11 +61,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/birth_metallicity_redshift.py
+++ b/colibre-zooms/scripts/birth_metallicity_redshift.py
@@ -73,11 +73,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/density_internal_energy.py
+++ b/colibre-zooms/scripts/density_internal_energy.py
@@ -12,7 +12,7 @@ from matplotlib.colors import LogNorm
 
 # Constants; these could be put in the parameter file but are rarely changed.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-internal_energy_bounds = [10 ** (-4), 10**8]  # in
+internal_energy_bounds = [10 ** (-4), 10 ** 8]  # in
 bins = 256
 
 
@@ -23,8 +23,8 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
-    internal_energy = (data.gas.internal_energies.to_physical()).to(km**2 / s**2)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
+    internal_energy = (data.gas.internal_energies.to_physical()).to(km ** 2 / s ** 2)
 
     return number_density.value, internal_energy.value
 
@@ -62,11 +62,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/density_pressure.py
+++ b/colibre-zooms/scripts/density_pressure.py
@@ -13,7 +13,7 @@ from matplotlib.animation import FuncAnimation
 
 # Constants; these could be put in the parameter file but are rarely changed.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-pressure_bounds = [10 ** (-8.0), 10**8.0]  # in K/cm^3
+pressure_bounds = [10 ** (-8.0), 10 ** 8.0]  # in K/cm^3
 bins = 256
 
 
@@ -24,8 +24,8 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
-    pressure = (data.gas.pressures.to_physical() / kb).to(K * cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
+    pressure = (data.gas.pressures.to_physical() / kb).to(K * cm ** -3)
 
     return number_density.value, pressure.value
 
@@ -64,11 +64,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/density_species_interp.py
+++ b/colibre-zooms/scripts/density_species_interp.py
@@ -41,7 +41,7 @@ def get_data(filename, tables, prefix_rho, prefix_T):
     data = load(filename)
     number_density = (
         getattr(data.gas, f"{prefix_rho}densities").to_physical() / mh
-    ).to(cm**-3)
+    ).to(cm ** -3)
     temperature = getattr(data.gas, f"{prefix_T}temperatures").to_physical().to("K")
     masses = data.gas.masses.to_physical().to("Msun")
 
@@ -64,7 +64,7 @@ def get_data(filename, tables, prefix_rho, prefix_T):
         with h5.File(tables, "r") as table_file:
             lrho = np.log10(
                 (data.gas.subgrid_physical_densities.to_physical() / mh)
-                .to(cm**-3)
+                .to(cm ** -3)
                 .value
             )
             lT = np.log10((data.gas.subgrid_temperatures).to_physical().to("K").value)
@@ -119,14 +119,7 @@ def get_data(filename, tables, prefix_rho, prefix_T):
     return out_tuple
 
 
-def make_hist(
-    filename,
-    density_bounds,
-    bins,
-    tables,
-    prefix_rho="",
-    prefix_T="",
-):
+def make_hist(filename, density_bounds, bins, tables, prefix_rho="", prefix_T=""):
     """
     Makes the histogram for filename with bounds as lower, higher
     for the bins and "bins" the number of bins along each dimension.
@@ -192,11 +185,7 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -254,12 +243,7 @@ def make_single_image(
 
     for filename in filenames:
         hh2, hhi, hhii, hd2z, hdi2z, d = make_hist(
-            filename,
-            density_bounds,
-            bins,
-            tables,
-            prefix_rho,
-            prefix_T,
+            filename, density_bounds, bins, tables, prefix_rho, prefix_T
         )
         hist_h2.append(hh2)
         hist_hi.append(hhi)

--- a/colibre-zooms/scripts/density_temperature.py
+++ b/colibre-zooms/scripts/density_temperature.py
@@ -24,7 +24,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
     temperature = data.gas.temperatures.to_physical().to("K")
 
     return number_density.value, temperature.value
@@ -64,11 +64,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/density_temperature_dust.py
+++ b/colibre-zooms/scripts/density_temperature_dust.py
@@ -11,7 +11,7 @@ from matplotlib.colors import Normalize
 
 # Set the limits of the figure.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-temperature_bounds = [10**0.0, 10**9.5]  # in K
+temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 dustfracs_bounds = [-5, -1]  # dimensionless (dust mass / gas mass)
 min_dustfracs = dustfracs_bounds[0]
 bins = 256
@@ -26,7 +26,7 @@ def get_data(filename, prefix_rho, prefix_T):
 
     number_density = (
         getattr(data.gas, f"{prefix_rho}densities").to_physical() / mh
-    ).to(cm**-3)
+    ).to(cm ** -3)
     temperature = getattr(data.gas, f"{prefix_T}temperatures").to_physical().to("K")
 
     dfracs = np.zeros(data.gas.masses.shape)
@@ -35,7 +35,7 @@ def get_data(filename, prefix_rho, prefix_T):
         if hasattr(getattr(data.gas.dust_mass_fractions, d), "units"):
             dfracs += getattr(data.gas.dust_mass_fractions, d)
 
-    dfracs[dfracs < 10.0**min_dustfracs] = 10.0**min_dustfracs
+    dfracs[dfracs < 10.0 ** min_dustfracs] = 10.0 ** min_dustfracs
 
     return number_density.value, temperature.value, np.log10(dfracs.value)
 
@@ -84,11 +84,7 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -209,9 +205,7 @@ def make_single_image(
         axis.set_ylim(*temperature_bounds)
 
     fig.colorbar(
-        mappable,
-        ax=ax.ravel().tolist(),
-        label="Mean (Logarithmic) Dust Mass Fraction",
+        mappable, ax=ax.ravel().tolist(), label="Mean (Logarithmic) Dust Mass Fraction"
     )
 
     fig.savefig(f"{output_path}/{prefix_T}density_temperature_dust.png")

--- a/colibre-zooms/scripts/density_temperature_dust2metal.py
+++ b/colibre-zooms/scripts/density_temperature_dust2metal.py
@@ -29,7 +29,7 @@ def get_data(filename, prefix_rho, prefix_T):
 
     number_density = (
         getattr(data.gas, f"{prefix_rho}densities").to_physical() / mh
-    ).to(cm**-3)
+    ).to(cm ** -3)
     temperature = getattr(data.gas, f"{prefix_T}temperatures").to_physical().to("K")
     masses = data.gas.masses.to_physical().to("Msun")
     Z = data.gas.metal_mass_fractions
@@ -91,11 +91,7 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/density_temperature_dust_to_metals.py
+++ b/colibre-zooms/scripts/density_temperature_dust_to_metals.py
@@ -12,7 +12,7 @@ from matplotlib.colors import LogNorm
 
 # Constants; these could be put in the parameter file but are rarely changed.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-temperature_bounds = [10**0.0, 10**9.5]  # in K
+temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 dtm_bounds = [1e-3, 1e-1]
 min_metallicity = 1e-8
 min_dmf = 1e-10
@@ -27,7 +27,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
     temperature = data.gas.temperatures.to_physical().to("K")
 
     metallicity = data.gas.metal_mass_fractions
@@ -93,11 +93,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -187,10 +183,7 @@ def make_single_image(
 
     for filename, hist, name, axis in zip(filenames, hists, names, ax.flat):
         mappable = axis.pcolormesh(
-            d,
-            T,
-            hist,
-            norm=LogNorm(vmin=dtm_bounds[0], vmax=dtm_bounds[1]),
+            d, T, hist, norm=LogNorm(vmin=dtm_bounds[0], vmax=dtm_bounds[1])
         )
         axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
         metadata = load(filename).metadata
@@ -198,11 +191,7 @@ def make_single_image(
         axis.set_xlim(*density_bounds)
         axis.set_ylim(*temperature_bounds)
 
-    fig.colorbar(
-        mappable,
-        ax=ax.ravel().tolist(),
-        label="Mean Dust / Metals Ratio []",
-    )
+    fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Mean Dust / Metals Ratio []")
 
     fig.savefig(f"{output_path}/density_temperature_dust_to_metals.png")
 

--- a/colibre-zooms/scripts/density_temperature_metals.py
+++ b/colibre-zooms/scripts/density_temperature_metals.py
@@ -12,7 +12,7 @@ from matplotlib.colors import Normalize
 
 # Constants; these could be put in the parameter file but are rarely changed.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-temperature_bounds = [10**0.0, 10**9.5]  # in K
+temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 metallicity_bounds = [-6, -1]  # In metal mass fraction
 min_metallicity = 1e-8
 bins = 256
@@ -25,7 +25,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
     temperature = data.gas.temperatures.to_physical().to("K")
 
     metallicity = data.gas.metal_mass_fractions
@@ -76,11 +76,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/density_temperature_sf_fraction.py
+++ b/colibre-zooms/scripts/density_temperature_sf_fraction.py
@@ -13,7 +13,7 @@ from matplotlib.colors import Normalize
 
 # Constants; these could be put in the parameter file but are rarely changed.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-temperature_bounds = [10**0.0, 10**9.5]  # in K
+temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 sf_mass_fraction_bounds = [-2.5, 0]  # log mass fraction of star-forming gas
 min_sf_mass_fraction = 1e-6  # Minimal mass fraction of star-forming gas
 bins = 256
@@ -27,7 +27,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
     temperature = data.gas.temperatures.to_physical().to("K")
     mass = data.gas.masses.to("Msun")
     sfr = data.gas.star_formation_rates.to("Msun/yr")
@@ -89,11 +89,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -197,9 +193,7 @@ def make_single_image(
         axis.set_ylim(*temperature_bounds)
 
     fig.colorbar(
-        mappable,
-        ax=ax.ravel().tolist(),
-        label="log Mass Fraction of Star-Forming Gas",
+        mappable, ax=ax.ravel().tolist(), label="log Mass Fraction of Star-Forming Gas"
     )
 
     fig.savefig(f"{output_path}/density_temperature_sf_fraction.png")

--- a/colibre-zooms/scripts/density_temperature_species.py
+++ b/colibre-zooms/scripts/density_temperature_species.py
@@ -12,7 +12,7 @@ from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-temperature_bounds = [10**0.0, 10**9.5]  # in K
+temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 specfracs_bounds = [1e-2, 1]  # dimensionless
 min_specfracs = specfracs_bounds[0]
 bins = 256
@@ -27,7 +27,7 @@ def get_data(filename, prefix_rho, prefix_T, species):
 
     number_density = (
         getattr(data.gas, f"{prefix_rho}densities").to_physical() / mh
-    ).to(cm**-3)
+    ).to(cm ** -3)
     temperature = getattr(data.gas, f"{prefix_T}temperatures").to_physical().to("K")
     masses = data.gas.masses.to_physical().to("Msun")
     hfrac = data.gas.element_mass_fractions.hydrogen.to_physical()
@@ -92,11 +92,7 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/gas_smoothing_lengths.py
+++ b/colibre-zooms/scripts/gas_smoothing_lengths.py
@@ -85,7 +85,7 @@ def make_single_image(filenames, names, h_bounds, number_of_simulations, output_
         )
 
         bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
-        bins = 10**bins
+        bins = 10 ** bins
 
         (line,) = ax.plot(bins, h, label=name)
 

--- a/colibre-zooms/scripts/last_AGN_density_distribution.py
+++ b/colibre-zooms/scripts/last_AGN_density_distribution.py
@@ -13,7 +13,7 @@ from swiftpipeline.argumentparser import ScriptArgumentParser
 
 
 def critical_density_DVS2012(
-    T_K: float = 10.0**7.5,
+    T_K: float = 10.0 ** 7.5,
     M_gas: float = 7.0e4,
     N_ngb: float = 48.0,
     X_H: float = 0.752,
@@ -57,7 +57,7 @@ def critical_density_DVS2012(
     # Critical density
     n_Hc = (
         31.0
-        * np.power(T_K / 10.0**7.5, 3.0 / 2.0)
+        * np.power(T_K / 10.0 ** 7.5, 3.0 / 2.0)
         * np.power(f_t / 10.0, -3.0 / 2.0)
         * np.power(M_gas / 7.0e4, -1.0 / 2.0)
         * np.power(N_ngb / 48.0, -1.0 / 2.0)
@@ -100,11 +100,7 @@ AGN_density_centers = 0.5 * (AGN_density_bins[1:] + AGN_density_bins[:-1])
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 axes = axes.flat
 
-ax_dict = {
-    "$z < 1$": axes[0],
-    "$1 < z < 3$": axes[1],
-    "$z > 3$": axes[2],
-}
+ax_dict = {"$z < 1$": axes[0], "$1 < z < 3$": axes[1], "$z > 3$": axes[2]}
 
 for label, ax in ax_dict.items():
     ax.loglog()
@@ -178,12 +174,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         H, _ = np.histogram(data, bins=AGN_density_bins)
         y_points = H / log_AGN_density_bin_width / Num_of_heated_parts_total
 
-        ax.plot(
-            AGN_density_centers,
-            y_points,
-            label=name,
-            color=f"C{color}",
-        )
+        ax.plot(AGN_density_centers, y_points, label=name, color=f"C{color}")
         ax.axvline(
             np.median(data),
             color=f"C{color}",
@@ -193,13 +184,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         )
 
         # Add the DV&S2012 line
-        ax.axvline(
-            n_crit,
-            color=f"C{color}",
-            linestyle="dotted",
-            zorder=-10,
-            alpha=0.5,
-        )
+        ax.axvline(n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5)
 
 axes[0].legend(loc="upper right", markerfirst=False)
 axes[2].set_xlabel(

--- a/colibre-zooms/scripts/last_SNII_density_distribution.py
+++ b/colibre-zooms/scripts/last_SNII_density_distribution.py
@@ -14,7 +14,7 @@ from swiftpipeline.argumentparser import ScriptArgumentParser
 
 
 def critical_density_DVS2012(
-    T_K: float = 10.0**7.5,
+    T_K: float = 10.0 ** 7.5,
     M_gas: float = 7.0e4,
     N_ngb: float = 48.0,
     X_H: float = 0.752,
@@ -58,7 +58,7 @@ def critical_density_DVS2012(
     # Critical density
     n_Hc = (
         31.0
-        * np.power(T_K / 10.0**7.5, 3.0 / 2.0)
+        * np.power(T_K / 10.0 ** 7.5, 3.0 / 2.0)
         * np.power(f_t / 10.0, -3.0 / 2.0)
         * np.power(M_gas / 7.0e4, -1.0 / 2.0)
         * np.power(N_ngb / 48.0, -1.0 / 2.0)
@@ -101,11 +101,7 @@ SNII_density_centers = 0.5 * (SNII_density_bins[1:] + SNII_density_bins[:-1])
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 axes = axes.flat
 
-ax_dict = {
-    "$z < 1$": axes[0],
-    "$1 < z < 3$": axes[1],
-    "$z > 3$": axes[2],
-}
+ax_dict = {"$z < 1$": axes[0], "$1 < z < 3$": axes[1], "$z > 3$": axes[2]}
 
 for label, ax in ax_dict.items():
     ax.loglog()
@@ -217,12 +213,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         H, _ = np.histogram(data, bins=SNII_density_bins)
         y_points = H / log_SNII_density_bin_width / Num_of_heated_parts_total
 
-        ax.plot(
-            SNII_density_centers,
-            y_points,
-            label=name,
-            color=f"C{color}",
-        )
+        ax.plot(SNII_density_centers, y_points, label=name, color=f"C{color}")
         ax.axvline(
             np.median(data),
             color=f"C{color}",
@@ -235,11 +226,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         for n_crit in [n_crit_min, n_crit_max]:
             if n_crit > 0.0:
                 ax.axvline(
-                    n_crit,
-                    color=f"C{color}",
-                    linestyle="dotted",
-                    zorder=-10,
-                    alpha=0.5,
+                    n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5
                 )
 
 axes[0].legend(loc="upper right", markerfirst=False)

--- a/colibre-zooms/scripts/last_SNII_kick_velocity_distribution.py
+++ b/colibre-zooms/scripts/last_SNII_kick_velocity_distribution.py
@@ -37,11 +37,7 @@ SNII_v_kick_centres = 0.5 * (SNII_v_kick_bins[1:] + SNII_v_kick_bins[:-1])
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 axes = axes.flat
 
-ax_dict = {
-    "$z < 1$": axes[0],
-    "$1 < z < 3$": axes[1],
-    "$z > 3$": axes[2],
-}
+ax_dict = {"$z < 1$": axes[0], "$1 < z < 3$": axes[1], "$z > 3$": axes[2]}
 
 for label, ax in ax_dict.items():
     ax.loglog()
@@ -118,12 +114,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         else:
             y_points = np.zeros_like(H)
 
-        ax.plot(
-            SNII_v_kick_centres,
-            y_points,
-            label=name,
-            color=f"C{color}",
-        )
+        ax.plot(SNII_v_kick_centres, y_points, label=name, color=f"C{color}")
         ax.axvline(
             np.median(data),
             color=f"C{color}",

--- a/colibre-zooms/scripts/max_SNII_kick_velocities.py
+++ b/colibre-zooms/scripts/max_SNII_kick_velocities.py
@@ -32,12 +32,7 @@ def get_data(filename):
     gas_SNII_v_kick_max = gas_SNII_v_kick_max[gas_SNII_kicked]
 
     # All kicks (contained in gas + stars info)
-    v_kick_max_all = np.concatenate(
-        [
-            stars_SNII_v_kick_max,
-            gas_SNII_v_kick_max,
-        ]
-    )
+    v_kick_max_all = np.concatenate([stars_SNII_v_kick_max, gas_SNII_v_kick_max])
 
     return v_kick_max_all
 
@@ -61,7 +56,7 @@ def make_single_image(
             np.log10(v_kick_max), range=np.log10(v_kick_bounds), bins=250, density=True
         )
         bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
-        bins = 10**bins
+        bins = 10 ** bins
         ax.plot(bins, h, label=name)
 
     ax.legend()

--- a/colibre-zooms/scripts/max_temperature_redshift.py
+++ b/colibre-zooms/scripts/max_temperature_redshift.py
@@ -66,11 +66,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre-zooms/scripts/max_temperatures.py
+++ b/colibre-zooms/scripts/max_temperatures.py
@@ -42,7 +42,7 @@ def make_single_image(filenames, names, T_bounds, number_of_simulations, output_
             log_T_max, range=np.log10(T_bounds), bins=250, density=True
         )
         bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
-        bins = 10**bins
+        bins = 10 ** bins
         ax.plot(bins, h, label=name)
 
         log_max_Ts.append(f"{name}: {log_T_max.max():.2f}")

--- a/colibre-zooms/scripts/number_of_agn_thermal_injections.py
+++ b/colibre-zooms/scripts/number_of_agn_thermal_injections.py
@@ -49,7 +49,7 @@ def make_single_image(filenames, names, N_bounds, number_of_simulations, output_
             np.log10(N_agn_events), range=np.log10(N_bounds), bins=250, density=False
         )
         bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
-        bins = 10**bins
+        bins = 10 ** bins
 
         # The cumsum is done from right to left (along the X axis)
         ax.plot(bins, np.cumsum(h[::-1])[::-1], label=name)

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -204,20 +204,17 @@ def register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes):
 
         # Oxygen mass
         M_O = getattr(
-            catalogue.element_masses_in_stars,
-            f"oxygen_mass_{aperture_size}_kpc",
+            catalogue.element_masses_in_stars, f"oxygen_mass_{aperture_size}_kpc"
         )
 
         # Magnesium mass
         M_Mg = getattr(
-            catalogue.element_masses_in_stars,
-            f"magnesium_mass_{aperture_size}_kpc",
+            catalogue.element_masses_in_stars, f"magnesium_mass_{aperture_size}_kpc"
         )
 
         # Iron mass
         M_Fe = getattr(
-            catalogue.element_masses_in_stars,
-            f"iron_mass_{aperture_size}_kpc",
+            catalogue.element_masses_in_stars, f"iron_mass_{aperture_size}_kpc"
         )
 
         # Avoid zeroes
@@ -243,16 +240,8 @@ def register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes):
         O_over_Fe.name = f"[O/Fe]$_*$ ({aperture_size} kpc)"
 
         # Register the field
-        setattr(
-            self,
-            f"star_magnesium_over_iron_{aperture_size}_kpc",
-            Mg_over_Fe,
-        )
-        setattr(
-            self,
-            f"star_oxygen_over_iron_{aperture_size}_kpc",
-            O_over_Fe,
-        )
+        setattr(self, f"star_magnesium_over_iron_{aperture_size}_kpc", Mg_over_Fe)
+        setattr(self, f"star_oxygen_over_iron_{aperture_size}_kpc", O_over_Fe)
 
     return
 
@@ -644,11 +633,7 @@ def register_cold_gas_mass_ratios(self, catalogue, aperture_sizes):
         sf_to_stellar_fraction.name = f"$M_{{\\rm SF}}/M_*$ ({aperture_size} kpc)"
 
         # Finally, register all the above fields
-        setattr(
-            self,
-            f"gas_neutral_H_mass_{aperture_size}_kpc",
-            neutral_H_mass,
-        )
+        setattr(self, f"gas_neutral_H_mass_{aperture_size}_kpc", neutral_H_mass)
 
         setattr(
             self,
@@ -730,11 +715,11 @@ def register_species_fractions(self, catalogue, aperture_sizes):
         # to be added for each.
 
         self.xgass_galaxy_selection = np.logical_and(
-            M_star > unyt.unyt_quantity(10**9, "Solar_Mass"),
+            M_star > unyt.unyt_quantity(10 ** 9, "Solar_Mass"),
             M_star < unyt.unyt_quantity(10 ** (11.5), "Solar_Mass"),
         )
         self.xcoldgass_galaxy_selection = np.logical_and(
-            M_star > unyt.unyt_quantity(10**9, "Solar_Mass"),
+            M_star > unyt.unyt_quantity(10 ** 9, "Solar_Mass"),
             M_star < unyt.unyt_quantity(10 ** (11.5), "Solar_Mass"),
         )
 

--- a/colibre/scripts/H2_mass_evolution.py
+++ b/colibre/scripts/H2_mass_evolution.py
@@ -75,7 +75,7 @@ S17_Omega_H2 = pow(10.0, S17_data[:, 1])
 simulation_lines.append(
     ax.errorbar(
         S17_expansion_factor,
-        S17_Omega_H2 * S17_expansion_factor**0,
+        S17_Omega_H2 * S17_expansion_factor ** 0,
         0,
         ls="none",
         marker="o",
@@ -94,8 +94,8 @@ D20_Omega_H2_hi = 1e7 * D20_data[:, 3]
 simulation_lines.append(
     ax.errorbar(
         D20_expansion_factor,
-        D20_Omega_H2 * D20_expansion_factor**0,
-        [D20_Omega_H2_lo, D20_Omega_H2_hi] * D20_expansion_factor**0,
+        D20_Omega_H2 * D20_expansion_factor ** 0,
+        [D20_Omega_H2_lo, D20_Omega_H2_hi] * D20_expansion_factor ** 0,
         ls="none",
         marker="o",
         label="Decarli et. al (2020)",

--- a/colibre/scripts/birth_density_distribution.py
+++ b/colibre/scripts/birth_density_distribution.py
@@ -14,7 +14,7 @@ from swiftpipeline.argumentparser import ScriptArgumentParser
 
 
 def critical_density_DVS2012(
-    T_K: float = 10.0**7.5,
+    T_K: float = 10.0 ** 7.5,
     M_gas: float = 7.0e4,
     N_ngb: float = 48.0,
     X_H: float = 0.752,
@@ -58,7 +58,7 @@ def critical_density_DVS2012(
     # Critical density
     n_Hc = (
         31.0
-        * np.power(T_K / 10.0**7.5, 3.0 / 2.0)
+        * np.power(T_K / 10.0 ** 7.5, 3.0 / 2.0)
         * np.power(f_t / 10.0, -3.0 / 2.0)
         * np.power(M_gas / 7.0e4, -1.0 / 2.0)
         * np.power(N_ngb / 48.0, -1.0 / 2.0)
@@ -99,11 +99,7 @@ birth_density_centers = 0.5 * (birth_density_bins[1:] + birth_density_bins[:-1])
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 axes = axes.flat
 
-ax_dict = {
-    "$z < 1$": axes[0],
-    "$1 < z < 3$": axes[1],
-    "$z > 3$": axes[2],
-}
+ax_dict = {"$z < 1$": axes[0], "$1 < z < 3$": axes[1], "$z > 3$": axes[2]}
 
 for label, ax in ax_dict.items():
     ax.loglog()
@@ -169,12 +165,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         H, _ = np.histogram(data, bins=birth_density_bins)
         y_points = H / log_birth_density_bin_width / Num_of_stars_total
 
-        ax.plot(
-            birth_density_centers,
-            y_points,
-            label=name,
-            color=f"C{color}",
-        )
+        ax.plot(birth_density_centers, y_points, label=name, color=f"C{color}")
 
         # Add the median stellar birth-density line
         ax.axvline(
@@ -189,11 +180,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         for n_crit in [n_crit_min, n_crit_max]:
             if n_crit > 0.0:
                 ax.axvline(
-                    n_crit,
-                    color=f"C{color}",
-                    linestyle="dotted",
-                    zorder=-10,
-                    alpha=0.5,
+                    n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5
                 )
 
 axes[0].legend(loc="upper right", markerfirst=False)

--- a/colibre/scripts/birth_density_metallicity.py
+++ b/colibre/scripts/birth_density_metallicity.py
@@ -11,7 +11,7 @@ from unyt import mh
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-density_bounds = [0.01, 10**7.0]  # in nh/cm^3
+density_bounds = [0.01, 10 ** 7.0]  # in nh/cm^3
 metal_mass_fraction_bounds = [1e-4, 0.5]  # dimensionless
 bins = 128
 
@@ -75,11 +75,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/birth_density_redshift.py
+++ b/colibre/scripts/birth_density_redshift.py
@@ -11,7 +11,7 @@ from unyt import mh
 from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
-density_bounds = [0.01, 10**7.0]  # in nh/cm^3
+density_bounds = [0.01, 10 ** 7.0]  # in nh/cm^3
 redshift_bounds = [-1.5, 12]  # dimensionless
 bins = 128
 
@@ -61,11 +61,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/birth_metallicity_redshift.py
+++ b/colibre/scripts/birth_metallicity_redshift.py
@@ -73,11 +73,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/deadtime_evolution.py
+++ b/colibre/scripts/deadtime_evolution.py
@@ -50,11 +50,7 @@ for color_index, (run_name, run_directory) in enumerate(
             loose=False,
             invalid_raise=True,
             usecols=(2, 12, 14),
-            dtype=[
-                ("a", "f4"),
-                ("wallclock", "f4"),
-                ("deadtime", "f4"),
-            ],
+            dtype=[("a", "f4"), ("wallclock", "f4"), ("deadtime", "f4")],
         )
     except (FileNotFoundError, ValueError):
         ax.plot([], [], "-", color=color, label=f"{run_name} - no deadtime data")

--- a/colibre/scripts/density_internal_energy.py
+++ b/colibre/scripts/density_internal_energy.py
@@ -12,7 +12,7 @@ from matplotlib.colors import LogNorm
 
 # Constants; these could be put in the parameter file but are rarely changed.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-internal_energy_bounds = [10 ** (-4), 10**8]  # in
+internal_energy_bounds = [10 ** (-4), 10 ** 8]  # in
 bins = 256
 
 
@@ -23,8 +23,8 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
-    internal_energy = (data.gas.internal_energies.to_physical()).to(km**2 / s**2)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
+    internal_energy = (data.gas.internal_energies.to_physical()).to(km ** 2 / s ** 2)
 
     return number_density.value, internal_energy.value
 
@@ -62,11 +62,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_pressure.py
+++ b/colibre/scripts/density_pressure.py
@@ -13,7 +13,7 @@ from matplotlib.animation import FuncAnimation
 
 # Constants; these could be put in the parameter file but are rarely changed.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-pressure_bounds = [10 ** (-8.0), 10**8.0]  # in K/cm^3
+pressure_bounds = [10 ** (-8.0), 10 ** 8.0]  # in K/cm^3
 bins = 256
 
 
@@ -24,8 +24,8 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
-    pressure = (data.gas.pressures.to_physical() / kb).to(K * cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
+    pressure = (data.gas.pressures.to_physical() / kb).to(K * cm ** -3)
 
     return number_density.value, pressure.value
 
@@ -64,11 +64,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_species_interp.py
+++ b/colibre/scripts/density_species_interp.py
@@ -41,7 +41,7 @@ def get_data(filename, tables, prefix_rho, prefix_T):
     data = load(filename)
     number_density = (
         getattr(data.gas, f"{prefix_rho}densities").to_physical() / mh
-    ).to(cm**-3)
+    ).to(cm ** -3)
     temperature = getattr(data.gas, f"{prefix_T}temperatures").to_physical().to("K")
     masses = data.gas.masses.to_physical().to("Msun")
 
@@ -64,7 +64,7 @@ def get_data(filename, tables, prefix_rho, prefix_T):
         with h5.File(tables, "r") as table_file:
             lrho = np.log10(
                 (data.gas.subgrid_physical_densities.to_physical() / mh)
-                .to(cm**-3)
+                .to(cm ** -3)
                 .value
             )
             lT = np.log10((data.gas.subgrid_temperatures).to_physical().to("K").value)
@@ -119,14 +119,7 @@ def get_data(filename, tables, prefix_rho, prefix_T):
     return out_tuple
 
 
-def make_hist(
-    filename,
-    density_bounds,
-    bins,
-    tables,
-    prefix_rho="",
-    prefix_T="",
-):
+def make_hist(filename, density_bounds, bins, tables, prefix_rho="", prefix_T=""):
     """
     Makes the histogram for filename with bounds as lower, higher
     for the bins and "bins" the number of bins along each dimension.
@@ -192,11 +185,7 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -254,12 +243,7 @@ def make_single_image(
 
     for filename in filenames:
         hh2, hhi, hhii, hd2z, hdi2z, d = make_hist(
-            filename,
-            density_bounds,
-            bins,
-            tables,
-            prefix_rho,
-            prefix_T,
+            filename, density_bounds, bins, tables, prefix_rho, prefix_T
         )
         hist_h2.append(hh2)
         hist_hi.append(hhi)

--- a/colibre/scripts/density_temperature.py
+++ b/colibre/scripts/density_temperature.py
@@ -24,7 +24,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
     temperature = data.gas.temperatures.to_physical().to("K")
 
     return number_density.value, temperature.value
@@ -64,11 +64,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_dust.py
+++ b/colibre/scripts/density_temperature_dust.py
@@ -11,7 +11,7 @@ from matplotlib.colors import Normalize
 
 # Set the limits of the figure.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-temperature_bounds = [10**0.0, 10**9.5]  # in K
+temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 dustfracs_bounds = [-5, -1]  # dimensionless (dust mass / gas mass)
 min_dustfracs = dustfracs_bounds[0]
 bins = 256
@@ -26,7 +26,7 @@ def get_data(filename, prefix_rho, prefix_T):
 
     number_density = (
         getattr(data.gas, f"{prefix_rho}densities").to_physical() / mh
-    ).to(cm**-3)
+    ).to(cm ** -3)
     temperature = getattr(data.gas, f"{prefix_T}temperatures").to_physical().to("K")
 
     dfracs = np.zeros(data.gas.masses.shape)
@@ -35,7 +35,7 @@ def get_data(filename, prefix_rho, prefix_T):
         if hasattr(getattr(data.gas.dust_mass_fractions, d), "units"):
             dfracs += getattr(data.gas.dust_mass_fractions, d)
 
-    dfracs[dfracs < 10.0**min_dustfracs] = 10.0**min_dustfracs
+    dfracs[dfracs < 10.0 ** min_dustfracs] = 10.0 ** min_dustfracs
 
     return number_density.value, temperature.value, np.log10(dfracs.value)
 
@@ -84,11 +84,7 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -209,9 +205,7 @@ def make_single_image(
         axis.set_ylim(*temperature_bounds)
 
     fig.colorbar(
-        mappable,
-        ax=ax.ravel().tolist(),
-        label="Mean (Logarithmic) Dust Mass Fraction",
+        mappable, ax=ax.ravel().tolist(), label="Mean (Logarithmic) Dust Mass Fraction"
     )
 
     fig.savefig(f"{output_path}/{prefix_T}density_temperature_dust.png")

--- a/colibre/scripts/density_temperature_dust2metal.py
+++ b/colibre/scripts/density_temperature_dust2metal.py
@@ -29,7 +29,7 @@ def get_data(filename, prefix_rho, prefix_T):
 
     number_density = (
         getattr(data.gas, f"{prefix_rho}densities").to_physical() / mh
-    ).to(cm**-3)
+    ).to(cm ** -3)
     temperature = getattr(data.gas, f"{prefix_T}temperatures").to_physical().to("K")
     masses = data.gas.masses.to_physical().to("Msun")
     Z = data.gas.metal_mass_fractions
@@ -91,11 +91,7 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_dust_to_metals.py
+++ b/colibre/scripts/density_temperature_dust_to_metals.py
@@ -12,7 +12,7 @@ from matplotlib.colors import LogNorm
 
 # Constants; these could be put in the parameter file but are rarely changed.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-temperature_bounds = [10**0.0, 10**9.5]  # in K
+temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 dtm_bounds = [1e-3, 1e-1]
 min_metallicity = 1e-8
 min_dmf = 1e-10
@@ -27,7 +27,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
     temperature = data.gas.temperatures.to_physical().to("K")
 
     metallicity = data.gas.metal_mass_fractions
@@ -93,11 +93,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -187,10 +183,7 @@ def make_single_image(
 
     for filename, hist, name, axis in zip(filenames, hists, names, ax.flat):
         mappable = axis.pcolormesh(
-            d,
-            T,
-            hist,
-            norm=LogNorm(vmin=dtm_bounds[0], vmax=dtm_bounds[1]),
+            d, T, hist, norm=LogNorm(vmin=dtm_bounds[0], vmax=dtm_bounds[1])
         )
         axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
         metadata = load(filename).metadata
@@ -198,11 +191,7 @@ def make_single_image(
         axis.set_xlim(*density_bounds)
         axis.set_ylim(*temperature_bounds)
 
-    fig.colorbar(
-        mappable,
-        ax=ax.ravel().tolist(),
-        label="Mean Dust / Metals Ratio []",
-    )
+    fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Mean Dust / Metals Ratio []")
 
     fig.savefig(f"{output_path}/density_temperature_dust_to_metals.png")
 

--- a/colibre/scripts/density_temperature_metals.py
+++ b/colibre/scripts/density_temperature_metals.py
@@ -12,7 +12,7 @@ from matplotlib.colors import Normalize
 
 # Constants; these could be put in the parameter file but are rarely changed.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-temperature_bounds = [10**0.0, 10**9.5]  # in K
+temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 metallicity_bounds = [-6, -1]  # In metal mass fraction
 min_metallicity = 1e-8
 bins = 256
@@ -25,7 +25,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
     temperature = data.gas.temperatures.to_physical().to("K")
 
     metallicity = data.gas.metal_mass_fractions
@@ -76,11 +76,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_sf_fraction.py
+++ b/colibre/scripts/density_temperature_sf_fraction.py
@@ -13,7 +13,7 @@ from matplotlib.colors import Normalize
 
 # Constants; these could be put in the parameter file but are rarely changed.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-temperature_bounds = [10**0.0, 10**9.5]  # in K
+temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 sf_mass_fraction_bounds = [-2.5, 0]  # log mass fraction of star-forming gas
 min_sf_mass_fraction = 1e-6  # Minimal mass fraction of star-forming gas
 bins = 256
@@ -27,7 +27,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
     temperature = data.gas.temperatures.to_physical().to("K")
     mass = data.gas.masses.to("Msun")
     sfr = data.gas.star_formation_rates.to("Msun/yr")
@@ -89,11 +89,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -197,9 +193,7 @@ def make_single_image(
         axis.set_ylim(*temperature_bounds)
 
     fig.colorbar(
-        mappable,
-        ax=ax.ravel().tolist(),
-        label="log Mass Fraction of Star-Forming Gas",
+        mappable, ax=ax.ravel().tolist(), label="log Mass Fraction of Star-Forming Gas"
     )
 
     fig.savefig(f"{output_path}/density_temperature_sf_fraction.png")

--- a/colibre/scripts/density_temperature_species.py
+++ b/colibre/scripts/density_temperature_species.py
@@ -12,7 +12,7 @@ from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
 density_bounds = [10 ** (-9.5), 1e7]  # in nh/cm^3
-temperature_bounds = [10**0.0, 10**9.5]  # in K
+temperature_bounds = [10 ** 0.0, 10 ** 9.5]  # in K
 specfracs_bounds = [1e-2, 1]  # dimensionless
 min_specfracs = specfracs_bounds[0]
 bins = 256
@@ -27,7 +27,7 @@ def get_data(filename, prefix_rho, prefix_T, species):
 
     number_density = (
         getattr(data.gas, f"{prefix_rho}densities").to_physical() / mh
-    ).to(cm**-3)
+    ).to(cm ** -3)
     temperature = getattr(data.gas, f"{prefix_T}temperatures").to_physical().to("K")
     masses = data.gas.masses.to_physical().to("Msun")
     hfrac = data.gas.element_mass_fractions.hydrogen.to_physical()
@@ -92,11 +92,7 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/gas_smoothing_lengths.py
+++ b/colibre/scripts/gas_smoothing_lengths.py
@@ -85,7 +85,7 @@ def make_single_image(filenames, names, h_bounds, number_of_simulations, output_
         )
 
         bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
-        bins = 10**bins
+        bins = 10 ** bins
 
         (line,) = ax.plot(bins, h, label=name)
 

--- a/colibre/scripts/last_AGN_density_distribution.py
+++ b/colibre/scripts/last_AGN_density_distribution.py
@@ -13,7 +13,7 @@ from swiftpipeline.argumentparser import ScriptArgumentParser
 
 
 def critical_density_DVS2012(
-    T_K: float = 10.0**7.5,
+    T_K: float = 10.0 ** 7.5,
     M_gas: float = 7.0e4,
     N_ngb: float = 48.0,
     X_H: float = 0.752,
@@ -57,7 +57,7 @@ def critical_density_DVS2012(
     # Critical density
     n_Hc = (
         31.0
-        * np.power(T_K / 10.0**7.5, 3.0 / 2.0)
+        * np.power(T_K / 10.0 ** 7.5, 3.0 / 2.0)
         * np.power(f_t / 10.0, -3.0 / 2.0)
         * np.power(M_gas / 7.0e4, -1.0 / 2.0)
         * np.power(N_ngb / 48.0, -1.0 / 2.0)
@@ -100,11 +100,7 @@ AGN_density_centers = 0.5 * (AGN_density_bins[1:] + AGN_density_bins[:-1])
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 axes = axes.flat
 
-ax_dict = {
-    "$z < 1$": axes[0],
-    "$1 < z < 3$": axes[1],
-    "$z > 3$": axes[2],
-}
+ax_dict = {"$z < 1$": axes[0], "$1 < z < 3$": axes[1], "$z > 3$": axes[2]}
 
 for label, ax in ax_dict.items():
     ax.loglog()
@@ -178,12 +174,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         H, _ = np.histogram(data, bins=AGN_density_bins)
         y_points = H / log_AGN_density_bin_width / Num_of_heated_parts_total
 
-        ax.plot(
-            AGN_density_centers,
-            y_points,
-            label=name,
-            color=f"C{color}",
-        )
+        ax.plot(AGN_density_centers, y_points, label=name, color=f"C{color}")
         ax.axvline(
             np.median(data),
             color=f"C{color}",
@@ -193,13 +184,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         )
 
         # Add the DV&S2012 line
-        ax.axvline(
-            n_crit,
-            color=f"C{color}",
-            linestyle="dotted",
-            zorder=-10,
-            alpha=0.5,
-        )
+        ax.axvline(n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5)
 
 axes[0].legend(loc="upper right", markerfirst=False)
 axes[2].set_xlabel(

--- a/colibre/scripts/last_SNII_density_distribution.py
+++ b/colibre/scripts/last_SNII_density_distribution.py
@@ -14,7 +14,7 @@ from swiftpipeline.argumentparser import ScriptArgumentParser
 
 
 def critical_density_DVS2012(
-    T_K: float = 10.0**7.5,
+    T_K: float = 10.0 ** 7.5,
     M_gas: float = 7.0e4,
     N_ngb: float = 48.0,
     X_H: float = 0.752,
@@ -58,7 +58,7 @@ def critical_density_DVS2012(
     # Critical density
     n_Hc = (
         31.0
-        * np.power(T_K / 10.0**7.5, 3.0 / 2.0)
+        * np.power(T_K / 10.0 ** 7.5, 3.0 / 2.0)
         * np.power(f_t / 10.0, -3.0 / 2.0)
         * np.power(M_gas / 7.0e4, -1.0 / 2.0)
         * np.power(N_ngb / 48.0, -1.0 / 2.0)
@@ -101,11 +101,7 @@ SNII_density_centers = 0.5 * (SNII_density_bins[1:] + SNII_density_bins[:-1])
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 axes = axes.flat
 
-ax_dict = {
-    "$z < 1$": axes[0],
-    "$1 < z < 3$": axes[1],
-    "$z > 3$": axes[2],
-}
+ax_dict = {"$z < 1$": axes[0], "$1 < z < 3$": axes[1], "$z > 3$": axes[2]}
 
 for label, ax in ax_dict.items():
     ax.loglog()
@@ -217,12 +213,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         H, _ = np.histogram(data, bins=SNII_density_bins)
         y_points = H / log_SNII_density_bin_width / Num_of_heated_parts_total
 
-        ax.plot(
-            SNII_density_centers,
-            y_points,
-            label=name,
-            color=f"C{color}",
-        )
+        ax.plot(SNII_density_centers, y_points, label=name, color=f"C{color}")
         ax.axvline(
             np.median(data),
             color=f"C{color}",
@@ -235,11 +226,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         for n_crit in [n_crit_min, n_crit_max]:
             if n_crit > 0.0:
                 ax.axvline(
-                    n_crit,
-                    color=f"C{color}",
-                    linestyle="dotted",
-                    zorder=-10,
-                    alpha=0.5,
+                    n_crit, color=f"C{color}", linestyle="dotted", zorder=-10, alpha=0.5
                 )
 
 axes[0].legend(loc="upper right", markerfirst=False)

--- a/colibre/scripts/last_SNII_kick_velocity_distribution.py
+++ b/colibre/scripts/last_SNII_kick_velocity_distribution.py
@@ -37,11 +37,7 @@ SNII_v_kick_centres = 0.5 * (SNII_v_kick_bins[1:] + SNII_v_kick_bins[:-1])
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 axes = axes.flat
 
-ax_dict = {
-    "$z < 1$": axes[0],
-    "$1 < z < 3$": axes[1],
-    "$z > 3$": axes[2],
-}
+ax_dict = {"$z < 1$": axes[0], "$1 < z < 3$": axes[1], "$z > 3$": axes[2]}
 
 for label, ax in ax_dict.items():
     ax.loglog()
@@ -113,12 +109,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
         H, _ = np.histogram(data, bins=SNII_v_kick_bins)
         y_points = H / log_SNII_v_kick_bin_width / Num_of_kicked_parts_total
 
-        ax.plot(
-            SNII_v_kick_centres,
-            y_points,
-            label=name,
-            color=f"C{color}",
-        )
+        ax.plot(SNII_v_kick_centres, y_points, label=name, color=f"C{color}")
         ax.axvline(
             np.median(data),
             color=f"C{color}",

--- a/colibre/scripts/load_sfh_data.py
+++ b/colibre/scripts/load_sfh_data.py
@@ -41,8 +41,8 @@ def read_obs_data(path="observational_data"):
     )
     lgrho = lgrho + log10(0.6) + hcorr
     obs1_a = 1.0 / (1.0 + z)
-    obs1_rho = 10**lgrho
-    obs1_rho_err = array([obs1_rho - 10**lgrho_down, 10**lgrho_up - obs1_rho])
+    obs1_rho = 10 ** lgrho
+    obs1_rho_err = array([obs1_rho - 10 ** lgrho_down, 10 ** lgrho_up - obs1_rho])
 
     # output.append(
     #    ObservationalData(
@@ -106,7 +106,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_cucciati2011.dat", unpack=True)
     rhostar = rhostar - 2.0 * log10(0.7) + 2.0 * log10(0.6777)
     obs5_a = 1.0 / (1 + z)
-    obs5_rho = 10**rhostar / 1.65
+    obs5_rho = 10 ** rhostar / 1.65
     obs5_rho_err = 10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65
     obs5_rho_err[0] = -obs5_rho_err[0] + obs5_rho
     obs5_rho_err[1] = -obs5_rho + obs5_rho_err[1]
@@ -121,7 +121,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_magnelli2013.dat", unpack=True)
     obs6_a = 1.0 / (1 + z)
     obs6_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs6_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -137,7 +137,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_gruppioni2013.dat", unpack=True)
     obs7_a = 1.0 / (1 + z)
     obs7_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs7_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -167,7 +167,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_schenker2013.dat", unpack=True)
     obs9_a = 1.0 / (1 + z)
     obs9_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs9_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -183,7 +183,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_p, err_m = loadtxt(f"{path}/sfr_bouwens2015_dust.dat", unpack=True)
     obs10_a = 1.0 / (1 + z)
     obs10_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs10_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -203,7 +203,7 @@ def read_obs_data(path="observational_data"):
     )
     obs11_a = 1.0 / (1 + z)
     obs11_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs11_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -221,7 +221,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_p, err_m = loadtxt(f"{path}/sfr_oesch2018.dat", unpack=True)
     obs12_a = 1.0 / (1 + z)
     obs12_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs12_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -239,7 +239,7 @@ def read_obs_data(path="observational_data"):
     )
     obs13_a = 1.0 / (1 + z)
     obs13_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs13_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -259,7 +259,7 @@ def read_obs_data(path="observational_data"):
     )
     obs14_a = 1.0 / (1 + z)
     obs14_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs14_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -294,7 +294,7 @@ def read_obs_data(path="observational_data"):
 
     output.append(
         ObservationalData(
-            eagle_data[:, 0], eagle_data[:, 2] / (25**3), None, "EAGLE-25 REF"
+            eagle_data[:, 0], eagle_data[:, 2] / (25 ** 3), None, "EAGLE-25 REF"
         )
     )
 
@@ -302,7 +302,7 @@ def read_obs_data(path="observational_data"):
 
     output.append(
         ObservationalData(
-            eagle_data[:, 0], eagle_data[:, 2] / (12**3), None, "EAGLE-12 REF"
+            eagle_data[:, 0], eagle_data[:, 2] / (12 ** 3), None, "EAGLE-12 REF"
         )
     )
 

--- a/colibre/scripts/max_SNII_kick_velocities.py
+++ b/colibre/scripts/max_SNII_kick_velocities.py
@@ -32,12 +32,7 @@ def get_data(filename):
     gas_SNII_v_kick_max = gas_SNII_v_kick_max[gas_SNII_kicked]
 
     # All kicks (contained in gas + stars info)
-    v_kick_max_all = np.concatenate(
-        [
-            stars_SNII_v_kick_max,
-            gas_SNII_v_kick_max,
-        ]
-    )
+    v_kick_max_all = np.concatenate([stars_SNII_v_kick_max, gas_SNII_v_kick_max])
 
     return v_kick_max_all
 
@@ -61,7 +56,7 @@ def make_single_image(
             np.log10(v_kick_max), range=np.log10(v_kick_bounds), bins=250, density=True
         )
         bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
-        bins = 10**bins
+        bins = 10 ** bins
         ax.plot(bins, h, label=name)
 
     ax.legend()

--- a/colibre/scripts/max_temperature_redshift.py
+++ b/colibre/scripts/max_temperature_redshift.py
@@ -66,11 +66,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/max_temperatures.py
+++ b/colibre/scripts/max_temperatures.py
@@ -42,7 +42,7 @@ def make_single_image(filenames, names, T_bounds, number_of_simulations, output_
             log_T_max, range=np.log10(T_bounds), bins=250, density=True
         )
         bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
-        bins = 10**bins
+        bins = 10 ** bins
         ax.plot(bins, h, label=name)
 
         log_max_Ts.append(f"{name}: {log_T_max.max():.2f}")

--- a/colibre/scripts/number_of_agn_thermal_injections.py
+++ b/colibre/scripts/number_of_agn_thermal_injections.py
@@ -49,7 +49,7 @@ def make_single_image(filenames, names, N_bounds, number_of_simulations, output_
             np.log10(N_agn_events), range=np.log10(N_bounds), bins=250, density=False
         )
         bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
-        bins = 10**bins
+        bins = 10 ** bins
 
         # The cumsum is done from right to left (along the X axis)
         ax.plot(bins, np.cumsum(h[::-1])[::-1], label=name)

--- a/colibre/scripts/particle_updates_step_cost.py
+++ b/colibre/scripts/particle_updates_step_cost.py
@@ -12,8 +12,8 @@ from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 
 # Set the limits of the figure.
-update_bounds = unyt.unyt_array([1, 10.0**10.0], units="dimensionless")
-wallclock_bounds = unyt.unyt_array([1, 10.0**6.0], units="ms")
+update_bounds = unyt.unyt_array([1, 10.0 ** 10.0], units="dimensionless")
+wallclock_bounds = unyt.unyt_array([1, 10.0 ** 6.0], units="ms")
 bins = 512
 
 

--- a/colibre/scripts/star_formation_history.py
+++ b/colibre/scripts/star_formation_history.py
@@ -16,7 +16,7 @@ from velociraptor.observations import load_observations
 from astropy.cosmology import z_at_value
 from astropy.units import Gyr
 
-sfr_output_units = unyt.msun / (unyt.year * unyt.Mpc**3)
+sfr_output_units = unyt.msun / (unyt.year * unyt.Mpc ** 3)
 
 from swiftpipeline.argumentparser import ScriptArgumentParser
 

--- a/eagle-xl/registration.py
+++ b/eagle-xl/registration.py
@@ -413,11 +413,11 @@ def register_species_fractions(self, catalogue, aperture_sizes):
             # to be added for each.
 
             self.xgass_galaxy_selection = np.logical_and(
-                M_star > unyt.unyt_quantity(10**9, "Solar_Mass"),
+                M_star > unyt.unyt_quantity(10 ** 9, "Solar_Mass"),
                 M_star < unyt.unyt_quantity(10 ** (11.5), "Solar_Mass"),
             )
             self.xcoldgass_galaxy_selection = np.logical_and(
-                M_star > unyt.unyt_quantity(10**9, "Solar_Mass"),
+                M_star > unyt.unyt_quantity(10 ** 9, "Solar_Mass"),
                 M_star < unyt.unyt_quantity(10 ** (11.5), "Solar_Mass"),
             )
 

--- a/eagle-xl/scripts/H2_mass_evolution.py
+++ b/eagle-xl/scripts/H2_mass_evolution.py
@@ -75,7 +75,7 @@ S17_Omega_H2 = pow(10.0, S17_data[:, 1])
 simulation_lines.append(
     ax.errorbar(
         S17_expansion_factor,
-        S17_Omega_H2 * S17_expansion_factor**0,
+        S17_Omega_H2 * S17_expansion_factor ** 0,
         0,
         ls="none",
         marker="o",
@@ -94,8 +94,8 @@ D20_Omega_H2_hi = 1e7 * D20_data[:, 3]
 simulation_lines.append(
     ax.errorbar(
         D20_expansion_factor,
-        D20_Omega_H2 * D20_expansion_factor**0,
-        [D20_Omega_H2_lo, D20_Omega_H2_hi] * D20_expansion_factor**0,
+        D20_Omega_H2 * D20_expansion_factor ** 0,
+        [D20_Omega_H2_lo, D20_Omega_H2_hi] * D20_expansion_factor ** 0,
         ls="none",
         marker="o",
         label="Decarli et. al (2020)",

--- a/eagle-xl/scripts/birth_density_distribution.py
+++ b/eagle-xl/scripts/birth_density_distribution.py
@@ -32,7 +32,7 @@ data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
 number_of_bins = 256
 
 birth_density_bins = unyt.unyt_array(
-    np.logspace(-3, 5, number_of_bins), units=1 / cm**3
+    np.logspace(-3, 5, number_of_bins), units=1 / cm ** 3
 )
 log_birth_density_bin_width = np.log10(birth_density_bins[1].value) - np.log10(
     birth_density_bins[0].value
@@ -45,11 +45,7 @@ birth_density_centers = 0.5 * (birth_density_bins[1:] + birth_density_bins[:-1])
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 axes = axes.flat
 
-ax_dict = {
-    "$z < 1$": axes[0],
-    "$1 < z < 3$": axes[1],
-    "$z > 3$": axes[2],
-}
+ax_dict = {"$z < 1$": axes[0], "$1 < z < 3$": axes[1], "$z > 3$": axes[2]}
 
 for label, ax in ax_dict.items():
     ax.loglog()

--- a/eagle-xl/scripts/birth_density_f_E.py
+++ b/eagle-xl/scripts/birth_density_f_E.py
@@ -28,11 +28,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -58,10 +54,10 @@ def bin_individual_data(data: SWIFTDataset):
     mask = f_E_fractions > 0.0
 
     f_E_fractions = f_E_fractions[mask]
-    birth_densities = (data.stars.birth_densities[mask] / mh).to(1 / cm**3).value
+    birth_densities = (data.stars.birth_densities[mask] / mh).to(1 / cm ** 3).value
 
     birth_density_bins = unyt.unyt_array(
-        np.logspace(-3, 5, number_of_bins), units=1 / cm**3
+        np.logspace(-3, 5, number_of_bins), units=1 / cm ** 3
     )
     feedback_energy_fraction_bins = unyt.unyt_array(
         np.logspace(-2, 1, number_of_bins), units="dimensionless"

--- a/eagle-xl/scripts/birth_density_metallicity.py
+++ b/eagle-xl/scripts/birth_density_metallicity.py
@@ -16,7 +16,7 @@ from matplotlib.colors import LogNorm, Normalize
 number_of_bins = 128
 
 birth_density_bins = unyt.unyt_array(
-    np.logspace(-3, 5, number_of_bins), units=1 / cm**3
+    np.logspace(-3, 5, number_of_bins), units=1 / cm ** 3
 )
 metal_mass_fraction_bins = unyt.unyt_array(
     np.logspace(-6, 0, number_of_bins), units="dimensionless"
@@ -35,11 +35,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -182,7 +178,7 @@ if __name__ == "__main__":
             metal_mass_fractions = snapshot.stars.metal_mass_fractions.value
 
         H, _, _ = np.histogram2d(
-            (snapshot.stars.birth_densities / mh).to(1 / cm**3).value,
+            (snapshot.stars.birth_densities / mh).to(1 / cm ** 3).value,
             metal_mass_fractions,
             bins=[birth_density_bins.value, metal_mass_fraction_bins.value],
         )

--- a/eagle-xl/scripts/deadtime_evolution.py
+++ b/eagle-xl/scripts/deadtime_evolution.py
@@ -50,11 +50,7 @@ for color_index, (run_name, run_directory) in enumerate(
             loose=False,
             invalid_raise=True,
             usecols=(2, 12, 14),
-            dtype=[
-                ("a", "f4"),
-                ("wallclock", "f4"),
-                ("deadtime", "f4"),
-            ],
+            dtype=[("a", "f4"), ("wallclock", "f4"), ("deadtime", "f4")],
         )
     except (FileNotFoundError, ValueError):
         ax.plot([], [], "-", color=color, label=f"{run_name} - no deadtime data")

--- a/eagle-xl/scripts/density_internal_energy.py
+++ b/eagle-xl/scripts/density_internal_energy.py
@@ -24,8 +24,8 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
-    internal_energy = (data.gas.internal_energies.to_physical()).to(km**2 / s**2)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
+    internal_energy = (data.gas.internal_energies.to_physical()).to(km ** 2 / s ** 2)
 
     return number_density.value, internal_energy.value
 
@@ -63,11 +63,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/eagle-xl/scripts/density_pressure.py
+++ b/eagle-xl/scripts/density_pressure.py
@@ -24,8 +24,8 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
-    pressure = (data.gas.pressures.to_physical() / kb).to(K * cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
+    pressure = (data.gas.pressures.to_physical() / kb).to(K * cm ** -3)
 
     return number_density.value, pressure.value
 
@@ -64,11 +64,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/eagle-xl/scripts/density_temperature.py
+++ b/eagle-xl/scripts/density_temperature.py
@@ -24,7 +24,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
     temperature = data.gas.temperatures.to_physical().to("K")
 
     return number_density.value, temperature.value
@@ -64,11 +64,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/eagle-xl/scripts/density_temperature_metals.py
+++ b/eagle-xl/scripts/density_temperature_metals.py
@@ -26,7 +26,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
     temperature = data.gas.temperatures.to_physical().to("K")
 
     metallicity = data.gas.metal_mass_fractions
@@ -77,11 +77,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/eagle-xl/scripts/gas_smoothing_lengths.py
+++ b/eagle-xl/scripts/gas_smoothing_lengths.py
@@ -85,7 +85,7 @@ def make_single_image(filenames, names, h_bounds, number_of_simulations, output_
         )
 
         bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
-        bins = 10**bins
+        bins = 10 ** bins
 
         (line,) = ax.plot(bins, h, label=name)
 

--- a/eagle-xl/scripts/load_sfh_data.py
+++ b/eagle-xl/scripts/load_sfh_data.py
@@ -41,8 +41,8 @@ def read_obs_data(path="observational_data"):
     )
     lgrho = lgrho + log10(0.6) + hcorr
     obs1_a = 1.0 / (1.0 + z)
-    obs1_rho = 10**lgrho
-    obs1_rho_err = array([obs1_rho - 10**lgrho_down, 10**lgrho_up - obs1_rho])
+    obs1_rho = 10 ** lgrho
+    obs1_rho_err = array([obs1_rho - 10 ** lgrho_down, 10 ** lgrho_up - obs1_rho])
 
     # output.append(
     #    ObservationalData(
@@ -106,7 +106,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_cucciati2011.dat", unpack=True)
     rhostar = rhostar - 2.0 * log10(0.7) + 2.0 * log10(0.6777)
     obs5_a = 1.0 / (1 + z)
-    obs5_rho = 10**rhostar / 1.65
+    obs5_rho = 10 ** rhostar / 1.65
     obs5_rho_err = 10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65
     obs5_rho_err[0] = -obs5_rho_err[0] + obs5_rho
     obs5_rho_err[1] = -obs5_rho + obs5_rho_err[1]
@@ -121,7 +121,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_magnelli2013.dat", unpack=True)
     obs6_a = 1.0 / (1 + z)
     obs6_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs6_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -137,7 +137,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_gruppioni2013.dat", unpack=True)
     obs7_a = 1.0 / (1 + z)
     obs7_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs7_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -167,7 +167,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_schenker2013.dat", unpack=True)
     obs9_a = 1.0 / (1 + z)
     obs9_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs9_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -183,7 +183,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_p, err_m = loadtxt(f"{path}/sfr_bouwens2015_dust.dat", unpack=True)
     obs10_a = 1.0 / (1 + z)
     obs10_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs10_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -203,7 +203,7 @@ def read_obs_data(path="observational_data"):
     )
     obs11_a = 1.0 / (1 + z)
     obs11_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs11_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -221,7 +221,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_p, err_m = loadtxt(f"{path}/sfr_oesch2018.dat", unpack=True)
     obs12_a = 1.0 / (1 + z)
     obs12_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs12_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -239,7 +239,7 @@ def read_obs_data(path="observational_data"):
     )
     obs13_a = 1.0 / (1 + z)
     obs13_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs13_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -259,7 +259,7 @@ def read_obs_data(path="observational_data"):
     )
     obs14_a = 1.0 / (1 + z)
     obs14_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs14_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -294,7 +294,7 @@ def read_obs_data(path="observational_data"):
 
     output.append(
         ObservationalData(
-            eagle_data[:, 0], eagle_data[:, 2] / (25**3), None, "EAGLE-25 REF"
+            eagle_data[:, 0], eagle_data[:, 2] / (25 ** 3), None, "EAGLE-25 REF"
         )
     )
 

--- a/eagle-xl/scripts/max_temperatures.py
+++ b/eagle-xl/scripts/max_temperatures.py
@@ -43,7 +43,7 @@ def make_single_image(filenames, names, T_bounds, number_of_simulations, output_
             np.log10(T_max), range=np.log10(T_bounds), bins=250, density=True
         )
         bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
-        bins = 10**bins
+        bins = 10 ** bins
         ax.plot(bins, h, label=name)
 
     ax.legend()

--- a/eagle-xl/scripts/particle_updates_step_cost.py
+++ b/eagle-xl/scripts/particle_updates_step_cost.py
@@ -12,8 +12,8 @@ from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 
 # Set the limits of the figure.
-update_bounds = unyt.unyt_array([1, 10.0**10.0], units="dimensionless")
-wallclock_bounds = unyt.unyt_array([1, 10.0**6.0], units="ms")
+update_bounds = unyt.unyt_array([1, 10.0 ** 10.0], units="dimensionless")
+wallclock_bounds = unyt.unyt_array([1, 10.0 ** 6.0], units="ms")
 bins = 512
 
 

--- a/eagle-xl/scripts/star_formation_history.py
+++ b/eagle-xl/scripts/star_formation_history.py
@@ -14,7 +14,7 @@ from swiftsimio import load
 
 from load_sfh_data import read_obs_data
 
-sfr_output_units = unyt.msun / (unyt.year * unyt.Mpc**3)
+sfr_output_units = unyt.msun / (unyt.year * unyt.Mpc ** 3)
 
 from swiftpipeline.argumentparser import ScriptArgumentParser
 

--- a/eagle-xl/scripts/subgrid_density_temperature.py
+++ b/eagle-xl/scripts/subgrid_density_temperature.py
@@ -25,11 +25,11 @@ def get_data(filename):
     data = load(filename)
 
     try:
-        number_density = (data.gas.subgrid_physical_densities / mh).to(cm**-3)
+        number_density = (data.gas.subgrid_physical_densities / mh).to(cm ** -3)
         temperature = data.gas.subgrid_temperatures.to_physical().to("K")
     except:
         # No sub-grid quantities present. Still make the figure, but use non-subgrid.
-        number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+        number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
         temperature = data.gas.temperatures.to_physical().to("K")
 
     return number_density.value, temperature.value
@@ -69,11 +69,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/flamingo/scripts/birth_density_distribution.py
+++ b/flamingo/scripts/birth_density_distribution.py
@@ -32,7 +32,7 @@ data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
 number_of_bins = 256
 
 birth_density_bins = unyt.unyt_array(
-    np.logspace(-3, 5, number_of_bins), units=1 / cm**3
+    np.logspace(-3, 5, number_of_bins), units=1 / cm ** 3
 )
 log_birth_density_bin_width = np.log10(birth_density_bins[1].value) - np.log10(
     birth_density_bins[0].value
@@ -45,11 +45,7 @@ birth_density_centers = 0.5 * (birth_density_bins[1:] + birth_density_bins[:-1])
 fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
 axes = axes.flat
 
-ax_dict = {
-    "$z < 1$": axes[0],
-    "$1 < z < 3$": axes[1],
-    "$z > 3$": axes[2],
-}
+ax_dict = {"$z < 1$": axes[0], "$1 < z < 3$": axes[1], "$z > 3$": axes[2]}
 
 for label, ax in ax_dict.items():
     ax.loglog()

--- a/flamingo/scripts/birth_density_f_E.py
+++ b/flamingo/scripts/birth_density_f_E.py
@@ -28,11 +28,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -58,10 +54,10 @@ def bin_individual_data(data: SWIFTDataset):
     mask = f_E_fractions > 0.0
 
     f_E_fractions = f_E_fractions[mask]
-    birth_densities = (data.stars.birth_densities[mask] / mh).to(1 / cm**3).value
+    birth_densities = (data.stars.birth_densities[mask] / mh).to(1 / cm ** 3).value
 
     birth_density_bins = unyt.unyt_array(
-        np.logspace(-3, 5, number_of_bins), units=1 / cm**3
+        np.logspace(-3, 5, number_of_bins), units=1 / cm ** 3
     )
     feedback_energy_fraction_bins = unyt.unyt_array(
         np.logspace(-2, 1, number_of_bins), units="dimensionless"

--- a/flamingo/scripts/birth_density_metallicity.py
+++ b/flamingo/scripts/birth_density_metallicity.py
@@ -16,7 +16,7 @@ from matplotlib.colors import LogNorm, Normalize
 number_of_bins = 128
 
 birth_density_bins = unyt.unyt_array(
-    np.logspace(-3, 5, number_of_bins), units=1 / cm**3
+    np.logspace(-3, 5, number_of_bins), units=1 / cm ** 3
 )
 metal_mass_fraction_bins = unyt.unyt_array(
     np.logspace(-6, 0, number_of_bins), units="dimensionless"
@@ -35,11 +35,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax
@@ -135,7 +131,7 @@ if __name__ == "__main__":
             metal_mass_fractions = snapshot.stars.metal_mass_fractions.value
 
         H, _, _ = np.histogram2d(
-            (snapshot.stars.birth_densities / mh).to(1 / cm**3).value,
+            (snapshot.stars.birth_densities / mh).to(1 / cm ** 3).value,
             metal_mass_fractions,
             bins=[birth_density_bins.value, metal_mass_fraction_bins.value],
         )

--- a/flamingo/scripts/deadtime_evolution.py
+++ b/flamingo/scripts/deadtime_evolution.py
@@ -50,11 +50,7 @@ for color_index, (run_name, run_directory) in enumerate(
             loose=False,
             invalid_raise=True,
             usecols=(2, 12, 14),
-            dtype=[
-                ("a", "f4"),
-                ("wallclock", "f4"),
-                ("deadtime", "f4"),
-            ],
+            dtype=[("a", "f4"), ("wallclock", "f4"), ("deadtime", "f4")],
         )
     except (FileNotFoundError, ValueError):
         ax.plot([], [], "-", color=color, label=f"{run_name} - no deadtime data")

--- a/flamingo/scripts/density_internal_energy.py
+++ b/flamingo/scripts/density_internal_energy.py
@@ -24,8 +24,8 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
-    internal_energy = (data.gas.internal_energies.to_physical()).to(km**2 / s**2)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
+    internal_energy = (data.gas.internal_energies.to_physical()).to(km ** 2 / s ** 2)
 
     return number_density.value, internal_energy.value
 
@@ -63,11 +63,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/flamingo/scripts/density_pressure.py
+++ b/flamingo/scripts/density_pressure.py
@@ -24,8 +24,8 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
-    pressure = (data.gas.pressures.to_physical() / kb).to(K * cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
+    pressure = (data.gas.pressures.to_physical() / kb).to(K * cm ** -3)
 
     return number_density.value, pressure.value
 
@@ -64,11 +64,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/flamingo/scripts/density_temperature.py
+++ b/flamingo/scripts/density_temperature.py
@@ -24,7 +24,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
     temperature = data.gas.temperatures.to_physical().to("K")
 
     return number_density.value, temperature.value
@@ -64,11 +64,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/flamingo/scripts/density_temperature_metals.py
+++ b/flamingo/scripts/density_temperature_metals.py
@@ -26,7 +26,7 @@ def get_data(filename):
 
     data = load(filename)
 
-    number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+    number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
     temperature = data.gas.temperatures.to_physical().to("K")
 
     metallicity = data.gas.metal_mass_fractions
@@ -77,11 +77,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/flamingo/scripts/gas_smoothing_lengths.py
+++ b/flamingo/scripts/gas_smoothing_lengths.py
@@ -85,7 +85,7 @@ def make_single_image(filenames, names, h_bounds, number_of_simulations, output_
         )
 
         bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
-        bins = 10**bins
+        bins = 10 ** bins
 
         (line,) = ax.plot(bins, h, label=name)
 

--- a/flamingo/scripts/load_sfh_data.py
+++ b/flamingo/scripts/load_sfh_data.py
@@ -41,8 +41,8 @@ def read_obs_data(path="observational_data"):
     )
     lgrho = lgrho + log10(0.6) + hcorr
     obs1_a = 1.0 / (1.0 + z)
-    obs1_rho = 10**lgrho
-    obs1_rho_err = array([obs1_rho - 10**lgrho_down, 10**lgrho_up - obs1_rho])
+    obs1_rho = 10 ** lgrho
+    obs1_rho_err = array([obs1_rho - 10 ** lgrho_down, 10 ** lgrho_up - obs1_rho])
 
     # output.append(
     #    ObservationalData(
@@ -106,7 +106,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_cucciati2011.dat", unpack=True)
     rhostar = rhostar - 2.0 * log10(0.7) + 2.0 * log10(0.6777)
     obs5_a = 1.0 / (1 + z)
-    obs5_rho = 10**rhostar / 1.65
+    obs5_rho = 10 ** rhostar / 1.65
     obs5_rho_err = 10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65
     obs5_rho_err[0] = -obs5_rho_err[0] + obs5_rho
     obs5_rho_err[1] = -obs5_rho + obs5_rho_err[1]
@@ -121,7 +121,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_magnelli2013.dat", unpack=True)
     obs6_a = 1.0 / (1 + z)
     obs6_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs6_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -137,7 +137,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_gruppioni2013.dat", unpack=True)
     obs7_a = 1.0 / (1 + z)
     obs7_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs7_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -167,7 +167,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_schenker2013.dat", unpack=True)
     obs9_a = 1.0 / (1 + z)
     obs9_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs9_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -183,7 +183,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_p, err_m = loadtxt(f"{path}/sfr_bouwens2015_dust.dat", unpack=True)
     obs10_a = 1.0 / (1 + z)
     obs10_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs10_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -203,7 +203,7 @@ def read_obs_data(path="observational_data"):
     )
     obs11_a = 1.0 / (1 + z)
     obs11_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs11_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -221,7 +221,7 @@ def read_obs_data(path="observational_data"):
     z, rhostar, err_p, err_m = loadtxt(f"{path}/sfr_oesch2018.dat", unpack=True)
     obs12_a = 1.0 / (1 + z)
     obs12_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs12_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -239,7 +239,7 @@ def read_obs_data(path="observational_data"):
     )
     obs13_a = 1.0 / (1 + z)
     obs13_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs13_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -259,7 +259,7 @@ def read_obs_data(path="observational_data"):
     )
     obs14_a = 1.0 / (1 + z)
     obs14_rho = (
-        10**rhostar / 1.65 * 0.6777 / 0.7
+        10 ** rhostar / 1.65 * 0.6777 / 0.7
     )  # convert to Chabrier IMF from Salpeter
     obs14_rho_err = (
         10 ** array([rhostar + (err_m), rhostar + err_p]) / 1.65 * 0.6777 / 0.7
@@ -294,7 +294,7 @@ def read_obs_data(path="observational_data"):
 
     output.append(
         ObservationalData(
-            eagle_data[:, 0], eagle_data[:, 2] / (25**3), None, "EAGLE-25 REF"
+            eagle_data[:, 0], eagle_data[:, 2] / (25 ** 3), None, "EAGLE-25 REF"
         )
     )
 

--- a/flamingo/scripts/max_temperatures.py
+++ b/flamingo/scripts/max_temperatures.py
@@ -43,7 +43,7 @@ def make_single_image(filenames, names, T_bounds, number_of_simulations, output_
             np.log10(T_max), range=np.log10(T_bounds), bins=250, density=True
         )
         bins = 0.5 * (bin_edges[1:] + bin_edges[:-1])
-        bins = 10**bins
+        bins = 10 ** bins
         ax.plot(bins, h, label=name)
 
     ax.legend()

--- a/flamingo/scripts/particle_updates_step_cost.py
+++ b/flamingo/scripts/particle_updates_step_cost.py
@@ -12,8 +12,8 @@ from swiftpipeline.argumentparser import ScriptArgumentParser
 from glob import glob
 
 # Set the limits of the figure.
-update_bounds = unyt.unyt_array([1, 10.0**10.0], units="dimensionless")
-wallclock_bounds = unyt.unyt_array([1, 10.0**6.0], units="ms")
+update_bounds = unyt.unyt_array([1, 10.0 ** 10.0], units="dimensionless")
+wallclock_bounds = unyt.unyt_array([1, 10.0 ** 6.0], units="ms")
 bins = 512
 
 

--- a/flamingo/scripts/star_formation_history.py
+++ b/flamingo/scripts/star_formation_history.py
@@ -18,7 +18,7 @@ from load_sfh_data import read_obs_data
 from astropy.cosmology import z_at_value
 from astropy.units import Gyr
 
-sfr_output_units = unyt.msun / (unyt.year * unyt.Mpc**3)
+sfr_output_units = unyt.msun / (unyt.year * unyt.Mpc ** 3)
 
 from swiftpipeline.argumentparser import ScriptArgumentParser
 

--- a/flamingo/scripts/subgrid_density_temperature.py
+++ b/flamingo/scripts/subgrid_density_temperature.py
@@ -25,11 +25,11 @@ def get_data(filename):
     data = load(filename)
 
     try:
-        number_density = (data.gas.subgrid_physical_densities / mh).to(cm**-3)
+        number_density = (data.gas.subgrid_physical_densities / mh).to(cm ** -3)
         temperature = data.gas.subgrid_temperatures.to_physical().to("K")
     except:
         # No sub-grid quantities present. Still make the figure, but use non-subgrid.
-        number_density = (data.gas.densities.to_physical() / mh).to(cm**-3)
+        number_density = (data.gas.densities.to_physical() / mh).to(cm ** -3)
         temperature = data.gas.temperatures.to_physical().to("K")
 
     return number_density.value, temperature.value
@@ -69,11 +69,7 @@ def setup_axes(number_of_simulations: int):
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
     fig, ax = plt.subplots(
-        vertical_number,
-        horizontal_number,
-        squeeze=True,
-        sharex=True,
-        sharey=True,
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/format.sh
+++ b/format.sh
@@ -1,13 +1,79 @@
-#! /bin/bash
-# Formats all relevant source code files.
-# Accepts an extra input argument that is passed to black.
-# Useful for --check.
+#!/bin/bash
 
-extra_arg=${1}
+# Check if we can run pip
+# This also serves as a check for python3
+python3 -m pip --version > /dev/null
+if [[ $? -ne 0 ]]
+then
+  echo "ERROR: cannot run 'python3 -m pip'"
+  exit 1
+fi
 
-return_code=0
+# Check if the virtual environment with black exists
+if [ ! -d black_formatting_env ]
+then
+  echo "Formatting environment not found, installing it..."
+  python3 -m venv black_formatting_env
+  ./black_formatting_env/bin/python3 -m pip install click==8.0.4 black==19.3b0
+fi
+# Now we know exactly which black to use
+black="./black_formatting_env/bin/python3 -m black"
 
-# find all Python scripts but exclude those in the observational_data
-# submodule
-scripts=$(find . -name "*.py" -not -path "./observational_data/*")
-black $scripts $extra_arg
+# Formatting command
+cmd="$black -t py38 $(find . -name '*.py' -not -path './black_formatting_env/*' -not -path './observational_data/*')"
+
+# Print the help
+function show_help {
+    echo -e "This script formats all Python scripts using black"
+    echo -e "  -h, --help \t Show this help"
+    echo -e "  -c, --check \t Test if the Python scripts are well formatted"
+}
+
+# Parse arguments
+TEST=0
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+	# print the help and exit
+	-h|--help)
+	    show_help
+	    exit
+	    ;;
+	# check if the code is well formatted
+	-c|--check)
+	    TEST=1
+	    shift
+	    ;;
+	# unknown option
+	*)
+	    echo "Argument '$1' not implemented"
+	    show_help
+	    exit
+	    ;;
+    esac
+done
+
+# Run the required commands
+if [[ $TEST -eq 1 ]]
+then
+    # Note trapping the exit status from both commands in the pipe. Also note
+    # do not use -q in grep as that closes the pipe on first match and we get
+    # a SIGPIPE error.
+    echo "Testing if Python scripts are correctly formatted"
+    $cmd --check
+    status=$?
+
+    # Check formatting
+    if [[ ! ${status} -eq 0 ]]
+    then
+        echo "ERROR: needs formatting"
+        exit 1
+    else
+        echo "Everything is correctly formatted"
+    fi
+else
+    echo "Formatting all Python scripts"
+    $cmd
+fi


### PR DESCRIPTION
The current version of `black` on the CI runners seems to be incompatible with the current version of `click` (see https://github.com/psf/black/issues/2964). To fix this, I have pinned the `black` and `click` versions. I have now also set up a virtual environment for the formatting script (as is done in the SWIFT repository) to ensure consistent formatting.

The 'new' version of `black` has caused some reformatting in a lot of the scripts.