### PR TITLE
Added additional CDDF plot that only uses half of the box.

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -286,8 +286,17 @@ scripts:
     section: Stellar Metallicity
     title: 'Fraction of Fe from SNIa vs [O/H]'
   - filename: scripts/column_density_distribution_function.py
+    title: Column Density Distribution Function (full box)
     caption: 'The column density distribution function of neutral hydrogen computed by projecting the entire box along the z-axis, corrected for the size of the box in redshift space.'
-    output_file: column_density_distribution_function.png
+    output_file: column_density_distribution_function_chunk1.png
     section: Column Densities
     additional_arguments:
       parallel: True
+  - filename: scripts/column_density_distribution_function.py
+    title: Column Density Distribution Function (half box)
+    caption: 'The column density distribution function of neutral hydrogen computed by projecting half the box along the z-axis, corrected for the size of the box in redshift space.'
+    output_file: column_density_distribution_function_chunk2.png
+    section: Column Densities
+    additional_arguments:
+      parallel: True
+      box_chunks: 2


### PR DESCRIPTION
The idea behind this is that low and intermediate column densities will be affected by a change in the integration depth. High column densities are usually completely dominated by a very small region and are less sensitive to this. As a result, comparing different box sizes makes little sense for lower column densities. Having a second plot where the integration depth is only half the box size can help to estimate how much impact the integration depth has on the CDDF.