### PR TITLE
Added FLAMINGO HSE data to COLIBRE gas fraction plots.

### DIFF
--- a/colibre-zooms/auto_plotter/baryon_fractions.yml
+++ b/colibre-zooms/auto_plotter/baryon_fractions.yml
@@ -68,6 +68,7 @@ gas_fraction_500:
     - filename: HaloMassGasFractions/Vikhlinin2006.hdf5
     - filename: HaloMassGasFractions/Eckert2016.hdf5
     - filename: HaloMassGasFractions/Lovisari2015.hdf5
+    - filename: HaloMassGasFractions/HSE-FLAMINGO.hdf5
 
 star_fraction_500:
   type: "2dhistogram"

--- a/colibre/auto_plotter/baryon_fractions.yml
+++ b/colibre/auto_plotter/baryon_fractions.yml
@@ -68,6 +68,7 @@ gas_fraction_500:
     - filename: HaloMassGasFractions/Vikhlinin2006.hdf5
     - filename: HaloMassGasFractions/Eckert2016.hdf5
     - filename: HaloMassGasFractions/Lovisari2015.hdf5
+    - filename: HaloMassGasFractions/HSE-FLAMINGO.hdf5
 
 star_fraction_500:
   type: "2dhistogram"


### PR DESCRIPTION
The FLAMINGO data were corrected for hydrostatic bias using the FLAMINGO correction factor. They include some of the other datasets and will be useful when comparing different jet models in the future.