### PR TITLE
Add the z=0 mass-size data from Crain+15 to the COLIBRE plotting pipeline

### DIFF
--- a/colibre-zooms/auto_plotter/galaxy_sizes.yml
+++ b/colibre-zooms/auto_plotter/galaxy_sizes.yml
@@ -29,7 +29,8 @@ stellar_mass_galaxy_size_50:
   observational_data:
     - filename: GalaxyStellarMassGalaxySize/Trujillo2020.hdf5
     - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p1.hdf5
-
+    - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p0.hdf5
+      
 stellar_mass_galaxy_size_30:
   type: "scatter"
   legend_loc: "upper left"
@@ -62,6 +63,7 @@ stellar_mass_galaxy_size_30:
   observational_data:
     - filename: GalaxyStellarMassGalaxySize/Trujillo2020.hdf5
     - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p1.hdf5
+    - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p0.hdf5
 
 stellar_mass_projected_galaxy_size_50:
   type: "scatter"

--- a/colibre/auto_plotter/galaxy_sizes.yml
+++ b/colibre/auto_plotter/galaxy_sizes.yml
@@ -29,6 +29,7 @@ stellar_mass_galaxy_size_50:
   observational_data:
     - filename: GalaxyStellarMassGalaxySize/Trujillo2020.hdf5
     - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p1.hdf5
+    - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p0.hdf5
 
 stellar_mass_galaxy_size_30:
   type: "scatter"
@@ -62,6 +63,7 @@ stellar_mass_galaxy_size_30:
   observational_data:
     - filename: GalaxyStellarMassGalaxySize/Trujillo2020.hdf5
     - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p1.hdf5
+    - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p0.hdf5
 
 stellar_mass_projected_galaxy_size_50:
   type: "scatter"

--- a/eagle-xl/auto_plotter/galaxy_sizes.yml
+++ b/eagle-xl/auto_plotter/galaxy_sizes.yml
@@ -29,6 +29,7 @@ stellar_mass_galaxy_size_100:
   observational_data:
     - filename: GalaxyStellarMassGalaxySize/Trujillo2020.hdf5
     - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p1.hdf5
+    - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p0.hdf5
 
 stellar_mass_galaxy_size_30:
   type: "scatter"
@@ -62,7 +63,8 @@ stellar_mass_galaxy_size_30:
   observational_data:
     - filename: GalaxyStellarMassGalaxySize/Trujillo2020.hdf5
     - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p1.hdf5
-
+    - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p0.hdf5
+      
 stellar_mass_projected_galaxy_size_100:
   type: "scatter"
   legend_loc: "upper left"

--- a/flamingo/auto_plotter/galaxy_sizes.yml
+++ b/flamingo/auto_plotter/galaxy_sizes.yml
@@ -28,6 +28,7 @@ stellar_mass_galaxy_size_100:
   observational_data:
     - filename: GalaxyStellarMassGalaxySize/Trujillo2020.hdf5
     - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p1.hdf5
+    - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p0.hdf5
 
 stellar_mass_galaxy_size_30:
   type: "2dhistogram"
@@ -60,6 +61,7 @@ stellar_mass_galaxy_size_30:
   observational_data:
     - filename: GalaxyStellarMassGalaxySize/Trujillo2020.hdf5
     - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p1.hdf5
+    - filename: GalaxyStellarMassGalaxySize/Crain2015_REF25_z0p0.hdf5
 
 stellar_mass_projected_galaxy_size_100:
   type: "2dhistogram"


### PR DESCRIPTION
Companion to https://github.com/SWIFTSIM/velociraptor-comparison-data/pull/117.