### PR TITLE
Extend x-axis range in baryon fraction plots

### DIFF
--- a/colibre-zooms/auto_plotter/baryon_fractions.yml
+++ b/colibre-zooms/auto_plotter/baryon_fractions.yml
@@ -6,7 +6,7 @@ baryon_fraction_500:
   x:
     quantity: "spherical_overdensities.mass_500_rhocrit"
     units: Solar_Mass
-    start: 1e12
+    start: 1e10
     end: 1e15
   y:
     quantity: "derived_quantities.baryon_fraction_true_R500"
@@ -18,9 +18,9 @@ baryon_fraction_500:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 15
+    number_of_bins: 25
     start:
-      value: 1e12
+      value: 1e10
       units: Solar_Mass
     end:
       value: 1e15
@@ -30,7 +30,7 @@ baryon_fraction_500:
     caption: Baryon (gas + stars) fractions within $R_{500}$ normalised by the cosmic mean. These are 'true' values, i.e. no cut or observational correction was applied.
     section: Baryon Fractions
 
-gas_fraction_500:
+gas_fraction_500_no_bias:
   type: "2dhistogram"
   select_structure_type: 10
   comment: "Centrals only"
@@ -38,7 +38,7 @@ gas_fraction_500:
   x:
     quantity: "spherical_overdensities.mass_500_rhocrit"
     units: Solar_Mass
-    start: 1e12
+    start: 1e10
     end: 1e15
   y:
     quantity: "derived_quantities.gas_fraction_true_R500"
@@ -51,16 +51,16 @@ gas_fraction_500:
     log: true
     min_num_points_highlight: 0
     adaptive: true
-    number_of_bins: 15
+    number_of_bins: 25
     start:
-      value: 1e12
+      value: 1e10
       units: Solar_Mass
     end:
       value: 1e15
       units: Solar_Mass
   metadata:
-    title: "Halo gas fractions within $R_{500}$"
-    caption: Gas fractions within $R_{500}$ normalised by the cosmic mean. These are 'true' values, i.e. no cut or observational correction was applied.
+    title: "Halo gas fractions within $R_{500}$ (no hydrostatic bias)"
+    caption: Gas fractions within $R_{500}$ normalised by the cosmic mean. These are 'true' values, i.e. no cut or observational correction was applied. The observational data does not include any correction for hydrostatic bias.
     section: Baryon Fractions
   observational_data:
     - filename: HaloMassGasFractions/Lin2012.hdf5
@@ -68,6 +68,40 @@ gas_fraction_500:
     - filename: HaloMassGasFractions/Vikhlinin2006.hdf5
     - filename: HaloMassGasFractions/Eckert2016.hdf5
     - filename: HaloMassGasFractions/Lovisari2015.hdf5
+
+gas_fraction_500_with_bias:
+  type: "2dhistogram"
+  select_structure_type: 10
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "spherical_overdensities.mass_500_rhocrit"
+    units: Solar_Mass
+    start: 1e10
+    end: 1e15
+  y:
+    quantity: "derived_quantities.gas_fraction_true_R500"
+    units:  "dimensionless"
+    log: false
+    start: 0.
+    end: 1.2
+  median:
+    plot: true
+    log: true
+    min_num_points_highlight: 0
+    adaptive: true
+    number_of_bins: 25
+    start:
+      value: 1e10
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: "Halo gas fractions within $R_{500}$ (with hydrostatic bias)"
+    caption: Gas fractions within $R_{500}$ normalised by the cosmic mean. These are 'true' values, i.e. no cut or observational correction was applied. The observational data was compiled from 10+ HSE data sets (Kugel et al., in prep.), and includes the -0.75 dex hydrostatic bias correction factor used for FLAMINGO.
+    section: Baryon Fractions
+  observational_data:
     - filename: HaloMassGasFractions/HSE-FLAMINGO.hdf5
 
 star_fraction_500:
@@ -78,7 +112,7 @@ star_fraction_500:
   x:
     quantity: "spherical_overdensities.mass_500_rhocrit"
     units: Solar_Mass
-    start: 1e12
+    start: 1e10
     end: 1e15
   y:
     quantity: "derived_quantities.star_fraction_true_R500"
@@ -90,7 +124,7 @@ star_fraction_500:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 15
+    number_of_bins: 25
     start:
       value: 1e13
       units: Solar_Mass
@@ -111,7 +145,7 @@ gas_mass_500:
   x:
     quantity: "spherical_overdensities.mass_500_rhocrit"
     units: Solar_Mass
-    start: 1e13
+    start: 1e10
     end: 1e15
   y:
     quantity: "spherical_overdensities.mass_gas_500_rhocrit"
@@ -122,9 +156,9 @@ gas_mass_500:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 15
+    number_of_bins: 25
     start:
-      value: 1e12
+      value: 1e10
       units: Solar_Mass
     end:
       value: 1e15

--- a/colibre/auto_plotter/baryon_fractions.yml
+++ b/colibre/auto_plotter/baryon_fractions.yml
@@ -6,7 +6,7 @@ baryon_fraction_500:
   x:
     quantity: "spherical_overdensities.mass_500_rhocrit"
     units: Solar_Mass
-    start: 1e12
+    start: 1e10
     end: 1e15
   y:
     quantity: "derived_quantities.baryon_fraction_true_R500"
@@ -18,9 +18,9 @@ baryon_fraction_500:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 15
+    number_of_bins: 25
     start:
-      value: 1e12
+      value: 1e10
       units: Solar_Mass
     end:
       value: 1e15
@@ -38,7 +38,7 @@ gas_fraction_500_no_bias:
   x:
     quantity: "spherical_overdensities.mass_500_rhocrit"
     units: Solar_Mass
-    start: 1e12
+    start: 1e10
     end: 1e15
   y:
     quantity: "derived_quantities.gas_fraction_true_R500"
@@ -51,9 +51,9 @@ gas_fraction_500_no_bias:
     log: true
     min_num_points_highlight: 0
     adaptive: true
-    number_of_bins: 15
+    number_of_bins: 25
     start:
-      value: 1e12
+      value: 1e10
       units: Solar_Mass
     end:
       value: 1e15
@@ -77,7 +77,7 @@ gas_fraction_500_with_bias:
   x:
     quantity: "spherical_overdensities.mass_500_rhocrit"
     units: Solar_Mass
-    start: 1e12
+    start: 1e10
     end: 1e15
   y:
     quantity: "derived_quantities.gas_fraction_true_R500"
@@ -90,9 +90,9 @@ gas_fraction_500_with_bias:
     log: true
     min_num_points_highlight: 0
     adaptive: true
-    number_of_bins: 15
+    number_of_bins: 25
     start:
-      value: 1e12
+      value: 1e10
       units: Solar_Mass
     end:
       value: 1e15
@@ -112,7 +112,7 @@ star_fraction_500:
   x:
     quantity: "spherical_overdensities.mass_500_rhocrit"
     units: Solar_Mass
-    start: 1e12
+    start: 1e10
     end: 1e15
   y:
     quantity: "derived_quantities.star_fraction_true_R500"
@@ -124,7 +124,7 @@ star_fraction_500:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 15
+    number_of_bins: 25
     start:
       value: 1e13
       units: Solar_Mass
@@ -145,7 +145,7 @@ gas_mass_500:
   x:
     quantity: "spherical_overdensities.mass_500_rhocrit"
     units: Solar_Mass
-    start: 1e13
+    start: 1e10
     end: 1e15
   y:
     quantity: "spherical_overdensities.mass_gas_500_rhocrit"
@@ -156,9 +156,9 @@ gas_mass_500:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 15
+    number_of_bins: 25
     start:
-      value: 1e12
+      value: 1e10
       units: Solar_Mass
     end:
       value: 1e15


### PR DESCRIPTION
This PR extends x-axis range in baryon fraction plots.

Also, it updates the baryon fraction .yml file in `/colibre-zoom/autoplotter` so that it has the same version as in `/colibre/autoplotter`