### PR TITLE
Fix dust double count

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -9,7 +9,7 @@ auto_plotter_registration: registration.py
 
 # Location of the 'observational data' repository and its compiled
 # contents.
-observational_data_directory: ../observational_data
+observational_data_directory: ../../observational_data
 
 # Style sheet to be used throughout with plotting
 matplotlib_stylesheet: mnras.mplstyle

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -9,7 +9,7 @@ auto_plotter_registration: registration.py
 
 # Location of the 'observational data' repository and its compiled
 # contents.
-observational_data_directory: ../../observational_data
+observational_data_directory: ../observational_data
 
 # Style sheet to be used throughout with plotting
 matplotlib_stylesheet: mnras.mplstyle

--- a/colibre/scripts/density_species_depletions.py
+++ b/colibre/scripts/density_species_depletions.py
@@ -162,8 +162,6 @@ def get_data(filename, prefix_rho, prefix_T):
         elfrac_dict[el] = getattr(data.gas.element_mass_fractions, el.lower()).astype(
             "float64"
         )
-        # if pairing and (el in dsfrac_dict):
-        #     elfrac_dict[el] += dsfrac_dict[el]
 
     # casting to float64 to avoid arcane np.histogram bug(?)
     out_tuple = (

--- a/colibre/scripts/density_species_depletions.py
+++ b/colibre/scripts/density_species_depletions.py
@@ -162,8 +162,8 @@ def get_data(filename, prefix_rho, prefix_T):
         elfrac_dict[el] = getattr(data.gas.element_mass_fractions, el.lower()).astype(
             "float64"
         )
-        if pairing and (el in dsfrac_dict):
-            elfrac_dict[el] += dsfrac_dict[el]
+        # if pairing and (el in dsfrac_dict):
+        #     elfrac_dict[el] += dsfrac_dict[el]
 
     # casting to float64 to avoid arcane np.histogram bug(?)
     out_tuple = (

--- a/colibre/scripts/density_species_diffuse.py
+++ b/colibre/scripts/density_species_diffuse.py
@@ -163,8 +163,8 @@ def get_data(filename, prefix_rho, prefix_T):
         elfrac_dict[el] = getattr(data.gas.element_mass_fractions, el.lower()).astype(
             "float64"
         )
-        if pairing and (el in dsfrac_dict):
-            elfrac_dict[el] += dsfrac_dict[el]
+        # if pairing and (el in dsfrac_dict):
+        #     elfrac_dict[el] += dsfrac_dict[el]
 
     # casting to float64 to avoid arcane np.histogram bug(?)
     out_tuple = (

--- a/colibre/scripts/density_species_diffuse.py
+++ b/colibre/scripts/density_species_diffuse.py
@@ -163,8 +163,6 @@ def get_data(filename, prefix_rho, prefix_T):
         elfrac_dict[el] = getattr(data.gas.element_mass_fractions, el.lower()).astype(
             "float64"
         )
-        # if pairing and (el in dsfrac_dict):
-        #     elfrac_dict[el] += dsfrac_dict[el]
 
     # casting to float64 to avoid arcane np.histogram bug(?)
     out_tuple = (


### PR DESCRIPTION
In the density-species scripts, avoid double correction for dust in paired mode as this is now done at the pre-processing phase.