### PR TITLE
Added stellar birth pressure distribution plot.

### DIFF
--- a/colibre/auto_plotter/stellar_birth_densities.yml
+++ b/colibre/auto_plotter/stellar_birth_densities.yml
@@ -25,7 +25,7 @@ stellar_birth_density_halo_mass_average_of_log_all:
   metadata:
     title: Average of log Stellar Birth Density-Halo Mass relation
     caption: Includes all haloes, including subhaloes.
-    section: Stellar Birth Densities
+    section: Stellar Birth Properties
     show_on_webpage: false
 
 stellar_birth_density_halo_mass_max_all:
@@ -55,7 +55,7 @@ stellar_birth_density_halo_mass_max_all:
   metadata:
     title: Maximal Stellar Birth Density-Halo Mass relation
     caption: Includes all haloes, including subhaloes.
-    section: Stellar Birth Densities
+    section: Stellar Birth Properties
     show_on_webpage: false
 
 stellar_birth_density_stellar_mass_average_of_log_all_50:
@@ -85,7 +85,7 @@ stellar_birth_density_stellar_mass_average_of_log_all_50:
   metadata:
     title: Average of log Stellar Birth Density-Stellar Mass relation
     caption: Includes all haloes, including subhaloes.
-    section: Stellar Birth Densities
+    section: Stellar Birth Properties
 
 stellar_birth_density_stellar_mass_max_all_50:
   type: "scatter"
@@ -114,4 +114,4 @@ stellar_birth_density_stellar_mass_max_all_50:
   metadata:
     title: Maximal Stellar Birth Density-Stellar Mass relation
     caption: Includes all haloes, including subhaloes.
-    section: Stellar Birth Densities
+    section: Stellar Birth Properties

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -92,6 +92,11 @@ scripts:
     title: Stellar Birth Densities
     section: Stellar Birth Densities
     output_file: birth_density_distribution.png
+  - filename: scripts/birth_pressure_distribution.py
+    caption: Distributions of stellar birth pressures, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median stellar birth-pressures.
+    title: Stellar Birth Pressures
+    section: Stellar Birth Densities
+    output_file: birth_pressure_distribution.png
   - filename: scripts/birth_density_metallicity.py
     caption: Stellar birth densities vs metallicity diagram. The pixel colour indicates the number of stellar particles in the pixel. At a given birth density, particles with metallicities lower than the smallest value along the Y axis are placed in the lowest-metallicity bin.
     title: Stellar Birth Densities-Metallicity

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -90,27 +90,27 @@ scripts:
   - filename: scripts/birth_density_distribution.py
     caption: Distributions of stellar birth densities, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median stellar birth-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for SN min and max heating temperatures with $f_t=10$.
     title: Stellar Birth Densities
-    section: Stellar Birth Densities
+    section: Stellar Birth Properties
     output_file: birth_density_distribution.png
   - filename: scripts/birth_pressure_distribution.py
     caption: Distributions of stellar birth pressures, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median stellar birth-pressures.
     title: Stellar Birth Pressures
-    section: Stellar Birth Densities
+    section: Stellar Birth Properties
     output_file: birth_pressure_distribution.png
   - filename: scripts/birth_density_metallicity.py
     caption: Stellar birth densities vs metallicity diagram. The pixel colour indicates the number of stellar particles in the pixel. At a given birth density, particles with metallicities lower than the smallest value along the Y axis are placed in the lowest-metallicity bin.
     title: Stellar Birth Densities-Metallicity
-    section: Stellar Birth Densities
+    section: Stellar Birth Properties
     output_file: birth_density_metallicity.png
   - filename: scripts/birth_density_redshift.py
     caption: Stellar birth densities vs birth redshift diagram. The pixel colour indicates the number of stellar particles in the pixel.
     title: Stellar Birth Densities-Birth Redshift
-    section: Stellar Birth Densities
+    section: Stellar Birth Properties
     output_file: birth_density_redshift.png
   - filename: scripts/birth_metallicity_redshift.py
     caption: Stellar metallicity vs birth redshift diagram. The pixel colour indicates the number of stellar particles in the pixel. At a given birth redshift, particles with metallicities lower than the smallest value along the X axis are placed in the lowest-metallicity bin.
     title: Stellar Metallicity-Birth Redshift
-    section: Stellar Birth Densities
+    section: Stellar Birth Properties
     output_file: metallicity_redshift.png
   - filename: scripts/last_SNII_density_distribution.py
     caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles. The dashed vertical lines show the median SNII gas-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for SN min and max heating temperatures with $f_t=10$.

--- a/colibre/scripts/birth_pressure_distribution.py
+++ b/colibre/scripts/birth_pressure_distribution.py
@@ -31,7 +31,7 @@ data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
 number_of_bins = 256
 
 birth_pressure_bins = unyt.unyt_array(
-    np.logspace(1, 7, number_of_bins), units="K/cm**3"
+    np.logspace(1.0, 8.0, number_of_bins), units="K/cm**3"
 )
 log_birth_pressure_bin_width = np.log10(birth_pressure_bins[1].value) - np.log10(
     birth_pressure_bins[0].value

--- a/colibre/scripts/birth_pressure_distribution.py
+++ b/colibre/scripts/birth_pressure_distribution.py
@@ -1,0 +1,92 @@
+"""
+Plots the birth pressure distribution.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import unyt
+import traceback
+
+from unyt import mh
+
+from swiftsimio import load
+from swiftpipeline.argumentparser import ScriptArgumentParser
+
+
+arguments = ScriptArgumentParser(
+    description="Creates a stellar birth pressure distribution plot, split by redshift"
+)
+
+snapshot_filenames = [
+    f"{directory}/{snapshot}"
+    for directory, snapshot in zip(arguments.directory_list, arguments.snapshot_list)
+]
+
+names = arguments.name_list
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
+number_of_bins = 256
+
+birth_pressure_bins = unyt.unyt_array(
+    np.logspace(1, 7, number_of_bins), units="K/cm**3"
+)
+log_birth_pressure_bin_width = np.log10(birth_pressure_bins[1].value) - np.log10(
+    birth_pressure_bins[0].value
+)
+birth_pressure_centers = 0.5 * (birth_pressure_bins[1:] + birth_pressure_bins[:-1])
+
+
+# Begin plotting
+fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
+axes = axes.flat
+
+ax_dict = {"$z < 1$": axes[0], "$1 < z < 3$": axes[1], "$z > 3$": axes[2]}
+
+for label, ax in ax_dict.items():
+    ax.loglog()
+    ax.text(0.025, 1.0 - 0.025 * 3, label, transform=ax.transAxes, ha="left", va="top")
+
+for color, (snapshot, name) in enumerate(zip(data, names)):
+
+    birth_densities = snapshot.stars.birth_densities.to("g/cm**3") / mh.to("g")
+    birth_temperatures = snapshot.stars.birth_temperatures.to("K")
+    birth_pressures = (birth_densities * birth_temperatures).to("K/cm**3")
+    birth_redshifts = 1 / snapshot.stars.birth_scale_factors.value - 1
+
+    # Segment birth pressures into redshift bins
+    birth_pressure_by_redshift = {
+        "$z < 1$": birth_pressures[birth_redshifts < 1],
+        "$1 < z < 3$": birth_pressures[
+            np.logical_and(birth_redshifts > 1, birth_redshifts < 3)
+        ],
+        "$z > 3$": birth_pressures[birth_redshifts > 3],
+    }
+
+    # Total number of stars formed
+    Num_of_stars_total = len(birth_redshifts)
+
+    for redshift, ax in ax_dict.items():
+        data = birth_pressure_by_redshift[redshift]
+
+        H, _ = np.histogram(data, bins=birth_pressure_bins)
+        y_points = H / log_birth_pressure_bin_width / Num_of_stars_total
+
+        ax.plot(birth_pressure_centers, y_points, label=name, color=f"C{color}")
+
+        # Add the median stellar birth-pressure line
+        ax.axvline(
+            np.median(data),
+            color=f"C{color}",
+            linestyle="dashed",
+            zorder=-10,
+            alpha=0.5,
+        )
+
+axes[0].legend(loc="upper right", markerfirst=False)
+axes[2].set_xlabel("Stellar Birth Pressure $P_B/k$ [K cm$^{-3}$]")
+axes[1].set_ylabel("$N_{\\rm bin}$ / d$\\log(P_B/k)$ / $N_{\\rm total}$")
+
+fig.savefig(f"{arguments.output_directory}/birth_pressure_distribution.png")


### PR DESCRIPTION
This adds a new plotting script that creates a stellar birth pressure distribution plot, similar to the existing stellar birth density distribution plot. The stellar birth pressure is simply determined by multiplying the stellar birth number density with the stellar birth temperature.

Example plot:
![birth_pressure_distribution](https://user-images.githubusercontent.com/7336967/183613120-0f6e12f6-f552-40f9-b69e-d7dcf140a128.png)
