### PR TITLE
Add metallicity-dependent model's info to html page

### DIFF
--- a/colibre/description.html
+++ b/colibre/description.html
@@ -136,6 +136,23 @@
         <td>{{ data.metadata.parameters | get_if_present_float("COLIBREFeedback:SNII_energy_fraction_max") }}</td>
     </tr>
     <tr>
+        <td>\(n_{\rm Z}\)</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("COLIBREFeedback:SNII_energy_fraction_n_Z") }}</td>
+    </tr>
+    <tr>
+        <td>\(Z_{\rm E,pivot}\)</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("COLIBREFeedback:SNII_energy_fraction_Z_0") }}</td>
+    </tr>
+    <tr>
+        <td>\(n_{\rm n}\)</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("COLIBREFeedback:SNII_energy_fraction_n_n") }}</td>
+    </tr>
+    <tr>
+        <td>\(n_{\rm E,pivot}\)</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("COLIBREFeedback:SNII_energy_fraction_n_0_H_p_cm3") }}
+        cm\(^{-3}\) </td>
+    </tr>
+    <tr>
         <td>\(f_{\rm kinetic}\)</td>
         <td>{{ data.metadata.parameters | get_if_present_float("COLIBREFeedback:SNII_f_kinetic") }}</td>
     </tr>


### PR DESCRIPTION
The bottom four parameters in the figure below

![Screenshot from 2022-08-17 09-51-59](https://user-images.githubusercontent.com/20153933/185064766-28cb9985-a29d-40e3-9447-c95d53f1eb7b.png)

