### PR TITLE
Added stellar birth temperature plots

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -97,6 +97,11 @@ scripts:
     title: Stellar Birth Pressures
     section: Stellar Birth Properties
     output_file: birth_pressure_distribution.png
+  - filename: scripts/birth_temperature_distribution.py
+    caption: Distributions of stellar birth temperatures, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median stellar birth-temperatures.
+    title: Stellar Birth Temperatures
+    section: Stellar Birth Properties
+    output_file: birth_temperature_distribution.png
   - filename: scripts/birth_density_metallicity.py
     caption: Stellar birth densities vs metallicity diagram. The pixel colour indicates the number of stellar particles in the pixel. At a given birth density, particles with metallicities lower than the smallest value along the Y axis are placed in the lowest-metallicity bin.
     title: Stellar Birth Densities-Metallicity
@@ -112,6 +117,11 @@ scripts:
     title: Stellar Metallicity-Birth Redshift
     section: Stellar Birth Properties
     output_file: metallicity_redshift.png
+  - filename: scripts/birth_density_temperature.py
+    caption: Stellar birth densities vs Stellar birth temperature diagram. The pixel colour indicates the number of stellar particles in the pixel.
+    title: Stellar Birth Densities-Stellar Birth Temperatures
+    section: Stellar Birth Properties
+    output_file: birth_density_temperature.png
   - filename: scripts/last_SNII_density_distribution.py
     caption: Distributions of the gas densities recorded when the gas was last heated by SNII, split by redshift. The y axis shows the number of SNII-heated gas particles per bin divided by the bin width and by the total of SNII-heated gas particles. The dashed vertical lines show the median SNII gas-densities, while the dotted lines indicade the critical density from C. Dalla Vecchia & J. Schaye (2012) for SN min and max heating temperatures with $f_t=10$.
     title: Density of the gas heated by SNII

--- a/colibre/scripts/birth_density_temperature.py
+++ b/colibre/scripts/birth_density_temperature.py
@@ -1,5 +1,5 @@
 """
-Makes a stellar-birth-density vs. metallicity 2D plot. Uses the swiftsimio library.
+Makes a stellar-birth-density vs. temperature 2D plot. Uses the swiftsimio library.
 """
 
 import matplotlib.pyplot as plt
@@ -12,7 +12,7 @@ from matplotlib.colors import LogNorm
 
 # Set the limits of the figure.
 density_bounds = [0.01, 10 ** 7.0]  # in nh/cm^3
-temperature_bounds = [10.0, 2.0e4]  # in K
+temperature_bounds = [10.0, 10 ** 4.5]  # in K
 bins = 128
 
 

--- a/colibre/scripts/birth_density_temperature.py
+++ b/colibre/scripts/birth_density_temperature.py
@@ -109,7 +109,16 @@ def make_single_image(
 
     for hist, name, axis in zip(hists, names, ax.flat):
         mappable = axis.pcolormesh(d, T, hist, norm=LogNorm(vmin=1, vmax=vmax))
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
 
     fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Number of stellar particles")
 

--- a/colibre/scripts/birth_density_temperature.py
+++ b/colibre/scripts/birth_density_temperature.py
@@ -1,0 +1,145 @@
+"""
+Makes a stellar-birth-density vs. metallicity 2D plot. Uses the swiftsimio library.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+
+from unyt import mh
+from matplotlib.colors import LogNorm
+
+# Set the limits of the figure.
+density_bounds = [0.01, 10 ** 7.0]  # in nh/cm^3
+temperature_bounds = [10.0, 2.0e4]  # in K
+bins = 128
+
+
+def get_data(filename):
+    """
+    Grabs the data (stellar birth temperature in K and stellar birth density in mh / cm^3).
+    """
+
+    data = load(filename)
+
+    birth_densities = data.stars.birth_densities.to("g/cm**3") / mh.to("g")
+    birth_temperatures = data.stars.birth_temperatures.to("K")
+
+    return birth_densities.value, birth_temperatures.value
+
+
+def make_hist(filename, density_bounds, temperature_bounds, bins):
+    """
+    Makes the histogram for filename with bounds as lower, higher
+    for the bins and "bins" the number of bins along each dimension.
+
+    Also returns the edges for pcolormesh to use.
+    """
+
+    density_bins = np.logspace(
+        np.log10(density_bounds[0]), np.log10(density_bounds[1]), bins
+    )
+    temperature_bins = np.logspace(
+        np.log10(temperature_bounds[0]), np.log10(temperature_bounds[1]), bins
+    )
+
+    H, density_edges, temperature_edges = np.histogram2d(
+        *get_data(filename), bins=[density_bins, temperature_bins]
+    )
+
+    return H.T, density_edges, temperature_edges
+
+
+def setup_axes(number_of_simulations: int):
+    """
+    Creates the figure and axis object. Creates a grid of a x b subplots
+    that add up to at least number_of_simulations.
+    """
+
+    sqrt_number_of_simulations = np.sqrt(number_of_simulations)
+    horizontal_number = int(np.ceil(sqrt_number_of_simulations))
+    # Ensure >= number_of_simulations plots in a grid
+    vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
+
+    fig, ax = plt.subplots(
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+    )
+
+    ax = np.array([ax]) if number_of_simulations == 1 else ax
+
+    if horizontal_number * vertical_number > number_of_simulations:
+        for axis in ax.flat[number_of_simulations:]:
+            axis.axis("off")
+
+    # Set all valid on bottom row to have the horizontal axis label.
+    for axis in np.atleast_2d(ax)[:][-1]:
+        axis.set_xlabel("$\\rho_B$ [$n_H$ cm$^{-3}$]")
+
+    for axis in np.atleast_2d(ax).T[:][0]:
+        axis.set_ylabel("$T_B$ [K]")
+
+    ax.flat[0].loglog()
+
+    return fig, ax
+
+
+def make_single_image(
+    filenames,
+    names,
+    number_of_simulations,
+    density_bounds,
+    temperature_bounds,
+    bins,
+    output_path,
+):
+    """
+    Makes a single plot of rho_birth-T_birth
+    """
+
+    fig, ax = setup_axes(number_of_simulations=number_of_simulations)
+
+    hists = []
+
+    for filename in filenames:
+        hist, d, T = make_hist(filename, density_bounds, temperature_bounds, bins)
+        hists.append(hist)
+
+    vmax = np.max([np.max(hist) for hist in hists])
+
+    for hist, name, axis in zip(hists, names, ax.flat):
+        mappable = axis.pcolormesh(d, T, hist, norm=LogNorm(vmin=1, vmax=vmax))
+        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+
+    fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Number of stellar particles")
+
+    fig.savefig(f"{output_path}/birth_density_temperature.png")
+
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(
+        description="Stellar-birth-density vs. Stellar-birth-temperature plot."
+    )
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        number_of_simulations=arguments.number_of_inputs,
+        density_bounds=density_bounds,
+        temperature_bounds=temperature_bounds,
+        bins=bins,
+        output_path=arguments.output_directory,
+    )

--- a/colibre/scripts/birth_temperature_distribution.py
+++ b/colibre/scripts/birth_temperature_distribution.py
@@ -1,0 +1,92 @@
+"""
+Plots the birth pressure distribution.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import unyt
+import traceback
+
+from unyt import mh
+
+from swiftsimio import load
+from swiftpipeline.argumentparser import ScriptArgumentParser
+
+
+arguments = ScriptArgumentParser(
+    description="Creates a stellar birth temperature distribution plot, split by redshift"
+)
+
+snapshot_filenames = [
+    f"{directory}/{snapshot}"
+    for directory, snapshot in zip(arguments.directory_list, arguments.snapshot_list)
+]
+
+names = arguments.name_list
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
+number_of_bins = 256
+
+birth_temperature_bins = unyt.unyt_array(
+    np.logspace(1.0, 4.1, number_of_bins), units="K"
+)
+log_birth_temperature_bin_width = np.log10(birth_temperature_bins[1].value) - np.log10(
+    birth_temperature_bins[0].value
+)
+birth_temperature_centers = 0.5 * (
+    birth_temperature_bins[1:] + birth_temperature_bins[:-1]
+)
+
+
+# Begin plotting
+fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
+axes = axes.flat
+
+ax_dict = {"$z < 1$": axes[0], "$1 < z < 3$": axes[1], "$z > 3$": axes[2]}
+
+for label, ax in ax_dict.items():
+    ax.loglog()
+    ax.text(0.025, 1.0 - 0.025 * 3, label, transform=ax.transAxes, ha="left", va="top")
+
+for color, (snapshot, name) in enumerate(zip(data, names)):
+
+    birth_temperatures = snapshot.stars.birth_temperatures.to("K")
+    birth_redshifts = 1 / snapshot.stars.birth_scale_factors.value - 1
+
+    # Segment birth pressures into redshift bins
+    birth_temperature_by_redshift = {
+        "$z < 1$": birth_temperatures[birth_redshifts < 1],
+        "$1 < z < 3$": birth_temperatures[
+            np.logical_and(birth_redshifts > 1, birth_redshifts < 3)
+        ],
+        "$z > 3$": birth_temperatures[birth_redshifts > 3],
+    }
+
+    # Total number of stars formed
+    Num_of_stars_total = len(birth_redshifts)
+
+    for redshift, ax in ax_dict.items():
+        data = birth_temperature_by_redshift[redshift]
+
+        H, _ = np.histogram(data, bins=birth_temperature_bins)
+        y_points = H / log_birth_temperature_bin_width / Num_of_stars_total
+
+        ax.plot(birth_temperature_centers, y_points, label=name, color=f"C{color}")
+
+        # Add the median stellar birth-pressure line
+        ax.axvline(
+            np.median(data),
+            color=f"C{color}",
+            linestyle="dashed",
+            zorder=-10,
+            alpha=0.5,
+        )
+
+axes[0].legend(loc="upper right", markerfirst=False)
+axes[2].set_xlabel("Stellar Birth Temperature $T_B$ [K]")
+axes[1].set_ylabel("$N_{\\rm bin}$ / d$\\log(T_B)$ / $N_{\\rm total}$")
+
+fig.savefig(f"{arguments.output_directory}/birth_temperature_distribution.png")

--- a/colibre/scripts/birth_temperature_distribution.py
+++ b/colibre/scripts/birth_temperature_distribution.py
@@ -1,5 +1,5 @@
 """
-Plots the birth pressure distribution.
+Plots the birth temperature distribution.
 """
 
 import matplotlib.pyplot as plt
@@ -7,7 +7,6 @@ import numpy as np
 import unyt
 import traceback
 
-from unyt import mh
 
 from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
@@ -31,7 +30,7 @@ data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
 number_of_bins = 256
 
 birth_temperature_bins = unyt.unyt_array(
-    np.logspace(1.0, 4.1, number_of_bins), units="K"
+    np.logspace(1.0, 4.5, number_of_bins), units="K"
 )
 log_birth_temperature_bin_width = np.log10(birth_temperature_bins[1].value) - np.log10(
     birth_temperature_bins[0].value
@@ -56,7 +55,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
     birth_temperatures = snapshot.stars.birth_temperatures.to("K")
     birth_redshifts = 1 / snapshot.stars.birth_scale_factors.value - 1
 
-    # Segment birth pressures into redshift bins
+    # Segment birth temperatures into redshift bins
     birth_temperature_by_redshift = {
         "$z < 1$": birth_temperatures[birth_redshifts < 1],
         "$1 < z < 3$": birth_temperatures[
@@ -76,7 +75,7 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
 
         ax.plot(birth_temperature_centers, y_points, label=name, color=f"C{color}")
 
-        # Add the median stellar birth-pressure line
+        # Add the median stellar birth-temperature line
         ax.axvline(
             np.median(data),
             color=f"C{color}",


### PR DESCRIPTION
This PR adds two new plots to the Stellar Birth Properties section:
 - a stellar birth temperature distribution plot, similar to the stellar birth density and stellar birth pressure ones.
 - a stellar birth density-stellar birth temperature phase diagram.

Example of the new plots:
![birth_temperature_distribution](https://user-images.githubusercontent.com/7336967/185194180-fffd9979-6431-4adc-88ab-445a8d557c1e.png)
![birth_density_temperature](https://user-images.githubusercontent.com/7336967/185194196-c068f10c-1f92-42ff-8bd5-043cf95d01c9.png)
