### PR TITLE
Fixed layout issues in multi-panel comparison plots.

### DIFF
--- a/colibre/scripts/bh_masses.py
+++ b/colibre/scripts/bh_masses.py
@@ -101,7 +101,16 @@ def make_single_image(
         # Indicate gas mass resolution of the run
         axis.plot([m_gas, m_gas], [mass_bounds[0], mass_bounds[1]], "k--", lw=0.2)
         axis.scatter(m_dyn, m_sub, s=1)
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
 
     fig.savefig(f"{output_path}/bh_masses.png")
 

--- a/colibre/scripts/birth_density_metallicity.py
+++ b/colibre/scripts/birth_density_metallicity.py
@@ -123,7 +123,16 @@ def make_single_image(
 
     for hist, name, axis in zip(hists, names, ax.flat):
         mappable = axis.pcolormesh(d, Z, hist, norm=LogNorm(vmin=1, vmax=vmax))
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
 
     fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Number of stellar particles")
 

--- a/colibre/scripts/birth_density_redshift.py
+++ b/colibre/scripts/birth_density_redshift.py
@@ -108,7 +108,16 @@ def make_single_image(
 
     for hist, name, axis in zip(hists, names, ax.flat):
         mappable = axis.pcolormesh(d, z, hist, norm=LogNorm(vmin=1, vmax=vmax))
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
 
     fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Number of stellar particles")
 

--- a/colibre/scripts/birth_metallicity_redshift.py
+++ b/colibre/scripts/birth_metallicity_redshift.py
@@ -122,7 +122,16 @@ def make_single_image(
 
     for hist, name, axis in zip(hists, names, ax.flat):
         mappable = axis.pcolormesh(Z, z, hist, norm=LogNorm(vmin=1, vmax=vmax))
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
 
     fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Number of stellar particles")
 

--- a/colibre/scripts/density_internal_energy.py
+++ b/colibre/scripts/density_internal_energy.py
@@ -108,7 +108,16 @@ def make_single_image(
 
     for hist, name, axis in zip(hists, names, ax.flat):
         mappable = axis.pcolormesh(d, T, hist, norm=LogNorm(vmin=1, vmax=vmax))
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
 
     fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Number of particles")
 

--- a/colibre/scripts/density_pressure.py
+++ b/colibre/scripts/density_pressure.py
@@ -110,7 +110,16 @@ def make_single_image(
 
     for hist, name, axis in zip(hists, names, ax.flat):
         mappable = axis.pcolormesh(d, P, hist, norm=LogNorm(vmin=1, vmax=vmax))
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
 
     fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Number of particles")
 

--- a/colibre/scripts/density_species_depletions.py
+++ b/colibre/scripts/density_species_depletions.py
@@ -345,7 +345,16 @@ def make_single_image(
             lw=0.25,
             zorder=0,
         )
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
         axis.legend(frameon=False, loc=6)
         axis.set_ylim(0, 1.1)
         axis2 = axis.twinx()

--- a/colibre/scripts/density_species_diffuse.py
+++ b/colibre/scripts/density_species_diffuse.py
@@ -346,7 +346,16 @@ def make_single_image(
             lw=0.25,
             zorder=0,
         )
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
         axis.legend(frameon=False, loc=6)
         axis.set_ylim(0, 1.1)
         axis2 = axis.twinx()

--- a/colibre/scripts/density_species_interp.py
+++ b/colibre/scripts/density_species_interp.py
@@ -278,7 +278,16 @@ def make_single_image(
         axis.plot(
             binmids, hist_h2 + hist_hi + hist_hii, color="0.7", label="total", ls=":"
         )
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
         axis.legend(frameon=False, loc=6)
         axis.set_ylim(0, 1.1)
         axis.set_xlim(np.log10(density_bounds[0]), np.log10(density_bounds[1]))

--- a/colibre/scripts/density_temperature.py
+++ b/colibre/scripts/density_temperature.py
@@ -155,7 +155,16 @@ def make_single_image(
 
     for filename, hist, name, axis in zip(filenames, hists, names, ax.flat):
         mappable = axis.pcolormesh(d, T, hist, norm=LogNorm(vmin=1, vmax=vmax))
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
         metadata = load(filename).metadata
         plot_eos(metadata, axis)
         axis.set_xlim(*density_bounds)

--- a/colibre/scripts/density_temperature_dust.py
+++ b/colibre/scripts/density_temperature_dust.py
@@ -198,7 +198,16 @@ def make_single_image(
             hist,
             norm=Normalize(vmin=dustfracs_bounds[0], vmax=dustfracs_bounds[1]),
         )
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
         metadata = load(filename).metadata
         plot_eos(metadata, axis)
         axis.set_xlim(*density_bounds)

--- a/colibre/scripts/density_temperature_dust2metal.py
+++ b/colibre/scripts/density_temperature_dust2metal.py
@@ -158,7 +158,16 @@ def make_single_image(
         mappable = axis.pcolormesh(
             d, T, hist, norm=LogNorm(vmin=DTMs_bounds[0], vmax=DTMs_bounds[1])
         )
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
 
     fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Dust to Metal Ratio")
 

--- a/colibre/scripts/density_temperature_dust_to_metals.py
+++ b/colibre/scripts/density_temperature_dust_to_metals.py
@@ -185,7 +185,16 @@ def make_single_image(
         mappable = axis.pcolormesh(
             d, T, hist, norm=LogNorm(vmin=dtm_bounds[0], vmax=dtm_bounds[1])
         )
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
         metadata = load(filename).metadata
         plot_eos(metadata, axis)
         axis.set_xlim(*density_bounds)

--- a/colibre/scripts/density_temperature_metals.py
+++ b/colibre/scripts/density_temperature_metals.py
@@ -171,7 +171,16 @@ def make_single_image(
             hist,
             norm=Normalize(vmin=metallicity_bounds[0], vmax=metallicity_bounds[1]),
         )
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
         metadata = load(filename).metadata
         plot_eos(metadata, axis)
         axis.set_xlim(*density_bounds)

--- a/colibre/scripts/density_temperature_sf_fraction.py
+++ b/colibre/scripts/density_temperature_sf_fraction.py
@@ -186,7 +186,16 @@ def make_single_image(
                 vmin=sf_mass_fraction_bounds[0], vmax=sf_mass_fraction_bounds[1]
             ),
         )
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
         metadata = load(filename).metadata
         plot_eos(metadata, axis)
         axis.set_xlim(*density_bounds)

--- a/colibre/scripts/density_temperature_species.py
+++ b/colibre/scripts/density_temperature_species.py
@@ -208,7 +208,16 @@ def make_single_image(
 
     for filename, hist, name, axis in zip(filenames, hists, names, ax.flat):
         mappable = axis.pcolormesh(d, T, hist, norm=LogNorm(vmin=1e-2, vmax=1e0))
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
         metadata = load(filename).metadata
         plot_eos(metadata, axis)
         axis.set_xlim(*density_bounds)

--- a/colibre/scripts/max_temperature_redshift.py
+++ b/colibre/scripts/max_temperature_redshift.py
@@ -115,7 +115,16 @@ def make_single_image(
 
     for hist, name, axis in zip(hists, names, ax.flat):
         mappable = axis.pcolormesh(max_temp, z, hist, norm=LogNorm(vmin=1, vmax=vmax))
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
 
     fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Number of particles")
 

--- a/colibre/scripts/particle_updates_step_cost.py
+++ b/colibre/scripts/particle_updates_step_cost.py
@@ -118,7 +118,16 @@ def make_single_image(
 
     for hist, name, axis in zip(hists, names, ax.flat):
         mappable = axis.pcolormesh(d, T, hist, norm=LogNorm(vmin=1, vmax=vmax))
-        axis.text(0.025, 0.975, name, ha="left", va="top", transform=axis.transAxes)
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
 
     fig.colorbar(mappable, label="Number of steps", pad=0)
 


### PR DESCRIPTION
When run in comparison mode, a lot of scripts produce multi-panel plot. If the run names are long, the layout of this plot usually looks pretty awful, e.g.:
![density_temperature_old](https://user-images.githubusercontent.com/7336967/185341444-a7e724fa-1e53-44e1-b14c-68da98f6f6a0.png)

I fixed this by (a) reducing the font size of the name, and (b) by making sure the name is not taken into account when applying `tight_layout`. Normal length names will now show up properly, and unusually long names will simply be hidden below the other axes.

Result:
![density_temperature_new](https://user-images.githubusercontent.com/7336967/185341804-2569c224-3a06-4d27-b95b-873a7e079ccc.png)
