### PR TITLE
Fixed some SOAP specific things in the FLAMINGO registration functions.

### DIFF
--- a/flamingo/registration.py
+++ b/flamingo/registration.py
@@ -46,7 +46,6 @@ for aperture_size in aperture_sizes:
     ssfr[good_stellar_mass] = (
         star_formation_rate[good_stellar_mass] / stellar_mass[good_stellar_mass]
     ).to(marginal_ssfr.units)
-    print(ssfr)
 
     # Name (label) of the derived field
     ssfr.name = f"Specific SFR ({aperture_size} kpc)"


### PR DESCRIPTION
This is still work in progress.

Fixes some problems with the FLAMINGO registration functions when running the pipeline on the SOAP catalogue output instead of the VR output:
 - SOAP has metal masses instead of mass fractions, so we still need to divide out the total mass
 - SOAP uses different units for the SFR, which led to an interesting bug when computing the SSFR, because of the known issue that `unyt` array assignment ignores units completely.