### PR TITLE
Added 2 extra colours to the default colour cycle.

### DIFF
--- a/colibre/mnras.mplstyle
+++ b/colibre/mnras.mplstyle
@@ -34,7 +34,7 @@ xtick.top: True
 ytick.right: True
 
 # Setup Colours
-axes.prop_cycle: cycler('color', ['00AEFF','FF8C40', 'CC4314', '5766B3', '68246D', '55E18E', 'A646FF', '1F1F1F', '7EFF4B', 'FFACFF'])
+axes.prop_cycle: cycler('color', ['00AEFF','FF8C40', 'CC4314', '5766B3', '68246D', '55E18E', 'A646FF', '1F1F1F', '7EFF4B', 'FFACFF', 'EBCF34', '00912E'])
 
 # Use a colourful default colour map
 image.cmap: plasma


### PR DESCRIPTION
After seeing these plots today:
![image](https://user-images.githubusercontent.com/7336967/186466753-58ae2f31-a6ae-4489-98ed-624abf59222c.png)
I decided it is time to add some more colours to the default colour cycle. Then we get:
![image](https://user-images.githubusercontent.com/7336967/186467054-01b36057-a437-4c7d-82d1-bee3fc53f372.png)
The extra colours are up for discussion, but I noticed that we do not have any shade of yellow yet, or any dark green, so that is why I picked these.