### PR TITLE
Add five black-hole-related scripts/plots

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -167,6 +167,31 @@ scripts:
     output_file: bh_masses.png
     section: Black Holes
     title: Black Hole Dynanmical and Subgrid Masses
+  - filename: scripts/bh_eddington_fractions.py
+    caption: The relation between black hole Eddington fraction and subgrid mass.
+    output_file: black_hole_eddington_fractions.png
+    section: Black Holes - Growth
+    title: Black Hole Eddington Fraction - Mass Relation
+  - filename: scripts/bh_merger_mass_fractions.py
+    caption: The fraction of subgrid mass growth through mergers versus subgrid mass.
+    output_file: black_hole_merger_mass_fractions.png
+    section: Black Holes - Growth
+    title: Black Hole Merger Mass Fractions - Mass Relation
+  - filename: scripts/bh_luminosities.py
+    caption: The (instantaneous and bolometric) AGN luminosity versus subgrid mass. Note that this does not include the coupling efficiency factor, i.e. this is not the thermal heating rate.
+    output_file: black_hole_luminosities.png
+    section: Black Holes - Radiation
+    title: Black Hole Luminosity - Mass Relation
+  - filename: scripts/bh_thermal_energies.py
+    caption: The total AGN injected thermal energies (over the BH lifetime) versus subgrid mass.
+    output_file: black_hole_thermal_energies.png
+    section: Black Holes - Radiation
+    title: Black Hole Thermal Energy - Mass Relation
+  - filename: scripts/bh_thermal_heatings.py
+    caption: The total number of particles heated by AGN thermal feedback (over the BH lifetime) versus subgrid mass.
+    output_file: black_hole_thermal_heatings.png
+    section: Black Holes - Radiation
+    title: Black Hole AGN Heating Events - Mass Relation
   - filename: scripts/gas_masses.py
     caption: Gas Particle Masses with the threshold for splitting indicated by the vertical dashed line.
     output_file: gas_masses.png

--- a/colibre/scripts/bh_eddington_fractions.py
+++ b/colibre/scripts/bh_eddington_fractions.py
@@ -1,0 +1,109 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+from velociraptor.tools.lines import binned_median_line
+from velociraptor.autoplotter.plot import scatter_x_against_y
+
+import unyt
+
+# Set the limits of the figure.
+mass_bounds = [1e3, 3e10]  # Msun
+value_bounds = [1e-7, 1e1]  # dimensionless
+bins = 25
+plot_scatter = True
+
+
+def get_data(filename):
+
+    data = load(filename)
+
+    masses = data.black_holes.subgrid_masses.to("Msun")
+
+    try:
+        values = data.black_holes.eddington_fractions
+    except AttributeError:
+        values = unyt.unyt_array(
+            np.zeros(masses.shape), dtype=np.float64, units=unyt.dimensionless
+        )
+
+    return masses, values
+
+
+def make_single_image(
+    filenames, names, mass_bounds, value_bounds, number_of_simulations, output_path
+):
+
+    fig, ax = plt.subplots()
+
+    ax.set_xlabel("Black Hole Subgrid Masses $M_{\\rm sub}$ [M$_\odot$]")
+    ax.set_ylabel(
+        "Black Hole Eddington Fraction $\dot{m}=\dot{M}_{\\rm BH}/\dot{M}_{\\rm Edd}$"
+    )
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+
+    for filename, name in zip(filenames, names):
+        masses, values = get_data(filename)
+        mass_bins = (
+            np.logspace(np.log10(mass_bounds[0]), np.log10(mass_bounds[1]), bins)
+            * unyt.Msun
+        )
+        mass_bins = mass_bins.to("Msun")
+        centers, medians, deviations, additional_x, additional_y = binned_median_line(
+            masses, values, mass_bins, return_additional=True
+        )
+
+        fill_plot, = ax.plot(centers, medians, label=name)
+        ax.fill_between(
+            centers,
+            medians - deviations[0],
+            medians + deviations[1],
+            alpha=0.2,
+            facecolor=fill_plot.get_color(),
+        )
+        if number_of_simulations == 1 and plot_scatter:
+            scatter_x_against_y(ax, masses, values)
+        ax.scatter(additional_x.value, additional_y.value, color=fill_plot.get_color())
+        ax.plot(
+            [1e-10, 1e11],
+            [0.01, 0.01],
+            color="black",
+            linestyle=":",
+            linewidth=0.75,
+            label="$\dot{m}=0.01$",
+        )
+
+    ax.legend()
+    ax.set_xlim(*mass_bounds)
+    ax.set_ylim(*value_bounds)
+
+    fig.savefig(f"{output_path}/black_hole_eddington_fractions.png")
+
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(
+        description="Eddington fraction - BH mass relation"
+    )
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        mass_bounds=mass_bounds,
+        value_bounds=value_bounds,
+        number_of_simulations=arguments.number_of_inputs,
+        output_path=arguments.output_directory,
+    )

--- a/colibre/scripts/bh_luminosities.py
+++ b/colibre/scripts/bh_luminosities.py
@@ -1,0 +1,117 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+from velociraptor.tools.lines import binned_median_line
+from velociraptor.autoplotter.plot import scatter_x_against_y
+
+import unyt
+from unyt import mh, cm, Gyr, speed_of_light
+
+# Set the limits of the figure.
+mass_bounds = [1e3, 3e10]  # Msun
+value_bounds = [1e38, 1e48]  # erg/s
+bins = 25
+plot_scatter = True
+
+
+def get_data(filename):
+
+    data = load(filename)
+
+    masses = data.black_holes.subgrid_masses.to("Msun")
+
+    try:
+        rad_effs = data.black_holes.radiative_efficiencies
+    except AttributeError:
+        rad_effs = unyt.unyt_array(
+            float(
+                data.metadata.parameters["COLIBREAGN:radiative_efficiency"].decode(
+                    "utf-8"
+                )
+            )
+            * np.ones_like(masses),
+            "dimensionless",
+        )
+
+    accr_rates = data.black_holes.accretion_rates.astype(np.float64).to(
+        unyt.kg / unyt.s
+    )
+
+    values = rad_effs * (speed_of_light ** 2) * accr_rates
+    values = values.to(unyt.erg / unyt.s)
+
+    # Make sure to take only black holes with a non-zero luminosity (efficiency)
+    masses = masses[rad_effs > 1e-6]
+    values = values[rad_effs > 1e-6]
+
+    return masses, values
+
+
+def make_single_image(
+    filenames, names, mass_bounds, value_bounds, number_of_simulations, output_path
+):
+
+    fig, ax = plt.subplots()
+
+    ax.set_xlabel("Black Hole Subgrid Masses $M_{\\rm sub}$ [M$_\odot$]")
+    ax.set_ylabel(
+        "Black Hole Luminosities $L_{\\rm bol}$ $[{\\rm erg}{\\rm \\, s}^{-1}]$"
+    )
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+
+    for filename, name in zip(filenames, names):
+        masses, values = get_data(filename)
+        mass_bins = (
+            np.logspace(np.log10(mass_bounds[0]), np.log10(mass_bounds[1]), bins)
+            * unyt.Msun
+        )
+        mass_bins = mass_bins.to("Msun")
+        centers, medians, deviations, additional_x, additional_y = binned_median_line(
+            masses, values, mass_bins, return_additional=True
+        )
+
+        fill_plot, = ax.plot(centers, medians, label=name)
+        ax.fill_between(
+            centers,
+            medians - deviations[0],
+            medians + deviations[1],
+            alpha=0.2,
+            facecolor=fill_plot.get_color(),
+        )
+        if number_of_simulations == 1 and plot_scatter:
+            scatter_x_against_y(ax, masses, values)
+        ax.scatter(additional_x.value, additional_y.value, color=fill_plot.get_color())
+
+    ax.legend()
+    ax.set_xlim(*mass_bounds)
+    ax.set_ylim(*value_bounds)
+
+    fig.savefig(f"{output_path}/black_hole_luminosities.png")
+
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(description="AGN Luminosity - BH mass relation")
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        mass_bounds=mass_bounds,
+        value_bounds=value_bounds,
+        number_of_simulations=arguments.number_of_inputs,
+        output_path=arguments.output_directory,
+    )

--- a/colibre/scripts/bh_merger_mass_fractions.py
+++ b/colibre/scripts/bh_merger_mass_fractions.py
@@ -1,0 +1,94 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+from velociraptor.tools.lines import binned_median_line
+from velociraptor.autoplotter.plot import scatter_x_against_y
+
+import unyt
+
+# Set the limits of the figure.
+mass_bounds = [1e3, 3e10]  # Msun
+value_bounds = [0, 1.02]  # dimensionless
+bins = 25
+plot_scatter = True
+
+
+def get_data(filename):
+
+    data = load(filename)
+
+    masses = data.black_holes.subgrid_masses.to("Msun")
+    accreted_masses = data.black_holes.total_accreted_masses.to("Msun")
+    values = 1.0 - accreted_masses / masses
+    values = values * unyt.dimensionless
+
+    return masses, values
+
+
+def make_single_image(
+    filenames, names, mass_bounds, value_bounds, number_of_simulations, output_path
+):
+
+    fig, ax = plt.subplots()
+
+    ax.set_xlabel("Black Hole Subgrid Masses $M_{\\rm sub}$ [M$_\odot$]")
+    ax.set_ylabel(r"Fraction of Mass Grown Through Mergers")
+    ax.set_xscale("log")
+
+    for filename, name in zip(filenames, names):
+        masses, values = get_data(filename)
+        mass_bins = (
+            np.logspace(np.log10(mass_bounds[0]), np.log10(mass_bounds[1]), bins)
+            * unyt.Msun
+        )
+        mass_bins = mass_bins.to("Msun")
+        centers, medians, deviations, additional_x, additional_y = binned_median_line(
+            masses, values, mass_bins, return_additional=True
+        )
+
+        fill_plot, = ax.plot(centers, medians, label=name)
+        ax.fill_between(
+            centers,
+            medians - deviations[0],
+            medians + deviations[1],
+            alpha=0.2,
+            facecolor=fill_plot.get_color(),
+        )
+        if number_of_simulations == 1 and plot_scatter:
+            scatter_x_against_y(ax, masses, values)
+        ax.scatter(additional_x.value, additional_y.value, color=fill_plot.get_color())
+
+    ax.legend()
+    ax.set_xlim(*mass_bounds)
+    ax.set_ylim(*value_bounds)
+
+    fig.savefig(f"{output_path}/black_hole_merger_mass_fractions.png")
+
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(
+        description="Merger Mass Fraction - BH mass relation"
+    )
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        mass_bounds=mass_bounds,
+        value_bounds=value_bounds,
+        number_of_simulations=arguments.number_of_inputs,
+        output_path=arguments.output_directory,
+    )

--- a/colibre/scripts/bh_thermal_energies.py
+++ b/colibre/scripts/bh_thermal_energies.py
@@ -1,0 +1,95 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+
+from velociraptor.tools.lines import binned_median_line
+from velociraptor.autoplotter.plot import scatter_x_against_y
+import unyt
+
+# Set the limits of the figure.
+mass_bounds = [1e3, 3e10]  # Msun
+value_bounds = [1e55, 1e63]  # erg
+bins = 25
+plot_scatter = True
+
+
+def get_data(filename):
+
+    data = load(filename)
+
+    masses = data.black_holes.subgrid_masses.to("Msun")
+    values = data.black_holes.agntotal_injected_energies.astype(np.float64).to("erg")
+
+    return masses, values
+
+
+def make_single_image(
+    filenames, names, mass_bounds, value_bounds, number_of_simulations, output_path
+):
+
+    fig, ax = plt.subplots()
+
+    ax.set_xlabel("Black Hole Subgrid Masses $M_{\\rm sub}$ [M$_\odot$]")
+    ax.set_ylabel(
+        "Black Hole Injected Thermal AGN Energies $E_{\\rm th}$ $[{\\rm erg}]$"
+    )
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+
+    for filename, name in zip(filenames, names):
+        masses, values = get_data(filename)
+        mass_bins = (
+            np.logspace(np.log10(mass_bounds[0]), np.log10(mass_bounds[1]), bins)
+            * unyt.Msun
+        )
+        mass_bins = mass_bins.to("Msun")
+        centers, medians, deviations, additional_x, additional_y = binned_median_line(
+            masses, values, mass_bins, return_additional=True
+        )
+
+        fill_plot, = ax.plot(centers, medians, label=name)
+        ax.fill_between(
+            centers,
+            medians - deviations[0],
+            medians + deviations[1],
+            alpha=0.2,
+            facecolor=fill_plot.get_color(),
+        )
+        if number_of_simulations == 1 and plot_scatter:
+            scatter_x_against_y(ax, masses, values)
+        ax.scatter(additional_x.value, additional_y.value, color=fill_plot.get_color())
+
+    ax.legend()
+    ax.set_xlim(*mass_bounds)
+    ax.set_ylim(*value_bounds)
+
+    fig.savefig(f"{output_path}/black_hole_thermal_energies.png")
+
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(
+        description="AGN injected thermal energies - BH mass relation"
+    )
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        mass_bounds=mass_bounds,
+        value_bounds=value_bounds,
+        number_of_simulations=arguments.number_of_inputs,
+        output_path=arguments.output_directory,
+    )

--- a/colibre/scripts/bh_thermal_heatings.py
+++ b/colibre/scripts/bh_thermal_heatings.py
@@ -1,0 +1,93 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+from velociraptor.tools.lines import binned_median_line
+from velociraptor.autoplotter.plot import scatter_x_against_y
+
+import unyt
+
+# Set the limits of the figure.
+mass_bounds = [1e3, 3e10]  # Msun
+value_bounds = [8e-1, 1e5]  # dimensionless
+bins = 25
+plot_scatter = True
+
+
+def get_data(filename):
+
+    data = load(filename)
+
+    masses = data.black_holes.subgrid_masses.to("Msun")
+    values = data.black_holes.number_of_heating_events
+
+    return masses, values
+
+
+def make_single_image(
+    filenames, names, mass_bounds, value_bounds, number_of_simulations, output_path
+):
+
+    fig, ax = plt.subplots()
+
+    ax.set_xlabel("Black Hole Subgrid Masses $M_{\\rm sub}$ [M$_\odot$]")
+    ax.set_ylabel("Number Of Particles Heated by AGN Feedback  $N_{\\rm th}$")
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+
+    for filename, name in zip(filenames, names):
+        masses, values = get_data(filename)
+        mass_bins = (
+            np.logspace(np.log10(mass_bounds[0]), np.log10(mass_bounds[1]), bins)
+            * unyt.Msun
+        )
+        mass_bins = mass_bins.to("Msun")
+        centers, medians, deviations, additional_x, additional_y = binned_median_line(
+            masses, values, mass_bins, return_additional=True
+        )
+
+        fill_plot, = ax.plot(centers, medians, label=name)
+        ax.fill_between(
+            centers,
+            medians - deviations[0],
+            medians + deviations[1],
+            alpha=0.2,
+            facecolor=fill_plot.get_color(),
+        )
+        if number_of_simulations == 1 and plot_scatter:
+            scatter_x_against_y(ax, masses, values)
+        ax.scatter(additional_x.value, additional_y.value, color=fill_plot.get_color())
+
+    ax.legend()
+    ax.set_xlim(*mass_bounds)
+    ax.set_ylim(*value_bounds)
+
+    fig.savefig(f"{output_path}/black_hole_thermal_heatings.png")
+
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(
+        description="Number of particles heated by AGN thermal feedback - BH mass relation"
+    )
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        mass_bounds=mass_bounds,
+        value_bounds=value_bounds,
+        number_of_simulations=arguments.number_of_inputs,
+        output_path=arguments.output_directory,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 swiftpipeline>=0.3.4
+velociraptor>=0.15.8
 scipy


### PR DESCRIPTION
This PR adds five black-hole-related scripts/plots from @FHusko's jets update (https://github.com/SWIFTSIM/pipeline-configs/pull/214)

Namely, the scripts are

- scripts/bh_eddington_fractions.py
- scripts/bh_merger_mass_fractions.py
- scripts/bh_luminosities.py
- scripts/bh_thermal_energies.py
- scripts/bh_thermal_heatings.py

