### PR TITLE
Compute Eddington Fractions if not present in the snapshot

### DIFF
--- a/colibre/scripts/bh_eddington_fractions.py
+++ b/colibre/scripts/bh_eddington_fractions.py
@@ -36,21 +36,17 @@ def get_data(filename):
     masses = data.black_holes.subgrid_masses.to("Msun")
 
     try:
-        values = data.black_holes.eddin222gton_fractions
-        print("found edd fractions")
+        values = data.black_holes.eddington_fractions
 
-    # Compute eddington fractions yourself if they are not stored in the snapshot
+    # Compute Eddington fractions yourself if they are not stored in the snapshot
     except AttributeError:
-        print(" not found edd fractions")
         acc_rates = data.black_holes.accretion_rates
 
         # Jet model
         try:
-            rad_effs = data.black_holes.radiative_2efficiencies
-            print("rad eff found")
+            rad_effs = data.black_holes.radiative_efficiencies
         # Purely thermal AGN feedback
         except AttributeError:
-            print("rad eff  not found")
             rad_effs = unyt.unyt_array(
                 float(
                     data.metadata.parameters["COLIBREAGN:radiative_efficiency"].decode(

--- a/colibre/scripts/bh_eddington_fractions.py
+++ b/colibre/scripts/bh_eddington_fractions.py
@@ -99,14 +99,15 @@ def make_single_image(
         if number_of_simulations == 1 and plot_scatter:
             scatter_x_against_y(ax, masses, values)
         ax.scatter(additional_x.value, additional_y.value, color=fill_plot.get_color())
-        ax.plot(
-            [1e-10, 1e11],
-            [0.01, 0.01],
-            color="black",
-            linestyle=":",
-            linewidth=0.75,
-            label="$\dot{m}=0.01$",
-        )
+
+    ax.plot(
+        [1e-10, 1e11],
+        [0.01, 0.01],
+        color="black",
+        linestyle=":",
+        linewidth=0.75,
+        label="$\dot{m}=0.01$",
+    )
 
     ax.legend()
     ax.set_xlim(*mass_bounds)

--- a/colibre/scripts/bh_luminosities.py
+++ b/colibre/scripts/bh_luminosities.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from swiftsimio import load
+from velociraptor.autoplotter.objects import VelociraptorLine
 from velociraptor.tools.lines import binned_median_line
 from velociraptor.autoplotter.plot import scatter_x_against_y
 

--- a/colibre/scripts/bh_merger_mass_fractions.py
+++ b/colibre/scripts/bh_merger_mass_fractions.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from swiftsimio import load
+from velociraptor.autoplotter.objects import VelociraptorLine
 from velociraptor.tools.lines import binned_median_line
 from velociraptor.autoplotter.plot import scatter_x_against_y
 

--- a/colibre/scripts/bh_thermal_energies.py
+++ b/colibre/scripts/bh_thermal_energies.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from swiftsimio import load
-
+from velociraptor.autoplotter.objects import VelociraptorLine
 from velociraptor.tools.lines import binned_median_line
 from velociraptor.autoplotter.plot import scatter_x_against_y
 import unyt

--- a/colibre/scripts/bh_thermal_heatings.py
+++ b/colibre/scripts/bh_thermal_heatings.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from swiftsimio import load
+from velociraptor.autoplotter.objects import VelociraptorLine
 from velociraptor.tools.lines import binned_median_line
 from velociraptor.autoplotter.plot import scatter_x_against_y
 


### PR DESCRIPTION
In the SPIN_JET version of AGN feedback, Eddington fractions are directly saved into snapshots.

In the COLIBRE version of AGN feedback, snapshots do not contain the Eddington fractions. 

The Eddington fractions can be computed based on BHs masses and instantaneous accretion rates, which is what the update in this PR does. The Eddington fractions are computed if the swift-pipeline cannot load them from the snapshot.

