### PR TITLE
Add a line showing the average energy fraction in supernova feedback

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -98,7 +98,7 @@ scripts:
     section: Stellar Birth Properties
     output_file: birth_pressure_distribution.png
   - filename: scripts/snii_energy_fraction_distribution.py
-    caption: Distributions of SNII energy fractions, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median SNII energy fraction.
+    caption: Distributions of SNII energy fractions, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median SNII energy fraction in three different redshift intervals. The dotted vertical line shows the average SNII energy fraction computed over all star particles in the simulation.
     title: SNII Energy Fraction
     section: Stellar Birth Properties
     output_file: snii_energy_fraction_distribution.png
@@ -323,7 +323,7 @@ scripts:
       yvar: C_Fe
       dataset: GALAH
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [C/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [C/H]Sun = 8.43. The median [C/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018). Contours use a log scale with 0.04 bin size and a minimum star count of 10.' 
+    caption: '[Fe/H] vs [C/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [C/H]Sun = 8.43. The median [C/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018). Contours use a log scale with 0.04 bin size and a minimum star count of 10.'
     output_file: stellar_abundances_FeH_CFe_APOGEE.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [C/Fe]'
@@ -332,7 +332,7 @@ scripts:
       yvar: C_Fe
       dataset: APOGEE
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [N/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [N/H]Sun = 7.83. The median [N/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018). Contours use a log scale with 0.04 bin size and a minimum star count of 10.' 
+    caption: '[Fe/H] vs [N/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [N/H]Sun = 7.83. The median [N/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018). Contours use a log scale with 0.04 bin size and a minimum star count of 10.'
     output_file: stellar_abundances_FeH_NFe_APOGEE.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [N/Fe]'
@@ -350,7 +350,7 @@ scripts:
       yvar: O_Fe
       dataset: GALAH
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [O/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [O/H]Sun = 8.69. The median [O/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018). Contours use a log scale with 0.04 bin size and a minimum star count of 10.' 
+    caption: '[Fe/H] vs [O/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [O/H]Sun = 8.69. The median [O/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018). Contours use a log scale with 0.04 bin size and a minimum star count of 10.'
     output_file: stellar_abundances_FeH_OFe_APOGEE.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [O/Fe]'
@@ -376,7 +376,7 @@ scripts:
       yvar: Mg_Fe
       dataset: GALAH
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [Mg/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6. The median [Mg/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018). Contours use a log scale with 0.04 bin size and a minimum star count of 10.' 
+    caption: '[Fe/H] vs [Mg/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6. The median [Mg/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018). Contours use a log scale with 0.04 bin size and a minimum star count of 10.'
     output_file: stellar_abundances_FeH_MgFe_APOGEE.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [Mg/Fe]'
@@ -393,7 +393,7 @@ scripts:
       xvar: Fe_H
       yvar: Mg_Fe
   - filename: scripts/stellar_abundances.py
-    caption: '[O/H] vs [O/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [O/H]Sun = 8.69. The median [O/Fe] vs median [O/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018). Contours use a log scale with 0.04 bin size and a minimum star count of 10.' 
+    caption: '[O/H] vs [O/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [O/H]Sun = 8.69. The median [O/Fe] vs median [O/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018). Contours use a log scale with 0.04 bin size and a minimum star count of 10.'
     output_file: stellar_abundances_OH_OFe_APOGEE.png
     section: Stellar Metal Abundances
     title: '[O/H] vs [O/Fe]'
@@ -402,7 +402,7 @@ scripts:
       yvar: O_Fe
       dataset: APOGEE
   - filename: scripts/stellar_abundances.py
-    caption: '[O/H] vs [Mg/Fe] using Asplund et al. (2009) values for [O/H]Sun = 8.69 and [Mg/H]Sun = 7.6. The median [Mg/Fe] vs median [O/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018). Contours use a log scale with 0.04 bin size and a minimum star count of 10.' 
+    caption: '[O/H] vs [Mg/Fe] using Asplund et al. (2009) values for [O/H]Sun = 8.69 and [Mg/H]Sun = 7.6. The median [Mg/Fe] vs median [O/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018). Contours use a log scale with 0.04 bin size and a minimum star count of 10.'
     output_file: stellar_abundances_OH_MgFe_APOGEE.png
     section: Stellar Metal Abundances
     title: '[O/H] vs [Mg/Fe]'

--- a/colibre/scripts/snii_energy_fraction_distribution.py
+++ b/colibre/scripts/snii_energy_fraction_distribution.py
@@ -116,6 +116,9 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
     # Total number of stars formed
     Num_of_stars_total = len(birth_redshifts)
 
+    # Average energy fraction (computed among all star particles)
+    average_energy_fraction = np.mean(energy_fractions)
+
     for redshift, ax in ax_dict.items():
         data = energy_fraction_by_redshift[redshift]
 
@@ -129,6 +132,14 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
             np.median(data),
             color=f"C{color}",
             linestyle="dashed",
+            zorder=-10,
+            alpha=0.5,
+        )
+
+        ax.axvline(
+            average_energy_fraction,
+            color=f"C{color}",
+            linestyle="dotted",
             zorder=-10,
             alpha=0.5,
         )


### PR DESCRIPTION
The dotted line in the figure below

![snii_energy_fraction_distribution](https://user-images.githubusercontent.com/20153933/196934605-5b411da1-12c0-49d2-ba1f-b021bc46128f.png)
