### PR TITLE
Fixed bug in hydrogen phases plots

### DIFF
--- a/colibre/scripts/density_species_depletions.py
+++ b/colibre/scripts/density_species_depletions.py
@@ -144,9 +144,14 @@ def get_data(filename, prefix_rho, prefix_T):
         for k in compdict.keys():
             if k in d:
                 for el in compdict[k].keys():
-                    elfrac = compdict[k][el] * getattr(
-                        data.gas.dust_mass_fractions, d.lower()
-                    )
+                    try:
+                        elfrac = compdict[k][el] * getattr(
+                            data.gas.dust_mass_fractions, d.lower()
+                        )
+                    except AttributeError:
+                        elfrac = compdict[k][el] * getattr(
+                            data.gas.dust_mass_fractions, d
+                        )
                     if el in dsfrac_dict:
                         # print(f"Add Grain: {d} Element {el} Elfrac : {elfrac}")
                         dsfrac_dict[el] += elfrac.astype("float64")
@@ -154,7 +159,10 @@ def get_data(filename, prefix_rho, prefix_T):
                         # print(f"Make Grain: {d} Element {el} Elfrac : {elfrac}")
                         dsfrac_dict[el] = elfrac.astype("float64")
 
-        dfrac = getattr(data.gas.dust_mass_fractions, d.lower())
+        try:
+            dfrac = getattr(data.gas.dust_mass_fractions, d.lower())
+        except AttributeError:
+            dfrac = getattr(data.gas.dust_mass_fractions, d)
         dfracs += dfrac
 
     elfrac_dict = {}

--- a/colibre/scripts/density_species_diffuse.py
+++ b/colibre/scripts/density_species_diffuse.py
@@ -143,19 +143,29 @@ def get_data(filename, prefix_rho, prefix_T):
         for k in compdict.keys():
             if k in d:
                 for el in compdict[k].keys():
-                    elfrac = np.clip(
-                        compdict[k][el]
-                        * getattr(data.gas.dust_mass_fractions, d.lower()),
-                        1e-10,
-                        1,
-                    )
+                    try:
+                        elfrac = np.clip(
+                            compdict[k][el]
+                            * getattr(data.gas.dust_mass_fractions, d.lower()),
+                            1e-10,
+                            1,
+                        )
+                    except AttributeError:
+                        elfrac = np.clip(
+                            compdict[k][el] * getattr(data.gas.dust_mass_fractions, d),
+                            1e-10,
+                            1,
+                        )
                     if el in dsfrac_dict:
                         # print(f"Add Grain: {d} Element {el} Elfrac : {(masses*elfrac).sum() / masses.sum()}")
                         dsfrac_dict[el] += elfrac.astype("float64")
                     else:
                         # print(f"Make Grain: {d} Element {el} Elfrac : {(masses*elfrac).sum() / masses.sum()}")
                         dsfrac_dict[el] = elfrac.astype("float64")
-        dfrac = getattr(data.gas.dust_mass_fractions, d.lower())
+        try:
+            dfrac = getattr(data.gas.dust_mass_fractions, d.lower())
+        except AttributeError:
+            dfrac = getattr(data.gas.dust_mass_fractions, d)
         dfracs += dfrac
 
     elfrac_dict = {}

--- a/colibre/scripts/density_species_interp.py
+++ b/colibre/scripts/density_species_interp.py
@@ -57,8 +57,12 @@ def get_data(filename, tables, prefix_rho, prefix_T):
     # Dust Mass Fractions
     dfracs = np.zeros(data.gas.masses.shape)
     dsfrac_dict = {}
+    print(dir(data.gas.dust_mass_fractions))
     for d in data.metadata.named_columns["DustMassFractions"]:
-        dfrac = getattr(data.gas.dust_mass_fractions, d.lower())
+        try:
+            dfrac = getattr(data.gas.dust_mass_fractions, d.lower())
+        except AttributeError:
+            dfrac = getattr(data.gas.dust_mass_fractions, d)
         dsfrac_dict[d] = dfrac.astype("float64")
         dfracs += dfrac
 

--- a/colibre/scripts/density_species_interp.py
+++ b/colibre/scripts/density_species_interp.py
@@ -57,7 +57,6 @@ def get_data(filename, tables, prefix_rho, prefix_T):
     # Dust Mass Fractions
     dfracs = np.zeros(data.gas.masses.shape)
     dsfrac_dict = {}
-    print(dir(data.gas.dust_mass_fractions))
     for d in data.metadata.named_columns["DustMassFractions"]:
         try:
             dfrac = getattr(data.gas.dust_mass_fractions, d.lower())


### PR DESCRIPTION
The issue was that the names of the `DustMassFractions` columns changed from lower case to camel case, and the scripts assumed lower case. I have added support for both, for backward compatibility.