### PR TITLE
Changes required to run on COLIBRE SOAP catalogues

### DIFF
--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -34,7 +34,7 @@ This file calculates:
 # Define aperture size in kpc
 aperture_sizes_30_50_100_kpc = {30, 50, 100}
 
-# Solar metal mass fraction used in Plöckinger S. & Schaye J. (2020)
+# Solar metal mass fraction used in Ploeckinger S. & Schaye J. (2020)
 solar_metal_mass_fraction = 0.0134
 
 # Solar value for O/H

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -71,7 +71,9 @@ def register_spesific_star_formation_rates(self, catalogue, aperture_sizes):
         )
 
         # Compute specific star formation rate using the "good" stellar mass
-        ssfr = unyt.unyt_array(np.zeros(len(star_formation_rate)), units=1 / unyt.year)
+        ssfr = unyt.unyt_array(
+            np.zeros(len(star_formation_rate)), units=star_formation_rate.units
+        )
         ssfr[good_stellar_mass] = (
             star_formation_rate[good_stellar_mass] / stellar_mass[good_stellar_mass]
         )

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -56,16 +56,18 @@ def register_spesific_star_formation_rates(self, catalogue, aperture_sizes):
     for aperture_size in aperture_sizes:
 
         # Get the halo mass
-        halo_mass = catalogue.masses.mass_200crit
+        halo_mass = catalogue.get_quantity("masses.mass_200crit")
 
         # Get stellar mass
-        stellar_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
+        stellar_mass = catalogue.get_quantity(
+            f"apertures.mass_star_{aperture_size}_kpc"
+        )
         # Need to mask out zeros, otherwise we get RuntimeWarnings
         good_stellar_mass = stellar_mass > unyt.unyt_quantity(0.0, stellar_mass.units)
 
         # Get star formation rate
-        star_formation_rate = getattr(
-            catalogue.apertures, f"sfr_gas_{aperture_size}_kpc"
+        star_formation_rate = catalogue.get_quantity(
+            f"apertures.sfr_gas_{aperture_size}_kpc"
         )
 
         # Compute specific star formation rate using the "good" stellar mass
@@ -169,7 +171,8 @@ def register_star_metallicities(self, catalogue, aperture_sizes, Z_sun):
 
         try:
             metal_mass_fraction_star = (
-                getattr(catalogue.apertures, f"zmet_star_{aperture_size}_kpc") / Z_sun
+                catalogue.get_quantity(f"apertures.zmet_star_{aperture_size}_kpc")
+                / Z_sun
             )
             metal_mass_fraction_star.name = (
                 f"Star Metallicity $Z_*$ rel. to "
@@ -195,9 +198,8 @@ def register_star_magnitudes(self, catalogue, aperture_sizes):
         for band in bands:
             try:
 
-                L_AB = getattr(
-                    catalogue.stellar_luminosities,
-                    f"{band}_luminosity_{aperture_size}_kpc",
+                L_AB = catalogue.get_quantity(
+                    f"stellar_luminosities.{band}_luminosity_{aperture_size}_kpc"
                 )
                 m_AB = np.copy(L_AB)
                 mask = L_AB > 0.0
@@ -218,16 +220,18 @@ def register_stellar_to_halo_mass_ratios(self, catalogue, aperture_sizes):
     for aperture_size in aperture_sizes:
 
         # Get the stellar mass in the aperture of a given size
-        stellar_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
+        stellar_mass = catalogue.get_quantity(
+            f"apertures.mass_star_{aperture_size}_kpc"
+        )
 
         # M200 critical
-        halo_M200crit = catalogue.masses.mass_200crit
+        halo_M200crit = catalogue.get_quantity("masses.mass_200crit")
         smhm = stellar_mass / halo_M200crit
         smhm.name = f"$M_* / M_{{\\rm 200crit}}$ ({aperture_size} kpc)"
         setattr(self, f"stellar_mass_to_halo_mass_200crit_{aperture_size}_kpc", smhm)
 
         # BN98
-        halo_MBN98 = catalogue.masses.mass_bn98
+        halo_MBN98 = catalogue.get_quantity("masses.mass_bn98")
         smhm = stellar_mass / halo_MBN98
         smhm.name = f"$M_* / M_{{\\rm BN98}}$ ({aperture_size} kpc)"
         setattr(self, f"stellar_mass_to_halo_mass_bn98_{aperture_size}_kpc", smhm)
@@ -238,53 +242,52 @@ def register_stellar_to_halo_mass_ratios(self, catalogue, aperture_sizes):
 def register_dust(self, catalogue, aperture_sizes, Z_sun, twelve_plus_log_OH_solar):
     # Loop over apertures
     for aperture_size in aperture_sizes:
-        metal_frac = getattr(catalogue.apertures, f"zmet_gas_{aperture_size}_kpc")
+        metal_frac = catalogue.get_quantity(f"apertures.zmet_gas_{aperture_size}_kpc")
         try:
             # Fetch dust fields
-            dust_mass_silicates = getattr(
-                catalogue.dust_masses, f"silicates_mass_{aperture_size}_kpc"
+            dust_mass_silicates = catalogue.get_quantity(
+                f"dust_masses.silicates_mass_{aperture_size}_kpc"
             )
-            dust_mass_graphite = getattr(
-                catalogue.dust_masses, f"graphite_mass_{aperture_size}_kpc"
+            dust_mass_graphite = catalogue.get_quantity(
+                f"dust_masses.graphite_mass_{aperture_size}_kpc"
             )
-            dust_mass_large_grain = getattr(
-                catalogue.dust_masses, f"large_grain_mass_{aperture_size}_kpc"
+            dust_mass_large_grain = catalogue.get_quantity(
+                f"dust_masses.large_grain_mass_{aperture_size}_kpc"
             )
-            dust_mass_small_grain = getattr(
-                catalogue.dust_masses, f"small_grain_mass_{aperture_size}_kpc"
+            dust_mass_small_grain = catalogue.get_quantity(
+                f"dust_masses.small_grain_mass_{aperture_size}_kpc"
             )
-            dust_mass_silicates_hi = getattr(
-                catalogue.dust_masses, f"atomic_silicates_mass_{aperture_size}_kpc"
+            dust_mass_silicates_hi = catalogue.get_quantity(
+                f"dust_masses.atomic_silicates_mass_{aperture_size}_kpc"
             )
-            dust_mass_graphite_hi = getattr(
-                catalogue.dust_masses, f"atomic_graphite_mass_{aperture_size}_kpc"
+            dust_mass_graphite_hi = catalogue.get_quantity(
+                f"dust_masses.atomic_graphite_mass_{aperture_size}_kpc"
             )
-            dust_mass_silicates_h2 = getattr(
-                catalogue.dust_masses, f"molecular_silicates_mass_{aperture_size}_kpc"
+            dust_mass_silicates_h2 = catalogue.get_quantity(
+                f"dust_masses.molecular_silicates_mass_{aperture_size}_kpc"
             )
-            dust_mass_graphite_h2 = getattr(
-                catalogue.dust_masses, f"molecular_graphite_mass_{aperture_size}_kpc"
+            dust_mass_graphite_h2 = catalogue.get_quantity(
+                f"dust_masses.molecular_graphite_mass_{aperture_size}_kpc"
             )
-            dust_mass_large_grain_h2 = getattr(
-                catalogue.dust_masses, f"molecular_large_grain_mass_{aperture_size}_kpc"
+            dust_mass_large_grain_h2 = catalogue.get_quantity(
+                f"dust_masses.molecular_large_grain_mass_{aperture_size}_kpc"
             )
-            dust_mass_small_grain_h2 = getattr(
-                catalogue.dust_masses, f"molecular_small_grain_mass_{aperture_size}_kpc"
+            dust_mass_small_grain_h2 = catalogue.get_quantity(
+                f"dust_masses.molecular_small_grain_mass_{aperture_size}_kpc"
             )
-            dust_mass_silicates_cd = getattr(
-                catalogue.dust_masses, f"cold_dense_silicates_mass_{aperture_size}_kpc"
+            dust_mass_silicates_cd = catalogue.get_quantity(
+                f"dust_masses.cold_dense_silicates_mass_{aperture_size}_kpc"
             )
-            dust_mass_graphite_cd = getattr(
-                catalogue.dust_masses, f"cold_dense_graphite_mass_{aperture_size}_kpc"
+            dust_mass_graphite_cd = catalogue.get_quantity(
+                f"dust_masses.cold_dense_graphite_mass_{aperture_size}_kpc"
             )
-            dust_mass_large_grain_cd = getattr(
-                catalogue.dust_masses,
-                f"cold_dense_large_grain_mass_{aperture_size}_kpc",
+            dust_mass_large_grain_cd = catalogue.get_quantity(
+                f"dust_masses.cold_dense_large_grain_mass_{aperture_size}_kpc"
             )
-            dust_mass_small_grain_cd = getattr(
-                catalogue.dust_masses,
-                f"cold_dense_small_grain_mass_{aperture_size}_kpc",
+            dust_mass_small_grain_cd = catalogue.get_quantity(
+                f"dust_masses.cold_dense_small_grain_mass_{aperture_size}_kpc"
             )
+
             # All dust mass
             dust_mass_total = dust_mass_graphite + dust_mass_silicates
             dust_mass_total_hi = dust_mass_graphite_hi + dust_mass_silicates_hi
@@ -348,38 +351,33 @@ def register_dust(self, catalogue, aperture_sizes, Z_sun, twelve_plus_log_OH_sol
         small_to_large.name = f"$\\mathcal{{D}}_{{\\rm S,Neut.}} / \\mathcal{{D}}_{{\\rm L,Neut.}}$ ({aperture_size} kpc)"
 
         # Fetch gas masses
-        gas_mass = getattr(catalogue.apertures, f"mass_gas_{aperture_size}_kpc")
-        atomic_mass = getattr(
-            catalogue.gas_hydrogen_species_masses, f"HI_mass_{aperture_size}_kpc"
+        gas_mass = catalogue.get_quantity(f"apertures.mass_gas_{aperture_size}_kpc")
+        atomic_mass = catalogue.get_quantity(
+            f"gas_hydrogen_species_masses.HI_mass_{aperture_size}_kpc"
         )
-        molecular_mass = getattr(
-            catalogue.gas_hydrogen_species_masses, f"H2_mass_{aperture_size}_kpc"
+        molecular_mass = catalogue.get_quantity(
+            f"gas_hydrogen_species_masses.H2_mass_{aperture_size}_kpc"
         )
         neutral_mass = atomic_mass + molecular_mass
-        colddense_mass = getattr(
-            catalogue.cold_dense_gas_properties,
-            f"cold_dense_gas_mass_{aperture_size}_kpc",
+        colddense_mass = catalogue.get_quantity(
+            f"cold_dense_gas_properties.cold_dense_gas_mass_{aperture_size}_kpc"
         )
 
         # Metal mass fractions of the gas
 
         try:
-            linOH_abundance_times_mgas = getattr(
-                catalogue.lin_element_ratios_times_masses,
-                f"lin_O_over_H_total_times_gas_mass_100_kpc",
+            linOH_abundance_times_mgas = catalogue.get_quantity(
+                f"lin_element_ratios_times_masses.lin_O_over_H_total_times_gas_mass_100_kpc"
             )
 
-            logOH_abundance_times_mhi = getattr(
-                catalogue.log_element_ratios_times_masses,
-                f"log_O_over_H_atomic_times_gas_mass_lowfloor_{aperture_size}_kpc",
+            logOH_abundance_times_mhi = catalogue.get_quantity(
+                f"log_element_ratios_times_masses.log_O_over_H_atomic_times_gas_mass_lowfloor_{aperture_size}_kpc"
             )
-            logOH_abundance_times_mh2 = getattr(
-                catalogue.log_element_ratios_times_masses,
-                f"log_O_over_H_molecular_times_gas_mass_lowfloor_{aperture_size}_kpc",
+            logOH_abundance_times_mh2 = catalogue.get_quantity(
+                f"log_element_ratios_times_masses.log_O_over_H_molecular_times_gas_mass_lowfloor_{aperture_size}_kpc"
             )
-            logOH_abundance_times_cd = getattr(
-                catalogue.log_element_ratios_times_masses,
-                f"log_O_over_H_times_gas_mass_lowfloor_{aperture_size}_kpc",
+            logOH_abundance_times_cd = catalogue.get_quantity(
+                f"log_element_ratios_times_masses.log_O_over_H_times_gas_mass_lowfloor_{aperture_size}_kpc"
             )
         except AttributeError:
             logOH_abundance_times_mgas = unyt.unyt_array(
@@ -476,7 +474,7 @@ def register_dust(self, catalogue, aperture_sizes, Z_sun, twelve_plus_log_OH_sol
         )
 
         # Compute dust to stellar ratio
-        mass_star = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
+        mass_star = catalogue.get_quantity(f"apertures.mass_star_{aperture_size}_kpc")
         dust_to_stars = dust_mass_total / mass_star
         dust_to_stars_hi = dust_mass_total_hi / mass_star
         dust_to_stars_h2 = dust_mass_total_h2 / mass_star
@@ -621,18 +619,18 @@ def register_star_Mg_and_O_to_Fe(self, catalogue, aperture_sizes):
     for aperture_size in aperture_sizes:
 
         # Oxygen mass
-        M_O = getattr(
-            catalogue.element_masses_in_stars, f"oxygen_mass_{aperture_size}_kpc"
+        M_O = catalogue.get_quantity(
+            f"element_masses_in_stars.oxygen_mass_{aperture_size}_kpc"
         )
 
         # Magnesium mass
-        M_Mg = getattr(
-            catalogue.element_masses_in_stars, f"magnesium_mass_{aperture_size}_kpc"
+        M_Mg = catalogue.get_quantity(
+            f"element_masses_in_stars.magnesium_mass_{aperture_size}_kpc"
         )
 
         # Iron mass
-        M_Fe = getattr(
-            catalogue.element_masses_in_stars, f"iron_mass_{aperture_size}_kpc"
+        M_Fe = catalogue.get_quantity(
+            f"element_masses_in_stars.iron_mass_{aperture_size}_kpc"
         )
 
         # Avoid zeroes
@@ -673,14 +671,12 @@ def register_oxygen_to_hydrogen(self, catalogue, aperture_sizes):
         ):
             # Fetch O over H times gas mass computed in apertures.  The factor of 16 (the
             # mass ratio between O and H) has already been accounted for.
-            log_O_over_H_times_gas_mass = getattr(
-                catalogue.lin_element_ratios_times_masses,
-                f"lin_O_over_H{short_phase}_times_gas_mass_{aperture_size}_kpc",
+            log_O_over_H_times_gas_mass = catalogue.get_quantity(
+                f"lin_element_ratios_times_masses.lin_O_over_H{short_phase}_times_gas_mass_{aperture_size}_kpc"
             )
             # Fetch gas mass in apertures
-            gas_cold_dense_mass = getattr(
-                catalogue.cold_dense_gas_properties,
-                f"cold_dense_gas_mass_{aperture_size}_kpc",
+            gas_cold_dense_mass = catalogue.get_quantity(
+                f"cold_dense_gas_properties.cold_dense_gas_mass_{aperture_size}_kpc"
             )
 
             # Compute gas-mass weighted O over H
@@ -711,15 +707,13 @@ def register_oxygen_to_hydrogen(self, catalogue, aperture_sizes):
         ):
             # Fetch O over H times gas mass computed in apertures.  The factor of 16 (the
             # mass ratio between O and H) has already been accounted for.
-            log_O_over_H_times_gas_mass = getattr(
-                catalogue.log_element_ratios_times_masses,
-                f"log_O_over_H_times_gas_mass_{floor}floor_{aperture_size}_kpc",
+            log_O_over_H_times_gas_mass = catalogue.get_quantity(
+                f"log_element_ratios_times_masses.log_O_over_H_times_gas_mass_{floor}floor_{aperture_size}_kpc"
             )
 
             # Fetch gas mass in apertures
-            gas_cold_dense_mass = getattr(
-                catalogue.cold_dense_gas_properties,
-                f"cold_dense_gas_mass_{aperture_size}_kpc",
+            gas_cold_dense_mass = catalogue.get_quantity(
+                f"cold_dense_gas_properties.cold_dense_gas_mass_{aperture_size}_kpc"
             )
 
             # Compute gas-mass weighted O over H
@@ -749,12 +743,11 @@ def register_iron_to_hydrogen(self, catalogue, aperture_sizes, fe_solar_abundanc
     for aperture_size in aperture_sizes:
         # Fetch linear Fe over H times stellar mass computed in apertures. The
         # mass ratio between Fe and H has already been accounted for.
-        lin_Fe_over_H_times_star_mass = getattr(
-            catalogue.lin_element_ratios_times_masses,
-            f"lin_Fe_over_H_times_star_mass_{aperture_size}_kpc",
+        lin_Fe_over_H_times_star_mass = catalogue.get_quantity(
+            f"lin_element_ratios_times_masses.lin_Fe_over_H_times_star_mass_{aperture_size}_kpc"
         )
         # Fetch stellar mass in apertures
-        star_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
+        star_mass = catalogue.get_quantity(f"apertures.mass_star_{aperture_size}_kpc")
 
         # Compute stellar-mass weighted Fe over H
         Fe_over_H = unyt.unyt_array(np.zeros_like(star_mass), "dimensionless")
@@ -775,12 +768,13 @@ def register_iron_to_hydrogen(self, catalogue, aperture_sizes, fe_solar_abundanc
 
             # Fetch Fe over H times stellar mass computed in apertures. The
             # mass ratio between Fe and H has already been accounted for.
-            log_Fe_over_H_times_star_mass = getattr(
-                catalogue.log_element_ratios_times_masses,
-                f"log_Fe_over_H_times_star_mass_{floor}floor_{aperture_size}_kpc",
+            log_Fe_over_H_times_star_mass = catalogue.get_quantity(
+                f"log_element_ratios_times_masses.log_Fe_over_H_times_star_mass_{floor}floor_{aperture_size}_kpc"
             )
             # Fetch stellar mass in apertures
-            star_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
+            star_mass = catalogue.get_quantity(
+                f"apertures.mass_star_{aperture_size}_kpc"
+            )
 
             # Compute stellar-mass weighted Fe over H
             Fe_over_H = unyt.unyt_array(np.zeros_like(star_mass), "dimensionless")
@@ -797,9 +791,8 @@ def register_iron_to_hydrogen(self, catalogue, aperture_sizes, fe_solar_abundanc
                 f"Stellar $10^{{\\rm [Fe/H]}}$ ({floor_label}, {aperture_size} kpc)"
             )
 
-            log_Fe_over_H_times_star_mass = getattr(
-                catalogue.log_element_ratios_times_masses,
-                f"log_Fe_over_H_times_star_mass_{floor}floor_{aperture_size}_kpc",
+            log_Fe_over_H_times_star_mass = catalogue.get_quantity(
+                f"log_element_ratios_times_masses.log_Fe_over_H_times_star_mass_{floor}floor_{aperture_size}_kpc"
             )
 
             # Register the field
@@ -811,9 +804,8 @@ def register_iron_to_hydrogen(self, catalogue, aperture_sizes, fe_solar_abundanc
 
             if floor == "low":
                 try:
-                    log_Fe_over_H_times_star_mass = getattr(
-                        catalogue.log_element_ratios_times_masses,
-                        f"log_SNIaFe_over_H_times_star_mass_{floor}floor_{aperture_size}_kpc",
+                    log_Fe_over_H_times_star_mass = catalogue.get_quantity(
+                        f"log_element_ratios_times_masses.log_SNIaFe_over_H_times_star_mass_{floor}floor_{aperture_size}_kpc"
                     )
                     Fe_over_H[mask] = pow(
                         10.0, log_Fe_over_H_times_star_mass[mask] / star_mass[mask]
@@ -847,14 +839,12 @@ def register_cold_dense_gas_metallicity(
     # Loop over apertures
     for aperture_size in aperture_sizes:
         # Fetch gas metal masses in apertures
-        lin_diffuse_metallicity = getattr(
-            catalogue.cold_dense_gas_properties,
-            f"cold_dense_diffuse_metal_mass_{aperture_size}_kpc",
+        lin_diffuse_metallicity = catalogue.get_quantity(
+            f"cold_dense_gas_properties.cold_dense_diffuse_metal_mass_{aperture_size}_kpc"
         )
         # Fetch gas mass in apertures
-        gas_cold_dense_mass = getattr(
-            catalogue.cold_dense_gas_properties,
-            f"cold_dense_gas_mass_{aperture_size}_kpc",
+        gas_cold_dense_mass = catalogue.get_quantity(
+            f"cold_dense_gas_properties.cold_dense_gas_mass_{aperture_size}_kpc"
         )
 
         # Compute gas-mass weighted metallicity, floor at a non-zero metallicity 1e-8
@@ -889,8 +879,8 @@ def register_hi_masses(self, catalogue, aperture_sizes):
     for aperture_size in aperture_sizes:
 
         # Fetch HI mass
-        HI_mass = getattr(
-            catalogue.gas_hydrogen_species_masses, f"HI_mass_{aperture_size}_kpc"
+        HI_mass = catalogue.get_quantity(
+            f"gas_hydrogen_species_masses.HI_mass_{aperture_size}_kpc"
         )
 
         # Label of the derived field
@@ -908,17 +898,17 @@ def register_dust_to_hi_ratio(self, catalogue, aperture_sizes):
     for aperture_size in aperture_sizes:
 
         # Fetch HI mass in apertures
-        HI_mass = getattr(
-            catalogue.gas_hydrogen_species_masses, f"HI_mass_{aperture_size}_kpc"
+        HI_mass = catalogue.get_quantity(
+            f"gas_hydrogen_species_masses.HI_mass_{aperture_size}_kpc"
         )
 
         try:
             # Fetch dust fields
-            dust_mass_silicates = getattr(
-                catalogue.dust_masses, f"silicates_mass_{aperture_size}_kpc"
+            dust_mass_silicates = catalogue.get_quantity(
+                f"dust_masses.silicates_mass_{aperture_size}_kpc"
             )
-            dust_mass_graphite = getattr(
-                catalogue.dust_masses, f"graphite_mass_{aperture_size}_kpc"
+            dust_mass_graphite = catalogue.get_quantity(
+                f"dust_masses.graphite_mass_{aperture_size}_kpc"
             )
             # All dust mass
             dust_mass_total = dust_mass_graphite + dust_mass_silicates
@@ -948,16 +938,20 @@ def register_h2_masses(self, catalogue, aperture_sizes):
     for aperture_size in aperture_sizes:
 
         # Fetch H2 mass
-        H2_mass = getattr(
-            catalogue.gas_hydrogen_species_masses, f"H2_mass_{aperture_size}_kpc"
+        H2_mass = catalogue.get_quantity(
+            f"gas_hydrogen_species_masses.H2_mass_{aperture_size}_kpc"
         )
 
         # Label of the derived field
         H2_mass.name = f"$M_{{\\rm H_2}}$ ({aperture_size} kpc)"
 
         # Compute H2 mass with correction due to He
-        He_mass = getattr(catalogue.gas_H_and_He_masses, f"He_mass_{aperture_size}_kpc")
-        H_mass = getattr(catalogue.gas_H_and_He_masses, f"H_mass_{aperture_size}_kpc")
+        He_mass = catalogue.get_quantity(
+            f"gas_H_and_He_masses.He_mass_{aperture_size}_kpc"
+        )
+        H_mass = catalogue.get_quantity(
+            f"gas_H_and_He_masses.H_mass_{aperture_size}_kpc"
+        )
 
         H2_mass_with_He = H2_mass * (1.0 + He_mass / H_mass)
 
@@ -977,11 +971,11 @@ def register_cold_gas_mass_ratios(self, catalogue, aperture_sizes):
     for aperture_size in aperture_sizes:
 
         # Fetch HI and H2 masses in apertures of a given size
-        HI_mass = getattr(
-            catalogue.gas_hydrogen_species_masses, f"HI_mass_{aperture_size}_kpc"
+        HI_mass = catalogue.get_quantity(
+            f"gas_hydrogen_species_masses.HI_mass_{aperture_size}_kpc"
         )
-        H2_mass = getattr(
-            catalogue.gas_hydrogen_species_masses, f"H2_mass_{aperture_size}_kpc"
+        H2_mass = catalogue.get_quantity(
+            f"gas_hydrogen_species_masses.H2_mass_{aperture_size}_kpc"
         )
 
         # Compute neutral H mass (HI + H2)
@@ -990,9 +984,11 @@ def register_cold_gas_mass_ratios(self, catalogue, aperture_sizes):
         neutral_H_mass.name = f"$M_{{\\rm HI + H_2}}$ ({aperture_size} kpc)"
 
         # Fetch total stellar mass
-        stellar_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
+        stellar_mass = catalogue.get_quantity(
+            f"apertures.mass_star_{aperture_size}_kpc"
+        )
         # Fetch mass of star-forming gas
-        sf_mass = getattr(catalogue.apertures, f"mass_gas_sf_{aperture_size}_kpc")
+        sf_mass = catalogue.get_quantity(f"apertures.mass_gas_sf_{aperture_size}_kpc")
 
         # Compute neutral H mass to stellar mass ratio
         neutral_H_to_stellar_fraction = neutral_H_mass / stellar_mass
@@ -1148,17 +1144,16 @@ def register_species_fractions(self, catalogue, aperture_sizes):
         gal_area = (
             2
             * np.pi
-            * getattr(
-                catalogue.projected_apertures,
-                f"projected_1_rhalfmass_star_{aperture_size}_kpc",
+            * catalogue.get_quantity(
+                f"projected_apertures.projected_1_rhalfmass_star_{aperture_size}_kpc"
             )
             ** 2
         )
 
         # Stellar mass
-        M_star = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
-        M_star_projected = getattr(
-            catalogue.projected_apertures, f"projected_1_mass_star_{aperture_size}_kpc"
+        M_star = catalogue.get_quantity(f"apertures.mass_star_{aperture_size}_kpc")
+        M_star_projected = catalogue.get_quantity(
+            f"projected_apertures.projected_1_mass_star_{aperture_size}_kpc"
         )
 
         # Selection functions for the xGASS and xCOLDGASS surveys, used for the H species
@@ -1180,20 +1175,24 @@ def register_species_fractions(self, catalogue, aperture_sizes):
         mu_star.name = f"$M_{{*, {aperture_size} {{\\rm kpc}}}} / \\pi R_{{*, {aperture_size} {{\\rm kpc}}}}^2$"
 
         # Atomic hydrogen mass in apertures
-        HI_mass = getattr(
-            catalogue.gas_hydrogen_species_masses, f"HI_mass_{aperture_size}_kpc"
+        HI_mass = catalogue.get_quantity(
+            f"gas_hydrogen_species_masses.HI_mass_{aperture_size}_kpc"
         )
         HI_mass.name = f"HI Mass ({aperture_size} kpc)"
 
         # Molecular hydrogen mass in apertures
-        H2_mass = getattr(
-            catalogue.gas_hydrogen_species_masses, f"H2_mass_{aperture_size}_kpc"
+        H2_mass = catalogue.get_quantity(
+            f"gas_hydrogen_species_masses.H2_mass_{aperture_size}_kpc"
         )
         H2_mass.name = f"H$_2$ Mass ({aperture_size} kpc)"
 
         # Compute H2 mass with correction due to He
-        He_mass = getattr(catalogue.gas_H_and_He_masses, f"He_mass_{aperture_size}_kpc")
-        H_mass = getattr(catalogue.gas_H_and_He_masses, f"H_mass_{aperture_size}_kpc")
+        He_mass = catalogue.get_quantity(
+            f"gas_H_and_He_masses.He_mass_{aperture_size}_kpc"
+        )
+        H_mass = catalogue.get_quantity(
+            f"gas_H_and_He_masses.H_mass_{aperture_size}_kpc"
+        )
 
         H2_mass_with_He = H2_mass * (1.0 + He_mass / H_mass)
         H2_mass_with_He.name = f"$M_{{\\rm H_2}}$ (incl. He, {aperture_size} kpc)"
@@ -1240,8 +1239,8 @@ def register_species_fractions(self, catalogue, aperture_sizes):
 def register_stellar_birth_densities(self, catalogue):
 
     try:
-        average_log_n_b = catalogue.stellar_birth_densities.logaverage
-        stellar_mass = catalogue.apertures.mass_star_100_kpc
+        average_log_n_b = catalogue.get_quantity("stellar_birth_densities.logaverage")
+        stellar_mass = catalogue.get_quantity("apertures.mass_star_100_kpc")
 
         exp_average_log_n_b = unyt.unyt_array(
             np.exp(average_log_n_b), units=average_log_n_b.units
@@ -1271,9 +1270,9 @@ def register_gas_fraction(self, catalogue):
     Omega_m = catalogue.units.cosmology.Om0
     Omega_b = catalogue.units.cosmology.Ob0
 
-    M_500 = catalogue.spherical_overdensities.mass_500_rhocrit
-    M_500_gas = catalogue.spherical_overdensities.mass_gas_500_rhocrit
-    M_500_star = catalogue.spherical_overdensities.mass_star_500_rhocrit
+    M_500 = catalogue.get_quantity("spherical_overdensities.mass_500_rhocrit")
+    M_500_gas = catalogue.get_quantity("spherical_overdensities.mass_gas_500_rhocrit")
+    M_500_star = catalogue.get_quantity("spherical_overdensities.mass_star_500_rhocrit")
     M_500_baryon = M_500_gas + M_500_star
 
     f_b_500 = (M_500_baryon / M_500) / (Omega_b / Omega_m)
@@ -1297,7 +1296,7 @@ def register_gas_fraction(self, catalogue):
 
 def register_los_star_veldisp(self, catalogue):
     for aperture_size in [10, 30]:
-        veldisp = getattr(catalogue.apertures, f"veldisp_star_{aperture_size}_kpc")
+        veldisp = catalogue.get_quantity(f"apertures.veldisp_star_{aperture_size}_kpc")
         los_veldisp = veldisp / np.sqrt(3.0)
         los_veldisp.name = f"LOS stellar velocity dispersion ({aperture_size} kpc)"
         setattr(self, f"los_veldisp_star_{aperture_size}_kpc", los_veldisp)
@@ -1307,7 +1306,7 @@ def register_los_star_veldisp(self, catalogue):
 
 def register_stellar_mass_scatter(self, catalogue, stellar_mass_scatter_amplitude):
 
-    stellar_mass = catalogue.apertures.mass_star_50_kpc
+    stellar_mass = catalogue.get_quantity("apertures.mass_star_50_kpc")
     stellar_mass_with_scatter = unyt.unyt_array(
         np.random.lognormal(
             np.log(stellar_mass.value), stellar_mass_scatter_amplitude * np.log(10.0)
@@ -1326,8 +1325,10 @@ def register_SNIa_rates(self, catalogue, aperture_sizes):
     for aperture_size in aperture_sizes:
 
         # Get stellar mass and SNIa rate
-        stellar_mass = getattr(catalogue.apertures, f"mass_star_{aperture_size}_kpc")
-        SNIa_rate = getattr(catalogue.snia_rates, f"snia_rates_{aperture_size}_kpc")
+        stellar_mass = catalogue.get_quantity(
+            f"apertures.mass_star_{aperture_size}_kpc"
+        )
+        SNIa_rate = catalogue.get_quantity(f"snia_rates.snia_rates_{aperture_size}_kpc")
 
         # calculate the SNIa rate per stellar mass
         SNIa_rate_per_stellar_mass = SNIa_rate / stellar_mass

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -1450,9 +1450,16 @@ def register_stellar_birth_densities(self, catalogue):
         average_log_n_b = catalogue.get_quantity("stellar_birth_densities.logaverage")
         stellar_mass = catalogue.get_quantity("apertures.mass_star_100_kpc")
 
-        exp_average_log_n_b = unyt.unyt_array(
-            np.exp(average_log_n_b), units=average_log_n_b.units
-        )
+        if catalogue.catalogue_type == "VR":
+            exp_average_log_n_b = unyt.unyt_array(
+                np.exp(average_log_n_b), units=average_log_n_b.units
+            )
+        elif catalogue.catalogue_type == "SOAP":
+            # If we encounter overflow, that is a good hint that we are reading a SOAP
+            # catalogue that already contains the right values
+            exp_average_log_n_b = average_log_n_b
+        else:
+            raise RuntimeError(f"Unknown catalogue type: {catalogue.catalogue_type}!")
 
         # Ensure haloes with zero stellar mass have zero stellar birth densities
         no_stellar_mass = stellar_mass <= unyt.unyt_quantity(0.0, stellar_mass.units)

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -905,9 +905,8 @@ def register_iron_to_hydrogen(self, catalogue, aperture_sizes, fe_solar_abundanc
         )
         # Fetch linear Fe (from SNIa) over H times stellar mass computed in apertures. The
         # mass ratio between Fe and H has already been accounted for.
-        lin_FeSNIa_over_H_times_star_mass = getattr(
-            catalogue.lin_element_ratios_times_masses,
-            f"lin_FeSNIa_over_H_times_star_mass_{aperture_size}_kpc",
+        lin_FeSNIa_over_H_times_star_mass = catalogue.get_quantity(
+            f"lin_element_ratios_times_masses.lin_FeSNIa_over_H_times_star_mass_{aperture_size}_kpc"
         )
         # Fetch stellar mass in apertures
         star_mass = catalogue.get_quantity(f"apertures.mass_star_{aperture_size}_kpc")

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -47,7 +47,7 @@ solar_fe_abundance = 2.82e-5
 stellar_mass_scatter_amplitude = 0.3
 
 
-def register_spesific_star_formation_rates(self, catalogue, aperture_sizes):
+def register_specific_star_formation_rates(self, catalogue, aperture_sizes):
 
     # Lowest sSFR below which the galaxy is considered passive
     marginal_ssfr = unyt.unyt_quantity(1e-11, units=1 / unyt.year)
@@ -71,12 +71,10 @@ def register_spesific_star_formation_rates(self, catalogue, aperture_sizes):
         )
 
         # Compute specific star formation rate using the "good" stellar mass
-        ssfr = unyt.unyt_array(
-            np.zeros(len(star_formation_rate)), units=star_formation_rate.units
-        )
+        ssfr = unyt.unyt_array(np.zeros(len(star_formation_rate)), units=1 / unyt.year)
         ssfr[good_stellar_mass] = (
             star_formation_rate[good_stellar_mass] / stellar_mass[good_stellar_mass]
-        )
+        ).to(ssfr.units)
 
         # Name (label) of the derived field
         ssfr.name = f"Specific SFR ({aperture_size} kpc)"
@@ -1350,7 +1348,7 @@ def register_SNIa_rates(self, catalogue, aperture_sizes):
 
 # Register derived fields
 register_SNIa_rates(self, catalogue, aperture_sizes_30_50_100_kpc)
-register_spesific_star_formation_rates(self, catalogue, aperture_sizes_30_50_100_kpc)
+register_specific_star_formation_rates(self, catalogue, aperture_sizes_30_50_100_kpc)
 register_star_metallicities(
     self, catalogue, aperture_sizes_30_50_100_kpc, solar_metal_mass_fraction
 )


### PR DESCRIPTION
This PR includes the changes to the pipeline that are necessary to run on a SOAP catalogue instead of a VR catalogue. All changes affect the registration functions, where you have to use the general `catalogue.get_quantity()` function rather than attributes of the catalogue to access variables. Everything else (i.e. the autoplotter) works as before.

This PR also includes some fixes for warnings that triggered, mostly because of division by zero.

This PR requires https://github.com/SWIFTSIM/velociraptor-python/pull/95, since it uses the new VR catalogue interface introduced there.