### PR TITLE
Add galaxy stellar mass function plots showing only calibration data

### DIFF
--- a/colibre/auto_plotter/mass_functions.yml
+++ b/colibre/auto_plotter/mass_functions.yml
@@ -147,6 +147,27 @@ stellar_mass_function_50:
     - filename: GalaxyStellarMassFunction/Schaye2015_100_50kpc.hdf5
     - filename: GalaxyStellarMassFunction/Thorne2021.hdf5
 
+stellar_mass_function_50_calibration:
+  type: "massfunction"
+  legend_loc: "lower left"
+  number_of_bins: 30
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 1e0
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture)
+    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex. Only Leja et al. (2020) and Driver et al. (2021) data are shown.
+    section: Stellar Mass Function
+  observational_data:
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+    - filename: GalaxyStellarMassFunction/Driver2021.hdf5
+
 adaptive_stellar_mass_function_50:
   type: "adaptivemassfunction"
   legend_loc: "lower left"
@@ -174,6 +195,27 @@ adaptive_stellar_mass_function_50:
     - filename: GalaxyStellarMassFunction/FIREbox.hdf5
     - filename: GalaxyStellarMassFunction/Schaye2015_100_50kpc.hdf5
     - filename: GalaxyStellarMassFunction/Thorne2021.hdf5
+
+adaptive_stellar_mass_function_50_calibration:
+  type: "adaptivemassfunction"
+  legend_loc: "lower left"
+  number_of_bins: 30
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 1e0
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture, adaptive)
+    caption: 50 kpc aperture GSMF, showing all galaxies with an adaptive bin-width. Only Leja et al. (2020) and Driver et al. (2021) data are shown.
+    section: Stellar Mass Function
+  observational_data:
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+    - filename: GalaxyStellarMassFunction/Driver2021.hdf5
 
 adaptive_stellar_mass_function_50_box_size_correction:
   type: "adaptivemassfunction"
@@ -203,6 +245,29 @@ adaptive_stellar_mass_function_50_box_size_correction:
     - filename: GalaxyStellarMassFunction/FIREbox.hdf5
     - filename: GalaxyStellarMassFunction/Schaye2015_100_50kpc.hdf5
     - filename: GalaxyStellarMassFunction/Thorne2021.hdf5
+
+adaptive_stellar_mass_function_50_box_size_correction_calibration:
+  type: "adaptivemassfunction"
+  legend_loc: "lower left"
+  number_of_bins: 30
+  box_size_correction: box_size_correction_25_to_50.yml
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 1e0
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture, adaptive, 25->50 Mpc box size correction)
+    caption: 50 kpc aperture GSMF, showing all galaxies with an adaptive bin-width. The data have been corrected to a box size of 50 Mpc, assuming the original simulation used a 25 Mpc box. Only Leja et al. (2020) and Driver et al. (2021) data are shown.
+    section: Stellar Mass Function
+  observational_data:
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+    - filename: GalaxyStellarMassFunction/Driver2021.hdf5
+
 
 adaptive_stellar_mass_function_passive_only_50:
   type: "massfunction"
@@ -294,6 +359,27 @@ stellar_mass_function_with_scatter_50:
     - filename: GalaxyStellarMassFunction/Schaye2015_100_50kpc.hdf5
     - filename: GalaxyStellarMassFunction/Thorne2021.hdf5
 
+stellar_mass_function_with_scatter_50_calibration:
+  type: "massfunction"
+  legend_loc: "lower left"
+  number_of_bins: 30
+  x:
+    quantity: "derived_quantities.mass_star_with_scatter_50_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 1e0
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture, with scatter)
+    caption: 50 kpc aperture GSMF, showing all galaxies with a fixed bin-width of 0.2 dex, with an additional 0.3 dex log-normal scatter in the stellar mass. Only Leja et al. (2020) and Driver et al. (2021) data are shown.
+    section: Stellar Mass Function
+  observational_data:
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+    - filename: GalaxyStellarMassFunction/Driver2021.hdf5
+
 adaptive_stellar_mass_function_with_scatter_50:
   type: "adaptivemassfunction"
   legend_loc: "lower left"
@@ -322,3 +408,24 @@ adaptive_stellar_mass_function_with_scatter_50:
     - filename: GalaxyStellarMassFunction/FIREbox.hdf5
     - filename: GalaxyStellarMassFunction/Schaye2015_100_50kpc.hdf5
     - filename: GalaxyStellarMassFunction/Thorne2021.hdf5
+
+adaptive_stellar_mass_function_with_scatter_50_calibration:
+  type: "adaptivemassfunction"
+  legend_loc: "lower left"
+  number_of_bins: 30
+  x:
+    quantity: "derived_quantities.mass_star_with_scatter_50_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 1e0
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture, adaptive, with scatter)
+    caption: 50 kpc aperture GSMF, showing all galaxies with an adaptive bin-width, with an additional 0.3 dex log-normal scatter in the stellar mass. Only Leja et al. (2020) and Driver et al. (2021) data are shown.
+    section: Stellar Mass Function
+  observational_data:
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+    - filename: GalaxyStellarMassFunction/Driver2021.hdf5


### PR DESCRIPTION
**Motivation for this PR:**
In the current GSMF plots, we have a great deal of comparison data. It is very useful to have all of them in order to better know and see where we are compared to other research groups. 

However, for calibration purposes, we only need the data we calibrate to. Having too many different curves in the same plot makes it more difficult for us to see how close we are relative to the calibration data.

After this PR, we will have two sets of GSMF plots: one with many curves showing comparison data, and the other showing only the calibration data (Driver 2021 for z \approx 0, and Leja for high z).

![stellar_mass_function_50](https://user-images.githubusercontent.com/20153933/214608559-a1f58091-51cb-4825-bbcb-106d2369a169.png)
![stellar_mass_function_50_calibration](https://user-images.githubusercontent.com/20153933/214608571-1d5b9521-fa98-4f8d-b12a-2bf85230e20e.png)
