### PR TITLE
Extend halo-mass range in black hole mass vs. halo mass plot

### DIFF
--- a/colibre/auto_plotter/black_holes.yml
+++ b/colibre/auto_plotter/black_holes.yml
@@ -212,7 +212,7 @@ halo_mass_black_hole_mass:
     quantity: "masses.mass_200crit"
     units: Solar_Mass
     start: 1e8
-    end: 1e13
+    end: 1e15
   y:
     quantity: "black_hole_masses.max"
     units: Solar_Mass
@@ -222,12 +222,12 @@ halo_mass_black_hole_mass:
     plot: true
     log: true
     adaptive: true
-    number_of_bins: 25
+    number_of_bins: 35
     start:
       value: 1e8
       units: Solar_Mass
     end:
-      value: 1e13
+      value: 1e15
       units: Solar_Mass
   metadata:
     title: Halo Mass-Black Hole Mass relation


### PR DESCRIPTION
This change is needed for large boxes:

**Before the change**

![before_halo_mass](https://user-images.githubusercontent.com/20153933/221426199-e8dbbead-1a41-43b4-8618-3de0a0d74147.png)

**After the change**

![after_halo_mass](https://user-images.githubusercontent.com/20153933/221426206-a602dc5f-15a2-4ade-a912-9f2c65f0c87d.png)
