### PR TITLE
WIP Update the SNIa rate plots in the pipeline

### DIFF
--- a/colibre/auto_plotter/snia_rates.yml
+++ b/colibre/auto_plotter/snia_rates.yml
@@ -1,110 +1,3 @@
-stellar_mass_snia_rates_50:
-  type: "scatter"
-  legend_loc: "upper left"
-  x:
-    quantity: "apertures.mass_star_50_kpc"
-    units: Solar_Mass
-    start: 1e6
-    end: 1e12
-  y:
-    quantity: "snia_rates.snia_rates_50_kpc"
-    units: "1/year"
-    start: 3e-8
-    end: 1e-1
-  mean:
-    plot: true
-    log: true
-    adaptive: true
-    number_of_bins: 30
-    start:
-      value: 1e6
-      units: Solar_Mass
-    end:
-      value: 1e12
-      units: Solar_Mass
-  metadata:
-    title: Stellar Mass-SNIa rate relation (50 kpc aperture)
-    caption: Uses a 50 kpc 3D aperture.
-    section: SNIa Rate (Stellar Mass)
-  observational_data_bracket_width: 10.0
-  observational_data:
-    - filename: GalaxyStellarMassSNIaRate/Kistler2014.hdf5
-    - filename: GalaxyStellarMassSNIaRate/Graur2015.hdf5
-    - filename: GalaxyStellarMassSNIaRate/Graur2017.hdf5
-    - filename: GalaxyStellarMassSNIaRate/Wiseman2021.hdf5
-
-stellar_mass_snia_rates_active_only_50:
-  type: "scatter"
-  comment: "Active only"
-  comment_loc: "lower left"
-  legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_active_50_kpc"
-  x:
-    quantity: "apertures.mass_star_50_kpc"
-    units: Solar_Mass
-    start: 1e6
-    end: 1e12
-  y:
-    quantity: "snia_rates.snia_rates_50_kpc"
-    units: "1/year"
-    start: 3e-8
-    end: 1e-1
-  mean:
-    plot: true
-    log: true
-    adaptive: true
-    number_of_bins: 30
-    start:
-      value: 1e6
-      units: Solar_Mass
-    end:
-      value: 1e12
-      units: Solar_Mass
-  metadata:
-    title: Stellar Mass-SNIa rate relation (active only, 50 kpc aperture)
-    caption: Uses a 50 kpc 3D aperture and only active galaxies.
-    section: SNIa Rate (Stellar Mass)
-  observational_data:
-    - filename: GalaxyStellarMassSNIaRate/Smith2012_active.hdf5
-    - filename: GalaxyStellarMassSNIaRate/Graur2015_active.hdf5
-    - filename: GalaxyStellarMassSNIaRate/Graur2017_active.hdf5
-
-stellar_mass_snia_rates_passive_only_50:
-  type: "scatter"
-  comment: "Passive only"
-  comment_loc: "lower left"
-  legend_loc: "upper left"
-  selection_mask: "derived_quantities.is_passive_50_kpc"
-  x:
-    quantity: "apertures.mass_star_50_kpc"
-    units: Solar_Mass
-    start: 1e6
-    end: 1e12
-  y:
-    quantity: "snia_rates.snia_rates_50_kpc"
-    units: "1/year"
-    start: 3e-8
-    end: 1e-1
-  mean:
-    plot: true
-    log: true
-    adaptive: true
-    number_of_bins: 30
-    start:
-      value: 1e6
-      units: Solar_Mass
-    end:
-      value: 1e12
-      units: Solar_Mass
-  metadata:
-    title: Stellar Mass-SNIa rate relation (passive only, 50 kpc aperture)
-    caption: Uses a 50 kpc 3D aperture and only passive galaxies.
-    section: SNIa Rate (Stellar Mass)
-  observational_data:
-    - filename: GalaxyStellarMassSNIaRate/Smith2012_passive.hdf5
-    - filename: GalaxyStellarMassSNIaRate/Graur2015_passive.hdf5
-    - filename: GalaxyStellarMassSNIaRate/Graur2017_passive.hdf5
-
 stellar_mass_snia_rates_per_stellar_mass_50:
   type: "scatter"
   legend_loc: "upper left"
@@ -212,6 +105,113 @@ stellar_mass_snia_rates_per_stellar_mass_passive_only_50:
     - filename: GalaxyStellarMassSNIaRatePerStellarMass/Graur2015_passive.hdf5
     - filename: GalaxyStellarMassSNIaRatePerStellarMass/Graur2017_passive.hdf5
 
+stellar_mass_snia_rates_50:
+  type: "scatter"
+  legend_loc: "upper left"
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    quantity: "snia_rates.snia_rates_50_kpc"
+    units: "1/year"
+    start: 3e-8
+    end: 1e-1
+  mean:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-SNIa rate relation (50 kpc aperture)
+    caption: Uses a 50 kpc 3D aperture.
+    section: SNIa Rate (Stellar Mass)
+  observational_data_bracket_width: 10.0
+  observational_data:
+    - filename: GalaxyStellarMassSNIaRate/Kistler2014.hdf5
+    - filename: GalaxyStellarMassSNIaRate/Graur2015.hdf5
+    - filename: GalaxyStellarMassSNIaRate/Graur2017.hdf5
+    - filename: GalaxyStellarMassSNIaRate/Wiseman2021.hdf5
+
+stellar_mass_snia_rates_active_only_50:
+  type: "scatter"
+  comment: "Active only"
+  comment_loc: "lower left"
+  legend_loc: "upper left"
+  selection_mask: "derived_quantities.is_active_50_kpc"
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    quantity: "snia_rates.snia_rates_50_kpc"
+    units: "1/year"
+    start: 3e-8
+    end: 1e-1
+  mean:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-SNIa rate relation (active only, 50 kpc aperture)
+    caption: Uses a 50 kpc 3D aperture and only active galaxies.
+    section: SNIa Rate (Stellar Mass)
+  observational_data:
+    - filename: GalaxyStellarMassSNIaRate/Smith2012_active.hdf5
+    - filename: GalaxyStellarMassSNIaRate/Graur2015_active.hdf5
+    - filename: GalaxyStellarMassSNIaRate/Graur2017_active.hdf5
+
+stellar_mass_snia_rates_passive_only_50:
+  type: "scatter"
+  comment: "Passive only"
+  comment_loc: "lower left"
+  legend_loc: "upper left"
+  selection_mask: "derived_quantities.is_passive_50_kpc"
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    quantity: "snia_rates.snia_rates_50_kpc"
+    units: "1/year"
+    start: 3e-8
+    end: 1e-1
+  mean:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: Solar_Mass
+    end:
+      value: 1e12
+      units: Solar_Mass
+  metadata:
+    title: Stellar Mass-SNIa rate relation (passive only, 50 kpc aperture)
+    caption: Uses a 50 kpc 3D aperture and only passive galaxies.
+    section: SNIa Rate (Stellar Mass)
+  observational_data:
+    - filename: GalaxyStellarMassSNIaRate/Smith2012_passive.hdf5
+    - filename: GalaxyStellarMassSNIaRate/Graur2015_passive.hdf5
+    - filename: GalaxyStellarMassSNIaRate/Graur2017_passive.hdf5
+
 gas_metallicity_snia_rates_per_stellar_mass_active_only_50:
   comment: "$M_\\star > 10^{10}$ $M_\\odot$ and active only"
   comment_loc: "lower left"
@@ -282,6 +282,41 @@ gas_metallicity_snia_rates_per_stellar_mass_active_only_50_Mstar5e10:
   observational_data:
     - filename: GalaxyGasMetallicitySNIaRatePerStellarMass/Graur2017.hdf5
 
+star_formation_rates_snia_rates_50:
+  comment: "$M_\\star > 10^{10}$ $M_\\odot$"
+  comment_loc: "lower left"
+  type: "scatter"
+  legend_loc: "upper left"
+  selection_mask: "derived_quantities.stellar_mass_is_bigger_than_1e10_msun_50_kpc"
+  x:
+    quantity: "apertures.sfr_gas_50_kpc"
+    units: "Solar_Mass/year"
+    start: 1e-3
+    end: 1e2
+  y:
+    quantity: "snia_rates.snia_rates_50_kpc"
+    units: "1/year"
+    start: 1e-6
+    end: 1e-1
+  mean:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e-3
+      units: "Solar_Mass/year"
+    end:
+      value: 1e2
+      units: "Solar_Mass/year"
+  metadata:
+    title: SFR-SNIa rate relation (50 kpc aperture)
+    caption: Uses a 50 kpc 3D aperture, only select galaxies with a stellar mass above 1e10 Msun.
+    section: SNIa Rate (SFR and sSFR)
+  observational_data:
+    - filename: StarFormationRateSNIaRate/Sullivan2006.hdf5
+    - filename: StarFormationRateSNIaRate/Smith2012.hdf5
+
 star_formation_rates_snia_rates_per_stellar_mass_50:
   comment: "$M_\\star > 10^{10}$ $M_\\odot$"
   comment_loc: "lower left"
@@ -317,17 +352,17 @@ star_formation_rates_snia_rates_per_stellar_mass_50:
     - filename: StarFormationRateSNIaRatePerStellarMass/Graur2015.hdf5
     - filename: StarFormationRateSNIaRatePerStellarMass/Graur2017.hdf5
 
-star_formation_rates_snia_rates_per_stellar_mass_50_Mstar5e10:
-  comment: "$M_\\star > 5 \\times 10^{10}$ $M_\\odot$"
+specific_star_formation_rates_snia_rates_per_stellar_mass_50:
+  comment: "$M_\\star > 10^{10}$ $M_\\odot$"
   comment_loc: "lower left"
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.stellar_mass_is_bigger_than_5e10_msun_50_kpc"
+  selection_mask: "derived_quantities.stellar_mass_is_bigger_than_1e10_msun_50_kpc"
   x:
-    quantity: "apertures.sfr_gas_50_kpc"
-    units: "Solar_Mass/year"
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
+    units: "1/gigayear"
     start: 1e-3
-    end: 1e2
+    end: 1e1
   y:
     quantity: "derived_quantities.snia_rate_per_stellar_mass_50_kpc"
     units: "1/year/Solar_Mass"
@@ -339,53 +374,21 @@ star_formation_rates_snia_rates_per_stellar_mass_50_Mstar5e10:
     adaptive: true
     number_of_bins: 30
     start:
-      value: 1e-3
-      units: "Solar_Mass/year"
+      value: 1e-4
+      units: "1/gigayear"
     end:
-      value: 1e2
-      units: "Solar_Mass/year"
+      value: 1e1
+      units: "1/gigayear"
   metadata:
-    title: SFR-SNIa rate per stellar mass relation (50 kpc aperture)
-    caption: Uses a 50 kpc 3D aperture, only select galaxies with a stellar mass above 5e10 Msun.
-    section: SNIa Rate (SFR and sSFR)
-  observational_data:
-    - filename: StarFormationRateSNIaRatePerStellarMass/Graur2015.hdf5
-    - filename: StarFormationRateSNIaRatePerStellarMass/Graur2017.hdf5
-
-star_formation_rates_snia_rates_50:
-  comment: "$M_\\star > 10^{10}$ $M_\\odot$"
-  comment_loc: "lower left"
-  type: "scatter"
-  legend_loc: "upper left"
-  selection_mask: "derived_quantities.stellar_mass_is_bigger_than_1e10_msun_50_kpc"
-  x:
-    quantity: "apertures.sfr_gas_50_kpc"
-    units: "Solar_Mass/year"
-    start: 1e-3
-    end: 1e2
-  y:
-    quantity: "snia_rates.snia_rates_50_kpc"
-    units: "1/year"
-    start: 1e-6
-    end: 1e-1
-  mean:
-    plot: true
-    log: true
-    adaptive: true
-    number_of_bins: 30
-    start:
-      value: 1e-3
-      units: "Solar_Mass/year"
-    end:
-      value: 1e2
-      units: "Solar_Mass/year"
-  metadata:
-    title: SFR-SNIa rate relation (50 kpc aperture)
+    title: sSFR-SNIa rate per stellar mass relation (50 kpc aperture)
     caption: Uses a 50 kpc 3D aperture, only select galaxies with a stellar mass above 1e10 Msun.
     section: SNIa Rate (SFR and sSFR)
   observational_data:
-    - filename: StarFormationRateSNIaRate/Sullivan2006.hdf5
-    - filename: StarFormationRateSNIaRate/Smith2012.hdf5
+    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Mannucci2005.hdf5
+    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Sullivan2006.hdf5
+    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Smith2012.hdf5
+    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Graur2015.hdf5
+    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Graur2017.hdf5
 
 star_formation_rates_snia_rates_50_Mstar5e10:
   comment: "$M_\\star > 5 \\times 10^{10}$ $M_\\odot$"
@@ -422,17 +425,17 @@ star_formation_rates_snia_rates_50_Mstar5e10:
     - filename: StarFormationRateSNIaRate/Sullivan2006.hdf5
     - filename: StarFormationRateSNIaRate/Smith2012.hdf5
 
-specific_star_formation_rates_snia_rates_per_stellar_mass_50:
-  comment: "$M_\\star > 10^{10}$ $M_\\odot$"
+star_formation_rates_snia_rates_per_stellar_mass_50_Mstar5e10:
+  comment: "$M_\\star > 5 \\times 10^{10}$ $M_\\odot$"
   comment_loc: "lower left"
   type: "scatter"
   legend_loc: "upper left"
-  selection_mask: "derived_quantities.stellar_mass_is_bigger_than_1e10_msun_50_kpc"
+  selection_mask: "derived_quantities.stellar_mass_is_bigger_than_5e10_msun_50_kpc"
   x:
-    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
-    units: "1/gigayear"
+    quantity: "apertures.sfr_gas_50_kpc"
+    units: "Solar_Mass/year"
     start: 1e-3
-    end: 1e1
+    end: 1e2
   y:
     quantity: "derived_quantities.snia_rate_per_stellar_mass_50_kpc"
     units: "1/year/Solar_Mass"
@@ -445,20 +448,17 @@ specific_star_formation_rates_snia_rates_per_stellar_mass_50:
     number_of_bins: 30
     start:
       value: 1e-3
-      units: "1/gigayear"
+      units: "Solar_Mass/year"
     end:
-      value: 1e1
-      units: "1/gigayear"
+      value: 1e2
+      units: "Solar_Mass/year"
   metadata:
-    title: sSFR-SNIa rate per stellar mass relation (50 kpc aperture)
-    caption: Uses a 50 kpc 3D aperture, only select galaxies with a stellar mass above 1e10 Msun.
+    title: SFR-SNIa rate per stellar mass relation (50 kpc aperture)
+    caption: Uses a 50 kpc 3D aperture, only select galaxies with a stellar mass above 5e10 Msun.
     section: SNIa Rate (SFR and sSFR)
   observational_data:
-    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Mannucci2005.hdf5
-    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Sullivan2006.hdf5
-    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Smith2012.hdf5
-    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Graur2015.hdf5
-    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Graur2017.hdf5
+    - filename: StarFormationRateSNIaRatePerStellarMass/Graur2015.hdf5
+    - filename: StarFormationRateSNIaRatePerStellarMass/Graur2017.hdf5
 
 specific_star_formation_rates_snia_rates_per_stellar_mass_50_Mstar5e10:
   comment: "$M_\\star > 5 \\times 10^{10}$ $M_\\odot$"
@@ -482,7 +482,7 @@ specific_star_formation_rates_snia_rates_per_stellar_mass_50_Mstar5e10:
     adaptive: true
     number_of_bins: 30
     start:
-      value: 1e-3
+      value: 1e-4
       units: "1/gigayear"
     end:
       value: 1e1

--- a/colibre/auto_plotter/snia_rates.yml
+++ b/colibre/auto_plotter/snia_rates.yml
@@ -31,6 +31,8 @@ stellar_mass_snia_rates_per_stellar_mass_50:
     - filename: GalaxyStellarMassSNIaRatePerStellarMass/Kistler2014.hdf5
     - filename: GalaxyStellarMassSNIaRatePerStellarMass/Graur2015.hdf5
     - filename: GalaxyStellarMassSNIaRatePerStellarMass/Graur2017.hdf5
+    - filename: GalaxyStellarMassSNIaRatePerStellarMass/Brown2019_vol_limited.hdf5
+    - filename: GalaxyStellarMassSNIaRatePerStellarMass/Brown2019_full.hdf5
     - filename: GalaxyStellarMassSNIaRatePerStellarMass/Wiseman2021.hdf5
 
 stellar_mass_snia_rates_per_stellar_mass_active_only_50:

--- a/colibre/auto_plotter/snia_rates.yml
+++ b/colibre/auto_plotter/snia_rates.yml
@@ -25,7 +25,7 @@ stellar_mass_snia_rates_50:
   metadata:
     title: Stellar Mass-SNIa rate relation (50 kpc aperture)
     caption: Uses a 50 kpc 3D aperture.
-    section: SNIa Rate
+    section: SNIa Rate (Stellar Mass)
   observational_data_bracket_width: 10.0
   observational_data:
     - filename: GalaxyStellarMassSNIaRate/Kistler2014.hdf5
@@ -63,7 +63,7 @@ stellar_mass_snia_rates_active_only_50:
   metadata:
     title: Stellar Mass-SNIa rate relation (active only, 50 kpc aperture)
     caption: Uses a 50 kpc 3D aperture and only active galaxies.
-    section: SNIa Rate
+    section: SNIa Rate (Stellar Mass)
   observational_data:
     - filename: GalaxyStellarMassSNIaRate/Smith2012_active.hdf5
     - filename: GalaxyStellarMassSNIaRate/Graur2015_active.hdf5
@@ -99,7 +99,7 @@ stellar_mass_snia_rates_passive_only_50:
   metadata:
     title: Stellar Mass-SNIa rate relation (passive only, 50 kpc aperture)
     caption: Uses a 50 kpc 3D aperture and only passive galaxies.
-    section: SNIa Rate
+    section: SNIa Rate (Stellar Mass)
   observational_data:
     - filename: GalaxyStellarMassSNIaRate/Smith2012_passive.hdf5
     - filename: GalaxyStellarMassSNIaRate/Graur2015_passive.hdf5
@@ -132,7 +132,7 @@ stellar_mass_snia_rates_per_stellar_mass_50:
   metadata:
     title: Stellar Mass-SNIa rate per stellar mass relation (50 kpc aperture)
     caption: Uses a 50 kpc 3D aperture.
-    section: SNIa Rate
+    section: SNIa Rate (Stellar Mass)
   observational_data_bracket_width: 10.0
   observational_data:
     - filename: GalaxyStellarMassSNIaRatePerStellarMass/Kistler2014.hdf5
@@ -170,7 +170,7 @@ stellar_mass_snia_rates_per_stellar_mass_active_only_50:
   metadata:
     title: Stellar Mass-SNIa rate per stellar mass relation (active only, 50 kpc aperture)
     caption: Uses a 50 kpc 3D aperture.
-    section: SNIa Rate
+    section: SNIa Rate (Stellar Mass)
   observational_data:
     - filename: GalaxyStellarMassSNIaRatePerStellarMass/Smith2012_active.hdf5
     - filename: GalaxyStellarMassSNIaRatePerStellarMass/Graur2015_active.hdf5
@@ -206,7 +206,7 @@ stellar_mass_snia_rates_per_stellar_mass_passive_only_50:
   metadata:
     title: Stellar Mass-SNIa rate per stellar mass relation (passive only, 50 kpc aperture)
     caption: Uses a 50 kpc 3D aperture.
-    section: SNIa Rate
+    section: SNIa Rate (Stellar Mass)
   observational_data:
     - filename: GalaxyStellarMassSNIaRatePerStellarMass/Smith2012_passive.hdf5
     - filename: GalaxyStellarMassSNIaRatePerStellarMass/Graur2015_passive.hdf5
@@ -243,7 +243,7 @@ gas_metallicity_snia_rates_per_stellar_mass_active_only_50:
   metadata:
     title: Gas metallicity-SNIa rate per stellar mass relation (active only, 50 kpc aperture)
     caption: Uses a 50 kpc 3D aperture, active galaxies only with a stellar mass above 1e10 Msun.
-    section: SNIa Rate
+    section: SNIa Rate (Gas Metallicity)
   observational_data:
     - filename: GalaxyGasMetallicitySNIaRatePerStellarMass/Graur2017.hdf5
 
@@ -278,7 +278,7 @@ gas_metallicity_snia_rates_per_stellar_mass_active_only_50_Mstar5e10:
   metadata:
     title: Gas metallicity-SNIa rate per stellar mass relation (active only, 50 kpc aperture)
     caption: Uses a 50 kpc 3D aperture, active galaxies only with a stellar mass above 5e10 Msun.
-    section: SNIa Rate
+    section: SNIa Rate (Gas Metallicity)
   observational_data:
     - filename: GalaxyGasMetallicitySNIaRatePerStellarMass/Graur2017.hdf5
 
@@ -312,7 +312,7 @@ star_formation_rates_snia_rates_per_stellar_mass_50:
   metadata:
     title: SFR-SNIa rate per stellar mass relation (50 kpc aperture)
     caption: Uses a 50 kpc 3D aperture, only select galaxies with a stellar mass above 1e10 Msun.
-    section: SNIa Rate
+    section: SNIa Rate (SFR and sSFR)
   observational_data:
     - filename: StarFormationRateSNIaRatePerStellarMass/Graur2015.hdf5
     - filename: StarFormationRateSNIaRatePerStellarMass/Graur2017.hdf5
@@ -347,14 +347,17 @@ star_formation_rates_snia_rates_per_stellar_mass_50_Mstar5e10:
   metadata:
     title: SFR-SNIa rate per stellar mass relation (50 kpc aperture)
     caption: Uses a 50 kpc 3D aperture, only select galaxies with a stellar mass above 5e10 Msun.
-    section: SNIa Rate
+    section: SNIa Rate (SFR and sSFR)
   observational_data:
     - filename: StarFormationRateSNIaRatePerStellarMass/Graur2015.hdf5
     - filename: StarFormationRateSNIaRatePerStellarMass/Graur2017.hdf5
 
 star_formation_rates_snia_rates_50:
+  comment: "$M_\\star > 10^{10}$ $M_\\odot$"
+  comment_loc: "lower left"
   type: "scatter"
   legend_loc: "upper left"
+  selection_mask: "derived_quantities.stellar_mass_is_bigger_than_1e10_msun_50_kpc"
   x:
     quantity: "apertures.sfr_gas_50_kpc"
     units: "Solar_Mass/year"
@@ -378,9 +381,45 @@ star_formation_rates_snia_rates_50:
       units: "Solar_Mass/year"
   metadata:
     title: SFR-SNIa rate relation (50 kpc aperture)
-    caption: Uses a 50 kpc 3D aperture.
-    section: SNIa Rate
+    caption: Uses a 50 kpc 3D aperture, only select galaxies with a stellar mass above 1e10 Msun.
+    section: SNIa Rate (SFR and sSFR)
   observational_data:
+    - filename: StarFormationRateSNIaRate/Sullivan2006.hdf5
+    - filename: StarFormationRateSNIaRate/Smith2012.hdf5
+
+star_formation_rates_snia_rates_50_Mstar5e10:
+  comment: "$M_\\star > 5 \\times 10^{10}$ $M_\\odot$"
+  comment_loc: "lower left"
+  type: "scatter"
+  legend_loc: "upper left"
+  selection_mask: "derived_quantities.stellar_mass_is_bigger_than_5e10_msun_50_kpc"
+  x:
+    quantity: "apertures.sfr_gas_50_kpc"
+    units: "Solar_Mass/year"
+    start: 1e-3
+    end: 1e2
+  y:
+    quantity: "snia_rates.snia_rates_50_kpc"
+    units: "1/year"
+    start: 1e-6
+    end: 1e-1
+  mean:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e-3
+      units: "Solar_Mass/year"
+    end:
+      value: 1e2
+      units: "Solar_Mass/year"
+  metadata:
+    title: SFR-SNIa rate relation (50 kpc aperture)
+    caption: Uses a 50 kpc 3D aperture, only select galaxies with a stellar mass above 1e10 Msun.
+    section: SNIa Rate (SFR and sSFR)
+  observational_data:
+    - filename: StarFormationRateSNIaRate/Sullivan2006.hdf5
     - filename: StarFormationRateSNIaRate/Smith2012.hdf5
 
 specific_star_formation_rates_snia_rates_per_stellar_mass_50:
@@ -413,8 +452,11 @@ specific_star_formation_rates_snia_rates_per_stellar_mass_50:
   metadata:
     title: sSFR-SNIa rate per stellar mass relation (50 kpc aperture)
     caption: Uses a 50 kpc 3D aperture, only select galaxies with a stellar mass above 1e10 Msun.
-    section: SNIa Rate
+    section: SNIa Rate (SFR and sSFR)
   observational_data:
+    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Mannucci2005.hdf5
+    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Sullivan2006.hdf5
+    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Smith2012.hdf5
     - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Graur2015.hdf5
     - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Graur2017.hdf5
 
@@ -448,8 +490,11 @@ specific_star_formation_rates_snia_rates_per_stellar_mass_50_Mstar5e10:
   metadata:
     title: sSFR-SNIa rate per stellar mass relation (50 kpc aperture)
     caption: Uses a 50 kpc 3D aperture, only select galaxies with a stellar mass above 5e10 Msun.
-    section: SNIa Rate
+    section: SNIa Rate (SFR and sSFR)
   observational_data:
+    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Mannucci2005.hdf5
+    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Sullivan2006.hdf5
+    - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Smith2012.hdf5
     - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Graur2015.hdf5
     - filename: SpecificStarFormationRateSNIaRatePerStellarMass/Graur2017.hdf5
 
@@ -480,7 +525,7 @@ stellar_mass_snia_rates_30:
   metadata:
     title: Stellar Mass-SNIa rate relation (50 kpc aperture)
     caption: Uses a 30 kpc 3D aperture.
-    section: SNIa Rate
+    section: SNIa Rate (Stellar Mass)
     show_on_webpage: false
   observational_data:
     - filename: GalaxyStellarMassSNIaRate/Wiseman2021.hdf5
@@ -512,7 +557,7 @@ stellar_mass_snia_rates_per_stellar_mass_30:
   metadata:
     title: Stellar Mass-SNIa rate per stellar mass relation (30 kpc aperture)
     caption: Uses a 30 kpc 3D aperture.
-    section: SNIa Rate
+    section: SNIa Rate (Stellar Mass)
     show_on_webpage: false
   observational_data:
     - filename: GalaxyStellarMassSNIaRatePerStellarMass/Wiseman2021.hdf5
@@ -546,7 +591,7 @@ stellar_mass_snia_rates_100:
   metadata:
     title: Stellar Mass-SNIa rate relation (100 kpc aperture)
     caption: Uses a 30 kpc 3D aperture.
-    section: SNIa Rate
+    section: SNIa Rate (Stellar Mass)
     show_on_webpage: false
   observational_data:
     - filename: GalaxyStellarMassSNIaRate/Wiseman2021.hdf5
@@ -578,7 +623,7 @@ stellar_mass_snia_rates_per_stellar_mass_100:
   metadata:
     title: Stellar Mass-SNIa rate per stellar mass relation (100 kpc aperture)
     caption: Uses a 30 kpc 3D aperture.
-    section: SNIa Rate
+    section: SNIa Rate (Stellar Mass)
     show_on_webpage: false
   observational_data:
     - filename: GalaxyStellarMassSNIaRatePerStellarMass/Wiseman2021.hdf5

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -20,6 +20,66 @@ description_template: description.html
 
 # Location and description of additional figures
 scripts:
+  - filename: scripts/cosmic_log_SNIa_rate_CSFH_based.py
+    title: 'Cosmic SNIa rate'
+    caption: SNIa rate history calculated from the SFR.txt file produced by SWIFT.
+    section: SN Rate (cosmic - CSFH based)
+    output_file: log_SNIa_rate_history_based_on_CSFH.png 
+  - filename: scripts/cosmic_SNIa_rate_CSFH_based.py
+    title: 'Cosmic SNIa rate'
+    caption: SNIa rate history calculated from the SFR.txt file produced by SWIFT.
+    section: SN Rate (cosmic - CSFH based)
+    output_file: SNIa_rate_history_based_on_CSFH.png 
+  - filename: scripts/cosmic_log_CC_SN_rate_CSFH_based.py
+    title: 'Cosmic CC SN rate'
+    caption: CC SN rate history calculated from the SFR.txt file produced by SWIFT.
+    section: SN Rate (cosmic - CSFH based)
+    output_file: log_CC_SN_rate_history_based_on_CSFH.png 
+  - filename: scripts/cosmic_CC_SN_rate_CSFH_based.py
+    title: 'Cosmic CC SN rate'
+    caption: CC SN rate history calculated from the SFR.txt file produced by SWIFT.
+    section: SN Rate (cosmic - CSFH based)
+    output_file: CC_SN_rate_history_based_on_CSFH.png 
+  - filename: scripts/cosmic_SNIa_over_CC_SN_rate_CSFH_based.py
+    title: 'Cosmic SNIa rate / CC SN rate'
+    caption: SNIa rate over CC SN rate history calculated from the SFR.txt file produced by SWIFT.
+    section: SN Rate (cosmic - CSFH based)
+    output_file: SNIa_over_CC_rate_history_based_on_CSFH.png 
+  - filename: scripts/cosmic_SNIa_rate.py
+    title: 'Cosmic SNIa rate'
+    caption: SNIa rate history plotted directly from the SNIa.txt file produced by SWIFT.
+    section: SN Rate (cosmic - stochastic)
+    output_file: SNIa_rate_history.png
+  - filename: scripts/cosmic_log_SNIa_rate.py
+    title: 'Cosmic SNIa rate'
+    caption: SNIa rate history plotted directly from the SNIa.txt file produced by SWIFT.
+    section: SN Rate (cosmic - stochastic)
+    output_file: log_SNIa_rate_history.png
+  - filename: scripts/cosmic_CC_SN_rate.py
+    title: 'Cosmic CC SN rate'
+    caption: CC SN rate history plotted directly from the SNII.txt file produced by SWIFT.
+    section: SN Rate (cosmic - stochastic)
+    output_file: CC_SN_rate_history.png
+  - filename: scripts/cosmic_log_CC_SN_rate.py
+    title: 'Cosmic CC SN rate'
+    caption: CC SN rate history plotted directly from the SNII.txt file produced by SWIFT.
+    section: SN Rate (cosmic - stochastic)
+    output_file: log_CC_SN_rate_history.png
+  - filename: scripts/cosmic_log_NSM_rate.py
+    title: 'Cosmic NS-NS merger rate'
+    caption: NS-NS merger rate or short GRB rate plotted directly from the r_processes.txt file produced by SWIFT.
+    section: SN Rate (cosmic - stochastic)
+    output_file: log_NSM_rate_history.png 
+  - filename: scripts/cosmic_log_CEJSN_rate.py
+    title: 'Cosmic common-envelop jets SN rate'
+    caption: Common-envelop (CE) jets SN rate plotted directly from the r_processes.txt file produced by SWIFT.
+    section: SN Rate (cosmic - stochastic)
+    output_file: log_CEJSN_rate_history.png
+  - filename: scripts/cosmic_log_collapsar_rate.py
+    title: 'Cosmic collapsar rate'
+    caption: Collapsar rate plotted directly from the r_processes.txt file produced by SWIFT.
+    section: SN Rate (cosmic - stochastic)
+    output_file: log_collapsar_rate_history.png
   - filename: scripts/density_temperature.py
     caption: Density-temperature diagram. If present, dashed line represents the entropy floor (equation of state).
     output_file: density_temperature.png
@@ -503,13 +563,3 @@ scripts:
     section: Column Densities
     additional_arguments:
       parallel: True
-  - filename: scripts/cosmic_SNIa_rate.py
-    title: 'Cosmic SNIa rate'
-    caption: SNIa rate history plotted directly from the SNIa.txt file produced by SWIFT.
-    section: SN Rate (cosmic)
-    output_file: SNIa_rate_history.png
-  - filename: scripts/cosmic_CC_SN_rate.py
-    title: 'Cosmic CC SN rate'
-    caption: CC SN rate history plotted directly from the SNII.txt file produced by SWIFT.
-    section: SN Rate (cosmic)
-    output_file: CC_SN_rate_history.png

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -506,5 +506,10 @@ scripts:
   - filename: scripts/cosmic_SNIa_rate.py
     title: 'Cosmic SNIa rate'
     caption: SNIa rate history plotted directly from the SNIa.txt file produced by SWIFT.
-    section: SNIa Rate
+    section: SN Rate (cosmic)
     output_file: SNIa_rate_history.png
+  - filename: scripts/cosmic_CC_SN_rate.py
+    title: 'Cosmic CC SN rate'
+    caption: CC SN rate history plotted directly from the SNII.txt file produced by SWIFT.
+    section: SN Rate (cosmic)
+    output_file: CC_SN_rate_history.png

--- a/colibre/description.html
+++ b/colibre/description.html
@@ -379,6 +379,99 @@
     </tr>
 </table>
 
+<h4>SNIa DTD</h4>
+{% if data.metadata.parameters.get("SNIaDTD:normalization_timescale_Gyr", False) %}
+<table>
+    <tr>
+        <th>Parameter</th>
+        <th>Value</th>
+    </tr>
+    {% if data.metadata.parameters.get("SNIaDTD:SNIa_efficiency_gauss_p_Msun", False) %}
+    <tr>
+        <td>Model</td>
+        <td>Gaussian</td>
+    </tr>
+    <tr>
+        <td>SNIa efficiency per Msun (Gaussian part)</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("SNIaDTD:SNIa_efficiency_gauss_p_Msun") }}</td>
+    </tr>
+    <tr>
+        <td>SNIa efficiency per Msun (constant part)</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("SNIaDTD:SNIa_efficiency_const_p_Msun") }}</td>
+    </tr>
+    <tr>
+        <td>SNIa delay time</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("SNIaDTD:SNIa_delay_time_Gyr") }} Gyr</td>
+    </tr>
+    <tr>
+        <td>Normalisation time scale (constant part)</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("SNIaDTD:normalization_timescale_Gyr") }} Gyr</td>
+    </tr>
+    <tr>
+        <td>Characteristic time of the Guassian</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("SNIaDTD:characteristic_time_Gyr") }} Gyr</td>
+    </tr>
+    <tr>
+        <td>Standard deviation time of the Guassian</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("SNIaDTD:STD_characteristic_time_Gyr") }} Gyr</td>
+    </tr>
+    {% else %}
+    <tr>
+        <td>Model</td>
+        <td>Power law</td>
+    </tr>
+    <tr>
+        <td>SNIa efficiency per Msun</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("SNIaDTD:SNIa_efficiency_p_Msun") }}</td>
+    </tr>
+    <tr>
+        <td>SNIa delay time</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("SNIaDTD:SNIa_delay_time_Gyr") }} Gyr</td>
+    </tr>
+    <tr>
+        <td>Normalisation time scale</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("SNIaDTD:normalization_timescale_Gyr") }} Gyr</td>
+    </tr>
+    <tr>
+        <td>power law slope</td>
+        {% if data.metadata.parameters.get("SNIaDTD:power_law_slope", False) %}
+        <td>{{ data.metadata.parameters | get_if_present_float("SNIaDTD:power_law_slope") }}</td>
+        {% else %}
+        <td>1.0</td>
+        {% endif %}
+    </tr>
+    {% endif %}
+</table>
+
+{% else %}
+{% if data.metadata.parameters.get("SNIaDTD:SNIa_timescale_Gyr", False) %}
+<table>
+    <tr>
+        <th>Parameter</th>
+        <th>Value</th>
+    </tr>
+    <tr>
+        <td>Model</td>
+        <td>exponential</td>
+    </tr>
+    <tr>
+        <td>SNIa efficiency per Msun</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("SNIaDTD:SNIa_efficiency_p_Msun") }}</td>
+    </tr>
+    <tr>
+        <td>SNIa delay time</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("SNIaDTD:SNIa_delay_time_Gyr") }} Gyr</td>
+    </tr>
+    <tr>
+        <td>exponential delay time</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("SNIaDTD:SNIa_timescale_Gyr") }} Gyr</td>
+    </tr>
+</table>
+{% else %}
+<p>DTD not found</p>
+{% endif %}
+{% endif %}
+
 <h4>AGN feedback</h4>
 {% if data.metadata.parameters.get("COLIBREAGN:AGN_delta_T_K", False) %}
 <table>

--- a/colibre/scripts/cosmic_CC_SN_rate.py
+++ b/colibre/scripts/cosmic_CC_SN_rate.py
@@ -1,0 +1,161 @@
+"""
+Plots the cosmic CCSN rate history.
+"""
+import unyt
+
+import matplotlib.pyplot as plt
+import numpy as np
+import glob
+
+from swiftsimio import load
+
+from velociraptor.observations import load_observations
+
+from astropy.cosmology import z_at_value
+from astropy.units import Gyr
+
+from swiftpipeline.argumentparser import ScriptArgumentParser
+
+arguments = ScriptArgumentParser(
+    description="Creates a CC SN rate history plot, with added observational data."
+)
+
+snapshot_filenames = [
+    f"{directory}/{snapshot}"
+    for directory, snapshot in zip(arguments.directory_list, arguments.snapshot_list)
+]
+
+CCSN_filenames = [f"{directory}/SNII.txt" for directory in arguments.directory_list]
+
+names = arguments.name_list
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+simulation_lines = []
+simulation_labels = []
+
+fig, ax = plt.subplots()
+
+ax.semilogx()
+
+log_multiplicative_factor = 4
+multiplicative_factor = 10 ** log_multiplicative_factor
+CCSN_rate_output_units = 1.0 / (unyt.yr * unyt.Mpc ** 3)
+
+for idx, (snapshot_filename, CCSN_filename, name) in enumerate(
+    zip(snapshot_filenames, CCSN_filenames, names)
+):
+    data = np.loadtxt(
+        CCSN_filename,
+        usecols=(4, 6, 11),
+        dtype=[("a", np.float32), ("z", np.float32), ("CC SN rate", np.float32)],
+    )
+
+    snapshot = load(snapshot_filename)
+
+    # Read cosmology from the first run in the list
+    if idx == 0:
+        cosmology = snapshot.metadata.cosmology
+
+    units = snapshot.units
+    CCSN_rate_units = 1.0 / (units.time * units.length ** 3)
+
+    # a, Redshift, SFR
+    scale_factor = data["a"]
+    CC_SN_rate = (data["CC SN rate"] * CC_SN_rate_units).to(CC_SN_rate_output_units)
+
+    # High z-order as we always want these to be on top of the observations
+    simulation_lines.append(
+        ax.plot(scale_factor, CCSN_rate.value * multiplicative_factor, zorder=10000)[0]
+    )
+    simulation_labels.append(name)
+
+
+observation_lines = []
+observation_labels = []
+
+path_to_obs_data = f"{arguments.config.config_directory}/{arguments.config.observational_data_directory}"
+observational_data = load_observations(
+    sorted(glob.glob(f"{path_to_obs_data}/data/CosmicCCSNRate/*.hdf5"))
+)
+
+for obs_data in observational_data:
+    observation_lines.append(
+        ax.errorbar(
+            obs_data.x.value,
+            obs_data.y.value * multiplicative_factor,
+            yerr=obs_data.y_scatter.value * multiplicative_factor,
+            label=obs_data.citation,
+            linestyle="none",
+            marker="o",
+            elinewidth=0.5,
+            markeredgecolor="none",
+            markersize=2,
+            zorder=-10,
+        )
+    )
+    observation_labels.append(f"{obs_data.citation}")
+
+redshift_ticks = np.array([0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0, 100.0])
+redshift_labels = [
+    "$0$",
+    "$0.2$",
+    "$0.5$",
+    "$1$",
+    "$2$",
+    "$3$",
+    "$5$",
+    "$10$",
+    "$20$",
+    "$50$",
+    "$100$",
+]
+a_ticks = 1.0 / (redshift_ticks + 1.0)
+
+ax.set_xticks(a_ticks)
+ax.set_xticklabels(redshift_labels)
+
+observation_legend = ax.legend(
+    observation_lines, observation_labels, markerfirst=True, loc="center right"
+)
+
+simulation_legend = ax.legend(
+    simulation_lines, simulation_labels, markerfirst=False, loc="upper right"
+)
+
+ax.add_artist(observation_legend)
+
+# Create second X-axis (to plot cosmic time alongside redshift)
+ax2 = ax.twiny()
+ax2.set_xscale("log")
+
+# Cosmic-time ticks (in Gyr) along the second X-axis
+t_ticks = np.array([0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, cosmology.age(1.0e-5).value])
+
+# To place the new ticks onto the X-axis we need to know the corresponding scale factors
+a_ticks_2axis = [
+    1.0 / (1.0 + z_at_value(cosmology.age, t_tick * Gyr)) for t_tick in t_ticks
+]
+
+# Attach the ticks to the second X-axis
+ax2.set_xticks(a_ticks_2axis)
+
+# Format the ticks' labels
+ax2.set_xticklabels(["$%2.1f$" % t_tick for t_tick in t_ticks])
+
+# Final adjustments
+ax.tick_params(axis="x", which="minor", bottom=False)
+ax2.tick_params(axis="x", which="minor", top=False)
+
+ax.set_ylim(0.0, 1.6)
+ax.set_xlim(1.02, 0.07)
+ax2.set_xlim(1.02, 0.07)
+
+ax.set_xlabel("Redshift $z$")
+ax.set_ylabel(
+    f"CC SN rate [$10^{{-{log_multiplicative_factor}}}$ yr$^{{-1}}$ cMpc$^{{-3}}$]"
+)
+ax2.set_xlabel("Cosmic time [Gyr]")
+
+fig.savefig(f"{output_path}/CC_SN_rate_history.png")

--- a/colibre/scripts/cosmic_CC_SN_rate_CSFH_based.py
+++ b/colibre/scripts/cosmic_CC_SN_rate_CSFH_based.py
@@ -1,0 +1,191 @@
+"""
+Plots the star formation history. Modified version of the script in the
+github.com/swiftsim/swiftsimio-examples repository.
+"""
+import unyt
+
+import matplotlib.pyplot as plt
+import numpy as np
+import glob
+
+from swiftsimio import load
+
+from load_sfh_data import read_obs_data
+
+from velociraptor.observations import load_observations
+
+from astropy.cosmology import z_at_value
+from astropy.units import Gyr
+
+sfr_output_units = unyt.msun / (unyt.year * unyt.Mpc ** 3)
+log_multiplicative_factor = 4
+multiplicative_factor = 10 ** log_multiplicative_factor
+SNIa_output_units = 1. / (unyt.year * unyt.Mpc ** 3)
+
+from swiftpipeline.argumentparser import ScriptArgumentParser
+
+def CC_SN_DTD(t, t_min, t_max):
+    mask = (t > t_min) & (t < t_max)
+    value = np.zeros(len(t)) / unyt.Gyr 
+    value_new = 1./(t_max - t_min) * (np.ones(len(t[mask])))
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new 
+    return value
+
+arguments = ScriptArgumentParser(
+    description="Creates a star formation history plot, with added observational data."
+)
+
+snapshot_filenames = [
+    f"{directory}/{snapshot}"
+    for directory, snapshot in zip(arguments.directory_list, arguments.snapshot_list)
+]
+
+sfr_filenames = [f"{directory}/SFR.txt" for directory in arguments.directory_list]
+
+names = arguments.name_list
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+simulation_lines = []
+simulation_labels = []
+
+fig, ax = plt.subplots()
+
+ax.set_xscale("log")
+
+for idx, (snapshot_filename, sfr_filename, name) in enumerate(
+    zip(snapshot_filenames, sfr_filenames, names)
+):
+    data = np.genfromtxt(sfr_filename).T
+
+    snapshot = load(snapshot_filename)
+
+    # Read cosmology from the first run in the list
+    if idx == 0:
+        cosmology = snapshot.metadata.cosmology
+
+    units = snapshot.units
+    boxsize = snapshot.metadata.boxsize
+    box_volume = boxsize[0] * boxsize[1] * boxsize[2]
+
+    sfr_units = snapshot.gas.star_formation_rates.units
+
+    # a, Redshift, SFR
+    scale_factor = data[2]
+    redshift = data[3]
+    star_formation_rate = (data[7] * sfr_units / box_volume).to(sfr_output_units)
+    times = data[1] * units.time 
+    dM = data[4] * units.mass
+    
+    # Calculate the times we plot
+    times_desired = np.linspace(0.05,13.8,500) * unyt.Gyr
+    scale_factors_use = np.interp(times_desired, times, scale_factor)
+
+    SNIa_rate = np.zeros(len(times_desired))
+
+    for i in range(1,len(times_desired)):
+        time_consider = times[times < times_desired[i]]
+        time_since_formation = times_desired[i] - time_consider
+        dM_consider = dM[times < times_desired[i]]
+        SNIa_rate_individual = 1.180e-2 * CC_SN_DTD(time_since_formation, 3*unyt.Myr, 0.04*unyt.Gyr) * dM_consider / unyt.Msun
+
+        SNIa_rate_sum = np.sum(SNIa_rate_individual)
+        SNIa_rate[i] = SNIa_rate_sum
+
+    SNIa_rate = (SNIa_rate / box_volume / unyt.Gyr).to(SNIa_output_units)
+
+    # High z-order as we always want these to be on top of the observations
+    simulation_lines.append(
+        ax.plot(scale_factors_use, SNIa_rate.value * multiplicative_factor, zorder=10000)[0]
+    )
+    simulation_labels.append(name)
+
+observation_lines = []
+observation_labels = []
+
+path_to_obs_data = f"{arguments.config.config_directory}/{arguments.config.observational_data_directory}"
+observational_data = load_observations(
+    sorted(glob.glob(f"{path_to_obs_data}/data/CosmicCCSNRate/*.hdf5"))
+)
+
+for obs_data in observational_data:
+    observation_lines.append(
+        ax.errorbar(
+            obs_data.x.value,
+            obs_data.y.value * multiplicative_factor,
+            yerr=obs_data.y_scatter.value * multiplicative_factor,
+            label=obs_data.citation,
+            linestyle="none",
+            marker="o",
+            elinewidth=0.5,
+            markeredgecolor="none",
+            markersize=2,
+            zorder=-10,
+            capsize=1.0,
+        )
+    )
+    observation_labels.append(f"{obs_data.citation}")
+
+
+redshift_ticks = np.array([0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0, 100.0])
+redshift_labels = [
+    "$0$",
+    "$0.2$",
+    "$0.5$",
+    "$1$",
+    "$2$",
+    "$3$",
+    "$5$",
+    "$10$",
+    "$20$",
+    "$50$",
+    "$100$",
+]
+a_ticks = 1.0 / (redshift_ticks + 1.0)
+
+ax.set_xticks(a_ticks)
+ax.set_xticklabels(redshift_labels)
+
+observation_legend = ax.legend(
+    observation_lines, observation_labels, markerfirst=True, loc=4, fontsize=4, ncol=2
+)
+
+simulation_legend = ax.legend(
+    simulation_lines, simulation_labels, markerfirst=False, loc="upper right"
+)
+
+ax.add_artist(observation_legend)
+
+# Create second X-axis (to plot cosmic time alongside redshift)
+ax2 = ax.twiny()
+ax2.set_xscale("log")
+
+# Cosmic-time ticks (in Gyr) along the second X-axis
+t_ticks = np.array([0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, cosmology.age(1.0e-5).value])
+
+# To place the new ticks onto the X-axis we need to know the corresponding scale factors
+a_ticks_2axis = [
+    1.0 / (1.0 + z_at_value(cosmology.age, t_tick * Gyr)) for t_tick in t_ticks
+]
+
+# Attach the ticks to the second X-axis
+ax2.set_xticks(a_ticks_2axis)
+
+# Format the ticks' labels
+ax2.set_xticklabels(["$%2.1f$" % t_tick for t_tick in t_ticks])
+
+# Final adjustments
+ax.tick_params(axis="x", which="minor", bottom=False)
+ax2.tick_params(axis="x", which="minor", top=False)
+
+ax.set_ylim(0, 26.0)
+ax.set_xlim(1.02, 0.07)
+ax2.set_xlim(1.02, 0.07)
+
+ax.set_xlabel("Redshift $z$")
+ax.set_ylabel(f"CC SN rate [$10^{{-{log_multiplicative_factor}}}$ yr$^{{-1}}$ cMpc$^{{-3}}$]")
+ax2.set_xlabel("Cosmic time [Gyr]")
+
+fig.savefig(f"{output_path}/CC_SN_rate_history_based_on_CSFH.png")

--- a/colibre/scripts/cosmic_SNIa_over_CC_SN_rate_CSFH_based.py
+++ b/colibre/scripts/cosmic_SNIa_over_CC_SN_rate_CSFH_based.py
@@ -1,0 +1,257 @@
+"""
+Plots the star formation history. Modified version of the script in the
+github.com/swiftsim/swiftsimio-examples repository.
+"""
+import unyt
+
+import matplotlib.pyplot as plt
+import numpy as np
+import glob
+
+from swiftsimio import load
+
+from load_sfh_data import read_obs_data
+
+from velociraptor.observations import load_observations
+
+from astropy.cosmology import z_at_value
+from astropy.units import Gyr
+
+sfr_output_units = unyt.msun / (unyt.year * unyt.Mpc ** 3)
+log_multiplicative_factor = 4
+multiplicative_factor = 10 ** log_multiplicative_factor
+SNIa_output_units = 1. / (unyt.year * unyt.Mpc ** 3)
+
+from swiftpipeline.argumentparser import ScriptArgumentParser
+
+def power_law_beta_one_DTD(t, t_delay, tH):
+    mask = t > 0.04
+    value = np.zeros(len(t)) / unyt.Gyr 
+    value_new = 1./(np.log(tH) - np.log(t_delay)) / t[mask]
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new 
+    return value
+
+def power_law_DTD(t, t_delay, tH, beta):
+    mask = t > 0.04
+    value = np.zeros(len(t)) / unyt.Gyr 
+    value_new = (1.-beta)/(tH**(1-beta) - (t_delay)**(1-beta)) / t[mask]**beta
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new 
+    return value
+
+
+def exponential_law_DTD(t, t_decay, t_delay):
+    mask = t > 0.04
+    value = np.zeros(len(t)) / unyt.Gyr
+    value_new = np.exp(-(t[mask]-t_delay)/t_decay)/t_decay
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new 
+    return value
+
+def Gaussian_law_DTD(t, t_delay, tmean, tsigma):
+    mask = t > 0.04
+    value = np.zeros(len(t)) / unyt.Gyr 
+    value_new = 1/np.sqrt(2*tsigma**2) * np.exp(-0.5*(t[mask]-tmean)**2 / (2*tsigma)**2)
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new 
+    return value
+
+def CC_SN_DTD(t, t_min, t_max):
+    mask = (t > t_min) & (t < t_max)
+    value = np.zeros(len(t)) / unyt.Gyr
+    value_new = 1./(t_max - t_min) * (np.ones(len(t[mask])))
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new
+    return value
+
+arguments = ScriptArgumentParser(
+    description="Creates a star formation history plot, with added observational data."
+)
+
+snapshot_filenames = [
+    f"{directory}/{snapshot}"
+    for directory, snapshot in zip(arguments.directory_list, arguments.snapshot_list)
+]
+
+sfr_filenames = [f"{directory}/SFR.txt" for directory in arguments.directory_list]
+
+names = arguments.name_list
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+simulation_lines = []
+simulation_labels = []
+
+fig, ax = plt.subplots()
+
+ax.set_xscale("log")
+
+
+for idx, (snapshot_filename, sfr_filename, name) in enumerate(
+    zip(snapshot_filenames, sfr_filenames, names)
+):
+    data = np.genfromtxt(sfr_filename).T
+
+    snapshot = load(snapshot_filename)
+
+    # find out which DTD model we are currently using in the code
+    normalization_timescale = snapshot.metadata.parameters.get("SNIaDTD:normalization_timescale_Gyr", None)
+    if normalization_timescale == None:
+        have_normalization_timescale = False
+    else:
+        normalization_timescale = float(normalization_timescale) * unyt.Gyr
+        have_normalization_timescale = True
+
+    exponential_decay = snapshot.metadata.parameters.get("SNIaDTD:SNIa_timescale_Gyr", None)
+    if exponential_decay == None:
+        have_exponential_decay = False
+    else:
+        have_exponential_decay = True 
+        exponential_decay = float(exponential_decay) * unyt.Gyr
+
+    Gaussian_SNIa_efficiency = snapshot.metadata.parameters.get("SNIaDTD:SNIa_efficiency_gauss_p_Msun", None)
+    if Gaussian_SNIa_efficiency == None:
+        have_Gaussian = False
+    else:
+        have_Gaussian = True
+        Gaussian_SNIa_efficiency = float(Gaussian_SNIa_efficiency) / unyt.Msun
+
+    power_law_slope = snapshot.metadata.parameters.get("SNIaDTD:power_law_slope", None) 
+    if power_law_slope == None:
+        have_slope = False 
+    else:
+        have_slope = True 
+        power_law_slope = float(power_law_slope)
+
+    if have_Gaussian:
+        used_DTD = "Gaussian"
+    elif have_slope and have_normalization_timescale:
+        used_DTD = "power-law"
+    elif have_normalization_timescale:
+        used_DTD = "power-law-beta-one"
+    else:
+        used_DTD = "exponential"
+
+    delay_time = float(snapshot.metadata.parameters.get("SNIaDTD:SNIa_delay_time_Gyr", False) ) * unyt.Gyr
+
+    if used_DTD == "power-law" or used_DTD == "exponential" or used_DTD == "power-law-beta-one":
+        SNIa_efficiency = float(snapshot.metadata.parameters.get("SNIaDTD:SNIa_efficiency_p_Msun", False) ) / unyt.Msun
+    elif used_DTD == "Gaussian":
+        Gaussian_SNIa_efficiency = float(snapshot.metadata.parameters.get("SNIaDTD:SNIa_efficiency_gauss_p_Msun", False)) / unyt.Msun
+        Gaussian_const_SNIa_efficiency = float(snapshot.metadata.parameters.get("SNIaDTD:SNIa_efficiency_const_p_Msun", False)) / unyt.Msun
+        Gaussian_characteristic_time = float(snapshot.metadata.parameters.get("SNIaDTD:characteristic_time_Gyr", False)) * unyt.Gyr
+        Gaussian_std_time = float(snapshot.metadata.parameters.get("SNIaDTD:STD_characteristic_time_Gyr", False)) * unyt.Gyr
+        
+    # Read cosmology from the first run in the list
+    if idx == 0:
+        cosmology = snapshot.metadata.cosmology
+
+    units = snapshot.units
+    boxsize = snapshot.metadata.boxsize
+    box_volume = boxsize[0] * boxsize[1] * boxsize[2]
+
+    sfr_units = snapshot.gas.star_formation_rates.units
+
+    # a, Redshift, SFR
+    scale_factor = data[2]
+    redshift = data[3]
+    star_formation_rate = (data[7] * sfr_units / box_volume).to(sfr_output_units)
+    times = data[1] * units.time 
+    dM = data[4] * units.mass
+    
+    # Calculate the times we plot
+    times_desired = np.linspace(0.05,13.8,500) * unyt.Gyr
+    scale_factors_use = np.interp(times_desired, times, scale_factor)
+
+    SNIa_rate = np.zeros(len(times_desired))
+    CC_SN_rate = np.zeros(len(times_desired))
+
+    for i in range(1,len(times_desired)):
+        time_consider = times[times < times_desired[i]]
+        time_since_formation = times_desired[i] - time_consider
+        dM_consider = dM[times < times_desired[i]]
+        #SNIa_rate_individual = 1.6e-3 * exponential_law_DTD(time_since_formation, 2.0, 0.04) * dM_consider
+        #SNIa_rate_individual = 1.6e-3 * power_law_beta_one_DTD(time_since_formation, 0.04, 13.6) * dM_consider
+        if used_DTD == "power-law":
+            SNIa_rate_individual = SNIa_efficiency * power_law_DTD(time_since_formation, delay_time, normalization_timescale,power_law_slope) * dM_consider
+        elif used_DTD == "power-law-beta-one":
+            SNIa_rate_individual = SNIa_efficiency * power_law_beta_one_DTD(time_since_formation, delay_time, normalization_timescale) * dM_consider
+        elif used_DTD == "exponential":
+            SNIa_rate_individual = SNIa_efficiency * exponential_law_DTD(time_since_formation, exponential_decay, delay_time) * dM_consider
+        elif used_DTD == "Gaussian":
+            SNIa_rate_individual = Gaussian_SNIa_efficiency * Gaussian_law_DTD(time_since_formation, delay_time, Gaussian_characteristic_time, Gaussian_std_time) * dM_consider
+
+        SNIa_rate_sum = np.sum(SNIa_rate_individual)
+        SNIa_rate[i] = SNIa_rate_sum
+
+        CC_SN_rate_individual = 1.180e-2 * CC_SN_DTD(time_since_formation, 3*unyt.Myr, 0.04*unyt.Gyr) * dM_consider / unyt.Msun
+
+        CC_SN_rate_sum = np.sum(CC_SN_rate_individual)
+        CC_SN_rate[i] = CC_SN_rate_sum
+
+
+    SNIa_rate = (SNIa_rate / box_volume / unyt.Gyr).to(SNIa_output_units)
+    CC_SN_rate = (CC_SN_rate / box_volume / unyt.Gyr).to(SNIa_output_units)
+
+    # High z-order as we always want these to be on top of the observations
+    simulation_lines.append(
+        ax.plot(scale_factors_use, SNIa_rate.value / CC_SN_rate.value, zorder=10000)[0]
+    )
+    simulation_labels.append(name)
+
+redshift_ticks = np.array([0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0, 100.0])
+redshift_labels = [
+    "$0$",
+    "$0.2$",
+    "$0.5$",
+    "$1$",
+    "$2$",
+    "$3$",
+    "$5$",
+    "$10$",
+    "$20$",
+    "$50$",
+    "$100$",
+]
+a_ticks = 1.0 / (redshift_ticks + 1.0)
+
+ax.set_xticks(a_ticks)
+ax.set_xticklabels(redshift_labels)
+
+simulation_legend = ax.legend(
+    simulation_lines, simulation_labels, markerfirst=False, loc="upper right"
+)
+
+# Create second X-axis (to plot cosmic time alongside redshift)
+ax2 = ax.twiny()
+ax2.set_xscale("log")
+
+# Cosmic-time ticks (in Gyr) along the second X-axis
+t_ticks = np.array([0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, cosmology.age(1.0e-5).value])
+
+# To place the new ticks onto the X-axis we need to know the corresponding scale factors
+a_ticks_2axis = [
+    1.0 / (1.0 + z_at_value(cosmology.age, t_tick * Gyr)) for t_tick in t_ticks
+]
+
+# Attach the ticks to the second X-axis
+ax2.set_xticks(a_ticks_2axis)
+
+# Format the ticks' labels
+ax2.set_xticklabels(["$%2.1f$" % t_tick for t_tick in t_ticks])
+
+# Final adjustments
+ax.tick_params(axis="x", which="minor", bottom=False)
+ax2.tick_params(axis="x", which="minor", top=False)
+
+ax.set_ylim(0, 0.6)
+ax.set_xlim(1.02, 0.07)
+ax2.set_xlim(1.02, 0.07)
+
+ax.set_xlabel("Redshift $z$")
+ax.set_ylabel(f"SNIa rate / CC SN rate")
+ax2.set_xlabel("Cosmic time [Gyr]")
+
+fig.savefig(f"{output_path}/SNIa_over_CC_rate_history_based_on_CSFH.png")

--- a/colibre/scripts/cosmic_SNIa_rate.py
+++ b/colibre/scripts/cosmic_SNIa_rate.py
@@ -93,6 +93,7 @@ for obs_data in observational_data:
             markeredgecolor="none",
             markersize=2,
             zorder=-10,
+            capsize=1.0,
         )
     )
     observation_labels.append(f"{obs_data.citation}")
@@ -117,7 +118,7 @@ ax.set_xticks(a_ticks)
 ax.set_xticklabels(redshift_labels)
 
 observation_legend = ax.legend(
-    observation_lines, observation_labels, markerfirst=True, loc="center right"
+    observation_lines, observation_labels, markerfirst=True, loc="lower right", fontsize="xx-small", ncol=2
 )
 
 simulation_legend = ax.legend(
@@ -159,3 +160,8 @@ ax.set_ylabel(
 ax2.set_xlabel("Cosmic time [Gyr]")
 
 fig.savefig(f"{output_path}/SNIa_rate_history.png")
+
+ax.set_xlim(1.02, 0.33)
+ax2.set_xlim(1.02, 0.33)
+
+fig.savefig(f"{output_path}/SNIa_rate_history_zoom.png")

--- a/colibre/scripts/cosmic_SNIa_rate_CSFH_based.py
+++ b/colibre/scripts/cosmic_SNIa_rate_CSFH_based.py
@@ -1,0 +1,276 @@
+"""
+Plots the star formation history. Modified version of the script in the
+github.com/swiftsim/swiftsimio-examples repository.
+"""
+import unyt
+
+import matplotlib.pyplot as plt
+import numpy as np
+import glob
+
+from swiftsimio import load
+
+from load_sfh_data import read_obs_data
+
+from velociraptor.observations import load_observations
+
+from astropy.cosmology import z_at_value
+from astropy.units import Gyr
+
+sfr_output_units = unyt.msun / (unyt.year * unyt.Mpc ** 3)
+log_multiplicative_factor = 4
+multiplicative_factor = 10 ** log_multiplicative_factor
+SNIa_output_units = 1. / (unyt.year * unyt.Mpc ** 3)
+
+from swiftpipeline.argumentparser import ScriptArgumentParser
+
+def power_law_beta_one_DTD(t, t_delay, tH):
+    mask = t > 0.04
+    value = np.zeros(len(t)) / unyt.Gyr 
+    value_new = 1./(np.log(tH) - np.log(t_delay)) / t[mask]
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new 
+    return value
+
+def power_law_DTD(t, t_delay, tH, beta):
+    mask = t > 0.04
+    value = np.zeros(len(t)) / unyt.Gyr 
+    value_new = (1.-beta)/(tH**(1-beta) - (t_delay)**(1-beta)) / t[mask]**beta
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new 
+    return value
+
+
+def exponential_law_DTD(t, t_decay, t_delay):
+    mask = t > 0.04
+    value = np.zeros(len(t)) / unyt.Gyr
+    value_new = np.exp(-(t[mask]-t_delay)/t_decay)/t_decay
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new 
+    return value
+
+def Gaussian_law_DTD(t, t_delay, tmean, tsigma):
+    mask = t > 0.04
+    value = np.zeros(len(t)) / unyt.Gyr
+    norm = 1./(tsigma* np.sqrt(2*np.pi))
+    delta_t = t[mask] - tmean
+    value_new = norm * np.exp(-0.5 * delta_t**2 / tsigma**2)
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new
+    return value
+
+arguments = ScriptArgumentParser(
+    description="Creates a star formation history plot, with added observational data."
+)
+
+snapshot_filenames = [
+    f"{directory}/{snapshot}"
+    for directory, snapshot in zip(arguments.directory_list, arguments.snapshot_list)
+]
+
+sfr_filenames = [f"{directory}/SFR.txt" for directory in arguments.directory_list]
+
+names = arguments.name_list
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+simulation_lines = []
+simulation_labels = []
+
+fig, ax = plt.subplots()
+
+ax.set_xscale("log")
+
+
+for idx, (snapshot_filename, sfr_filename, name) in enumerate(
+    zip(snapshot_filenames, sfr_filenames, names)
+):
+    data = np.genfromtxt(sfr_filename).T
+
+    snapshot = load(snapshot_filename)
+
+    # find out which DTD model we are currently using in the code
+    normalization_timescale = snapshot.metadata.parameters.get("SNIaDTD:normalization_timescale_Gyr", None)
+    if normalization_timescale == None:
+        have_normalization_timescale = False
+    else:
+        normalization_timescale = float(normalization_timescale) * unyt.Gyr
+        have_normalization_timescale = True
+
+    exponential_decay = snapshot.metadata.parameters.get("SNIaDTD:SNIa_timescale_Gyr", None)
+    if exponential_decay == None:
+        have_exponential_decay = False
+    else:
+        have_exponential_decay = True 
+        exponential_decay = float(exponential_decay) * unyt.Gyr
+
+    Gaussian_SNIa_efficiency = snapshot.metadata.parameters.get("SNIaDTD:SNIa_efficiency_gauss_p_Msun", None)
+    if Gaussian_SNIa_efficiency == None:
+        have_Gaussian = False
+    else:
+        have_Gaussian = True
+        Gaussian_SNIa_efficiency = float(Gaussian_SNIa_efficiency) / unyt.Msun
+
+    power_law_slope = snapshot.metadata.parameters.get("SNIaDTD:power_law_slope", None) 
+    if power_law_slope == None:
+        have_slope = False 
+    else:
+        have_slope = True 
+        power_law_slope = float(power_law_slope)
+
+    if have_Gaussian:
+        used_DTD = "Gaussian"
+    elif have_slope and have_normalization_timescale:
+        used_DTD = "power-law"
+    elif have_normalization_timescale:
+        used_DTD = "power-law-beta-one"
+    else:
+        used_DTD = "exponential"
+
+    delay_time = float(snapshot.metadata.parameters.get("SNIaDTD:SNIa_delay_time_Gyr", False) ) * unyt.Gyr
+
+    if used_DTD == "power-law" or used_DTD == "exponential" or used_DTD == "power-law-beta-one":
+        SNIa_efficiency = float(snapshot.metadata.parameters.get("SNIaDTD:SNIa_efficiency_p_Msun", False) ) / unyt.Msun
+    elif used_DTD == "Gaussian":
+        Gaussian_SNIa_efficiency = float(snapshot.metadata.parameters.get("SNIaDTD:SNIa_efficiency_gauss_p_Msun", False)) / unyt.Msun
+        Gaussian_const_SNIa_efficiency = float(snapshot.metadata.parameters.get("SNIaDTD:SNIa_efficiency_const_p_Msun", False)) / unyt.Msun
+        Gaussian_characteristic_time = float(snapshot.metadata.parameters.get("SNIaDTD:characteristic_time_Gyr", False)) * unyt.Gyr
+        Gaussian_std_time = float(snapshot.metadata.parameters.get("SNIaDTD:STD_characteristic_time_Gyr", False)) * unyt.Gyr
+        
+    # Read cosmology from the first run in the list
+    if idx == 0:
+        cosmology = snapshot.metadata.cosmology
+
+    units = snapshot.units
+    boxsize = snapshot.metadata.boxsize
+    box_volume = boxsize[0] * boxsize[1] * boxsize[2]
+
+    sfr_units = snapshot.gas.star_formation_rates.units
+
+    # a, Redshift, SFR
+    scale_factor = data[2]
+    redshift = data[3]
+    star_formation_rate = (data[7] * sfr_units / box_volume).to(sfr_output_units)
+    times = data[1] * units.time 
+    dM = data[4] * units.mass
+    
+    # Calculate the times we plot
+    times_desired = np.linspace(0.05,13.8,500) * unyt.Gyr
+    scale_factors_use = np.interp(times_desired, times, scale_factor)
+
+    SNIa_rate = np.zeros(len(times_desired))
+
+    for i in range(1,len(times_desired)):
+        time_consider = times[times < times_desired[i]]
+        time_since_formation = times_desired[i] - time_consider
+        dM_consider = dM[times < times_desired[i]]
+        #SNIa_rate_individual = 1.6e-3 * exponential_law_DTD(time_since_formation, 2.0, 0.04) * dM_consider
+        #SNIa_rate_individual = 1.6e-3 * power_law_beta_one_DTD(time_since_formation, 0.04, 13.6) * dM_consider
+        if used_DTD == "power-law":
+            SNIa_rate_individual = SNIa_efficiency * power_law_DTD(time_since_formation, delay_time, normalization_timescale,power_law_slope) * dM_consider
+        elif used_DTD == "power-law-beta-one":
+            SNIa_rate_individual = SNIa_efficiency * power_law_beta_one_DTD(time_since_formation, delay_time, normalization_timescale) * dM_consider
+        elif used_DTD == "exponential":
+            SNIa_rate_individual = SNIa_efficiency * exponential_law_DTD(time_since_formation, exponential_decay, delay_time) * dM_consider
+        elif used_DTD == "Gaussian":
+            SNIa_rate_individual = Gaussian_SNIa_efficiency * Gaussian_law_DTD(time_since_formation, delay_time, Gaussian_characteristic_time, Gaussian_std_time) * dM_consider
+
+        SNIa_rate_sum = np.sum(SNIa_rate_individual)
+        SNIa_rate[i] = SNIa_rate_sum
+
+    SNIa_rate = (SNIa_rate / box_volume / unyt.Gyr).to(SNIa_output_units)
+
+    # High z-order as we always want these to be on top of the observations
+    simulation_lines.append(
+        ax.plot(scale_factors_use, SNIa_rate.value * multiplicative_factor, zorder=10000)[0]
+    )
+    simulation_labels.append(name)
+
+observation_lines = []
+observation_labels = []
+
+path_to_obs_data = f"{arguments.config.config_directory}/{arguments.config.observational_data_directory}"
+observational_data = load_observations(
+    sorted(glob.glob(f"{path_to_obs_data}/data/CosmicSNIaRate/*.hdf5"))
+)
+
+for obs_data in observational_data:
+    observation_lines.append(
+        ax.errorbar(
+            obs_data.x.value,
+            obs_data.y.value * multiplicative_factor,
+            yerr=obs_data.y_scatter.value * multiplicative_factor,
+            label=obs_data.citation,
+            linestyle="none",
+            marker="o",
+            elinewidth=0.5,
+            markeredgecolor="none",
+            markersize=2,
+            zorder=-10,
+            capsize=1.0,
+        )
+    )
+    observation_labels.append(f"{obs_data.citation}")
+
+
+redshift_ticks = np.array([0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0, 100.0])
+redshift_labels = [
+    "$0$",
+    "$0.2$",
+    "$0.5$",
+    "$1$",
+    "$2$",
+    "$3$",
+    "$5$",
+    "$10$",
+    "$20$",
+    "$50$",
+    "$100$",
+]
+a_ticks = 1.0 / (redshift_ticks + 1.0)
+
+ax.set_xticks(a_ticks)
+ax.set_xticklabels(redshift_labels)
+
+observation_legend = ax.legend(
+    observation_lines, observation_labels, markerfirst=True, loc=4, fontsize=4, ncol=2
+)
+
+simulation_legend = ax.legend(
+    simulation_lines, simulation_labels, markerfirst=False, loc="upper right"
+)
+
+ax.add_artist(observation_legend)
+
+# Create second X-axis (to plot cosmic time alongside redshift)
+ax2 = ax.twiny()
+ax2.set_xscale("log")
+
+# Cosmic-time ticks (in Gyr) along the second X-axis
+t_ticks = np.array([0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, cosmology.age(1.0e-5).value])
+
+# To place the new ticks onto the X-axis we need to know the corresponding scale factors
+a_ticks_2axis = [
+    1.0 / (1.0 + z_at_value(cosmology.age, t_tick * Gyr)) for t_tick in t_ticks
+]
+
+# Attach the ticks to the second X-axis
+ax2.set_xticks(a_ticks_2axis)
+
+# Format the ticks' labels
+ax2.set_xticklabels(["$%2.1f$" % t_tick for t_tick in t_ticks])
+
+# Final adjustments
+ax.tick_params(axis="x", which="minor", bottom=False)
+ax2.tick_params(axis="x", which="minor", top=False)
+
+ax.set_ylim(0, 1.6)
+ax.set_xlim(1.02, 0.07)
+ax2.set_xlim(1.02, 0.07)
+
+ax.set_xlabel("Redshift $z$")
+ax.set_ylabel(f"SNIa rate [$10^{{-{log_multiplicative_factor}}}$ yr$^{{-1}}$ cMpc$^{{-3}}$]")
+ax2.set_xlabel("Cosmic time [Gyr]")
+
+fig.savefig(f"{output_path}/SNIa_rate_history_based_on_CSFH.png")

--- a/colibre/scripts/cosmic_log_CC_SN_rate.py
+++ b/colibre/scripts/cosmic_log_CC_SN_rate.py
@@ -129,6 +129,7 @@ ax.add_artist(observation_legend)
 # Create second X-axis (to plot cosmic time alongside redshift)
 ax2 = ax.twiny()
 ax2.set_xscale("log")
+ax.set_yscale("log")
 
 # Cosmic-time ticks (in Gyr) along the second X-axis
 t_ticks = np.array([0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, cosmology.age(1.0e-5).value])
@@ -148,7 +149,7 @@ ax2.set_xticklabels(["$%2.1f$" % t_tick for t_tick in t_ticks])
 ax.tick_params(axis="x", which="minor", bottom=False)
 ax2.tick_params(axis="x", which="minor", top=False)
 
-ax.set_ylim(0.0, 26.0)
+ax.set_ylim(1e-1, 3e1)
 ax.set_xlim(1.02, 0.07)
 ax2.set_xlim(1.02, 0.07)
 
@@ -158,5 +159,5 @@ ax.set_ylabel(
 )
 ax2.set_xlabel("Cosmic time [Gyr]")
 
-fig.savefig(f"{output_path}/CC_SN_rate_history.png")
+fig.savefig(f"{output_path}/log_CC_SN_rate_history.png")
 

--- a/colibre/scripts/cosmic_log_CC_SN_rate_CSFH_based.py
+++ b/colibre/scripts/cosmic_log_CC_SN_rate_CSFH_based.py
@@ -1,0 +1,193 @@
+"""
+Plots the star formation history. Modified version of the script in the
+github.com/swiftsim/swiftsimio-examples repository.
+"""
+import unyt
+
+import matplotlib.pyplot as plt
+import numpy as np
+import glob
+
+from swiftsimio import load
+
+from load_sfh_data import read_obs_data
+
+from velociraptor.observations import load_observations
+
+from astropy.cosmology import z_at_value
+from astropy.units import Gyr
+
+sfr_output_units = unyt.msun / (unyt.year * unyt.Mpc ** 3)
+log_multiplicative_factor = 4
+multiplicative_factor = 10 ** log_multiplicative_factor
+SNIa_output_units = 1. / (unyt.year * unyt.Mpc ** 3)
+
+from swiftpipeline.argumentparser import ScriptArgumentParser
+
+def CC_SN_DTD(t, t_min, t_max):
+    mask = (t > t_min) & (t < t_max)
+    value = np.zeros(len(t)) / unyt.Gyr 
+    value_new = 1./(t_max - t_min) * (np.ones(len(t[mask])))
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new 
+    return value
+
+arguments = ScriptArgumentParser(
+    description="Creates a star formation history plot, with added observational data."
+)
+
+snapshot_filenames = [
+    f"{directory}/{snapshot}"
+    for directory, snapshot in zip(arguments.directory_list, arguments.snapshot_list)
+]
+
+sfr_filenames = [f"{directory}/SFR.txt" for directory in arguments.directory_list]
+
+names = arguments.name_list
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+simulation_lines = []
+simulation_labels = []
+
+fig, ax = plt.subplots()
+
+ax.set_xscale("log")
+ax.set_yscale("log")
+
+
+for idx, (snapshot_filename, sfr_filename, name) in enumerate(
+    zip(snapshot_filenames, sfr_filenames, names)
+):
+    data = np.genfromtxt(sfr_filename).T
+
+    snapshot = load(snapshot_filename)
+
+    # Read cosmology from the first run in the list
+    if idx == 0:
+        cosmology = snapshot.metadata.cosmology
+
+    units = snapshot.units
+    boxsize = snapshot.metadata.boxsize
+    box_volume = boxsize[0] * boxsize[1] * boxsize[2]
+
+    sfr_units = snapshot.gas.star_formation_rates.units
+
+    # a, Redshift, SFR
+    scale_factor = data[2]
+    redshift = data[3]
+    star_formation_rate = (data[7] * sfr_units / box_volume).to(sfr_output_units)
+    times = data[1] * units.time 
+    dM = data[4] * units.mass
+    
+    # Calculate the times we plot
+    times_desired = np.linspace(0.05,13.8,500) * unyt.Gyr
+    scale_factors_use = np.interp(times_desired, times, scale_factor)
+
+    SNIa_rate = np.zeros(len(times_desired))
+
+    for i in range(1,len(times_desired)):
+        time_consider = times[times < times_desired[i]]
+        time_since_formation = times_desired[i] - time_consider
+        dM_consider = dM[times < times_desired[i]]
+        SNIa_rate_individual = 1.180e-2 * CC_SN_DTD(time_since_formation, 3*unyt.Myr, 0.04*unyt.Gyr) * dM_consider / unyt.Msun
+
+        SNIa_rate_sum = np.sum(SNIa_rate_individual)
+        SNIa_rate[i] = SNIa_rate_sum
+
+    SNIa_rate = (SNIa_rate / box_volume / unyt.Gyr).to(SNIa_output_units)
+
+    # High z-order as we always want these to be on top of the observations
+    simulation_lines.append(
+        ax.plot(scale_factors_use, SNIa_rate.value * multiplicative_factor, zorder=10000)[0]
+    )
+    simulation_labels.append(name)
+
+observation_lines = []
+observation_labels = []
+
+path_to_obs_data = f"{arguments.config.config_directory}/{arguments.config.observational_data_directory}"
+observational_data = load_observations(
+    sorted(glob.glob(f"{path_to_obs_data}/data/CosmicCCSNRate/*.hdf5"))
+)
+
+for obs_data in observational_data:
+    observation_lines.append(
+        ax.errorbar(
+            obs_data.x.value,
+            obs_data.y.value * multiplicative_factor,
+            yerr=obs_data.y_scatter.value * multiplicative_factor,
+            label=obs_data.citation,
+            linestyle="none",
+            marker="o",
+            elinewidth=0.5,
+            markeredgecolor="none",
+            markersize=2,
+            zorder=-10,
+            capsize=1.0,
+        )
+    )
+    observation_labels.append(f"{obs_data.citation}")
+
+
+redshift_ticks = np.array([0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0, 100.0])
+redshift_labels = [
+    "$0$",
+    "$0.2$",
+    "$0.5$",
+    "$1$",
+    "$2$",
+    "$3$",
+    "$5$",
+    "$10$",
+    "$20$",
+    "$50$",
+    "$100$",
+]
+a_ticks = 1.0 / (redshift_ticks + 1.0)
+
+ax.set_xticks(a_ticks)
+ax.set_xticklabels(redshift_labels)
+
+observation_legend = ax.legend(
+    observation_lines, observation_labels, markerfirst=True, loc=4, fontsize=4, ncol=2
+)
+
+simulation_legend = ax.legend(
+    simulation_lines, simulation_labels, markerfirst=False, loc="upper right"
+)
+
+ax.add_artist(observation_legend)
+
+# Create second X-axis (to plot cosmic time alongside redshift)
+ax2 = ax.twiny()
+ax2.set_xscale("log")
+
+# Cosmic-time ticks (in Gyr) along the second X-axis
+t_ticks = np.array([0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, cosmology.age(1.0e-5).value])
+
+# To place the new ticks onto the X-axis we need to know the corresponding scale factors
+a_ticks_2axis = [
+    1.0 / (1.0 + z_at_value(cosmology.age, t_tick * Gyr)) for t_tick in t_ticks
+]
+
+# Attach the ticks to the second X-axis
+ax2.set_xticks(a_ticks_2axis)
+
+# Format the ticks' labels
+ax2.set_xticklabels(["$%2.1f$" % t_tick for t_tick in t_ticks])
+
+# Final adjustments
+ax.tick_params(axis="x", which="minor", bottom=False)
+ax2.tick_params(axis="x", which="minor", top=False)
+
+ax.set_ylim(1e-1, 3e1)
+ax.set_xlim(1.02, 0.07)
+ax2.set_xlim(1.02, 0.07)
+
+ax.set_xlabel("Redshift $z$")
+ax.set_ylabel(f"CC SN rate [$10^{{-{log_multiplicative_factor}}}$ yr$^{{-1}}$ cMpc$^{{-3}}$]")
+ax2.set_xlabel("Cosmic time [Gyr]")
+
+fig.savefig(f"{output_path}/log_CC_SN_rate_history_based_on_CSFH.png")

--- a/colibre/scripts/cosmic_log_CEJSN_rate.py
+++ b/colibre/scripts/cosmic_log_CEJSN_rate.py
@@ -61,13 +61,16 @@ for idx, (snapshot_filename, r_process_filename, name) in enumerate(
     units = snapshot.units
     r_process_rate_units = 1.0 / (units.time * units.length ** 3)
 
-    dt = (data["t2"] - data["t1"]) * 1e5
+    volume = snapshot.metadata.boxsize[0] * snapshot.metadata.boxsize[1]* snapshot.metadata.boxsize[2]
+    volume.convert_to_units("Mpc**3")
+
+    dt = (data["t2"] - data["t1"]) 
 
     # a, Redshift, SFR
     scale_factor = data["a"]
-    NSM_rate = (data["NSM"] /dt * r_process_rate_units).to(r_process_rate_output_units)
-    CEJSN_rate = (data["CEJSN"]/dt * r_process_rate_units).to(r_process_rate_output_units)
-    collapsar_rate = (data["collapsar"]/dt * r_process_rate_units).to(r_process_rate_output_units)
+    NSM_rate = (data["NSM"]/volume.value /dt * r_process_rate_units).to(r_process_rate_output_units)
+    CEJSN_rate = (data["CEJSN"]/volume.value/dt * r_process_rate_units).to(r_process_rate_output_units)
+    collapsar_rate = (data["collapsar"]/volume.value/dt * r_process_rate_units).to(r_process_rate_output_units)
 
     # High z-order as we always want these to be on top of the observations
     simulation_lines.append(

--- a/colibre/scripts/cosmic_log_CEJSN_rate.py
+++ b/colibre/scripts/cosmic_log_CEJSN_rate.py
@@ -74,7 +74,7 @@ for idx, (snapshot_filename, r_process_filename, name) in enumerate(
 
     # High z-order as we always want these to be on top of the observations
     simulation_lines.append(
-        ax.plot(scale_factor, CEJSN_rate.value * multiplicative_factor, zorder=10000, linestyle="--")[0]
+        ax.plot(scale_factor, CEJSN_rate.value * multiplicative_factor, zorder=10000)[0]
     )
     simulation_labels.append(name)
 

--- a/colibre/scripts/cosmic_log_CEJSN_rate.py
+++ b/colibre/scripts/cosmic_log_CEJSN_rate.py
@@ -1,5 +1,5 @@
 """
-Plots the cosmic CCSN rate history.
+Plots the cosmic r_process rate history.
 """
 import unyt
 
@@ -17,7 +17,7 @@ from astropy.units import Gyr
 from swiftpipeline.argumentparser import ScriptArgumentParser
 
 arguments = ScriptArgumentParser(
-    description="Creates a CC SN rate history plot, with added observational data."
+    description="Creates a r-process rate history plot, with added observational data."
 )
 
 snapshot_filenames = [
@@ -25,7 +25,7 @@ snapshot_filenames = [
     for directory, snapshot in zip(arguments.directory_list, arguments.snapshot_list)
 ]
 
-CCSN_filenames = [f"{directory}/SNII.txt" for directory in arguments.directory_list]
+r_process_filenames = [f"{directory}/r_processes.txt" for directory in arguments.directory_list]
 
 names = arguments.name_list
 output_path = arguments.output_directory
@@ -41,15 +41,15 @@ ax.semilogx()
 
 log_multiplicative_factor = 4
 multiplicative_factor = 10 ** log_multiplicative_factor
-CC_SN_rate_output_units = 1.0 / (unyt.yr * unyt.Mpc ** 3)
+r_process_rate_output_units = 1.0 / (unyt.yr * unyt.Mpc ** 3)
 
-for idx, (snapshot_filename, CCSN_filename, name) in enumerate(
-    zip(snapshot_filenames, CCSN_filenames, names)
+for idx, (snapshot_filename, r_process_filename, name) in enumerate(
+    zip(snapshot_filenames, r_process_filenames, names)
 ):
     data = np.loadtxt(
-        CCSN_filename,
-        usecols=(4, 6, 11),
-        dtype=[("a", np.float32), ("z", np.float32), ("CC SN rate", np.float32)],
+        r_process_filename,
+        usecols=(2,3, 4, 6, 14, 15, 16),
+        dtype=[("t2", np.float32), ("t1", np.float32), ("a", np.float32), ("z", np.float32), ("NSM", np.float32), ("CEJSN", np.float32), ("collapsar", np.float32)],
     )
 
     snapshot = load(snapshot_filename)
@@ -59,43 +59,22 @@ for idx, (snapshot_filename, CCSN_filename, name) in enumerate(
         cosmology = snapshot.metadata.cosmology
 
     units = snapshot.units
-    CC_SN_rate_units = 1.0 / (units.time * units.length ** 3)
+    r_process_rate_units = 1.0 / (units.time * units.length ** 3)
+
+    dt = (data["t2"] - data["t1"]) * 1e5
 
     # a, Redshift, SFR
     scale_factor = data["a"]
-    CC_SN_rate = (data["CC SN rate"] * CC_SN_rate_units).to(CC_SN_rate_output_units)
+    NSM_rate = (data["NSM"] /dt * r_process_rate_units).to(r_process_rate_output_units)
+    CEJSN_rate = (data["CEJSN"]/dt * r_process_rate_units).to(r_process_rate_output_units)
+    collapsar_rate = (data["collapsar"]/dt * r_process_rate_units).to(r_process_rate_output_units)
 
     # High z-order as we always want these to be on top of the observations
     simulation_lines.append(
-        ax.plot(scale_factor, CC_SN_rate.value * multiplicative_factor, zorder=10000)[0]
+        ax.plot(scale_factor, CEJSN_rate.value * multiplicative_factor, zorder=10000, linestyle="--")[0]
     )
     simulation_labels.append(name)
 
-
-observation_lines = []
-observation_labels = []
-
-path_to_obs_data = f"{arguments.config.config_directory}/{arguments.config.observational_data_directory}"
-observational_data = load_observations(
-    sorted(glob.glob(f"{path_to_obs_data}/data/CosmicCCSNRate/*.hdf5"))
-)
-
-for obs_data in observational_data:
-    observation_lines.append(
-        ax.errorbar(
-            obs_data.x.value,
-            obs_data.y.value * multiplicative_factor,
-            yerr=obs_data.y_scatter.value * multiplicative_factor,
-            label=obs_data.citation,
-            linestyle="none",
-            marker="o",
-            elinewidth=0.5,
-            markeredgecolor="none",
-            markersize=2,
-            zorder=-10,
-        )
-    )
-    observation_labels.append(f"{obs_data.citation}")
 
 redshift_ticks = np.array([0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0, 100.0])
 redshift_labels = [
@@ -116,19 +95,14 @@ a_ticks = 1.0 / (redshift_ticks + 1.0)
 ax.set_xticks(a_ticks)
 ax.set_xticklabels(redshift_labels)
 
-observation_legend = ax.legend(
-    observation_lines, observation_labels, markerfirst=True, loc="center right", fontsize="xx-small"
-)
-
 simulation_legend = ax.legend(
     simulation_lines, simulation_labels, markerfirst=False, loc="upper right"
 )
 
-ax.add_artist(observation_legend)
-
 # Create second X-axis (to plot cosmic time alongside redshift)
 ax2 = ax.twiny()
 ax2.set_xscale("log")
+ax.set_yscale("log")
 
 # Cosmic-time ticks (in Gyr) along the second X-axis
 t_ticks = np.array([0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, cosmology.age(1.0e-5).value])
@@ -148,15 +122,14 @@ ax2.set_xticklabels(["$%2.1f$" % t_tick for t_tick in t_ticks])
 ax.tick_params(axis="x", which="minor", bottom=False)
 ax2.tick_params(axis="x", which="minor", top=False)
 
-ax.set_ylim(0.0, 26.0)
+ax.set_ylim(1e-5, 1e-1)
 ax.set_xlim(1.02, 0.07)
 ax2.set_xlim(1.02, 0.07)
 
 ax.set_xlabel("Redshift $z$")
 ax.set_ylabel(
-    f"CC SN rate [$10^{{-{log_multiplicative_factor}}}$ yr$^{{-1}}$ cMpc$^{{-3}}$]"
+    f"Common-envelop jets SN rate [$10^{{-{log_multiplicative_factor}}}$ yr$^{{-1}}$ cMpc$^{{-3}}$]"
 )
 ax2.set_xlabel("Cosmic time [Gyr]")
 
-fig.savefig(f"{output_path}/CC_SN_rate_history.png")
-
+fig.savefig(f"{output_path}/log_CEJSN_rate_history.png")

--- a/colibre/scripts/cosmic_log_NSM_rate.py
+++ b/colibre/scripts/cosmic_log_NSM_rate.py
@@ -1,5 +1,5 @@
 """
-Plots the cosmic CCSN rate history.
+Plots the cosmic r_process rate history.
 """
 import unyt
 
@@ -17,7 +17,7 @@ from astropy.units import Gyr
 from swiftpipeline.argumentparser import ScriptArgumentParser
 
 arguments = ScriptArgumentParser(
-    description="Creates a CC SN rate history plot, with added observational data."
+    description="Creates a r-process rate history plot, with added observational data."
 )
 
 snapshot_filenames = [
@@ -25,7 +25,7 @@ snapshot_filenames = [
     for directory, snapshot in zip(arguments.directory_list, arguments.snapshot_list)
 ]
 
-CCSN_filenames = [f"{directory}/SNII.txt" for directory in arguments.directory_list]
+r_process_filenames = [f"{directory}/r_processes.txt" for directory in arguments.directory_list]
 
 names = arguments.name_list
 output_path = arguments.output_directory
@@ -41,15 +41,15 @@ ax.semilogx()
 
 log_multiplicative_factor = 4
 multiplicative_factor = 10 ** log_multiplicative_factor
-CC_SN_rate_output_units = 1.0 / (unyt.yr * unyt.Mpc ** 3)
+r_process_rate_output_units = 1.0 / (unyt.yr * unyt.Mpc ** 3)
 
-for idx, (snapshot_filename, CCSN_filename, name) in enumerate(
-    zip(snapshot_filenames, CCSN_filenames, names)
+for idx, (snapshot_filename, r_process_filename, name) in enumerate(
+    zip(snapshot_filenames, r_process_filenames, names)
 ):
     data = np.loadtxt(
-        CCSN_filename,
-        usecols=(4, 6, 11),
-        dtype=[("a", np.float32), ("z", np.float32), ("CC SN rate", np.float32)],
+        r_process_filename,
+        usecols=(2,3, 4, 6, 14, 15, 16),
+        dtype=[("t2", np.float32), ("t1", np.float32), ("a", np.float32), ("z", np.float32), ("NSM", np.float32), ("CEJSN", np.float32), ("collapsar", np.float32)],
     )
 
     snapshot = load(snapshot_filename)
@@ -59,43 +59,22 @@ for idx, (snapshot_filename, CCSN_filename, name) in enumerate(
         cosmology = snapshot.metadata.cosmology
 
     units = snapshot.units
-    CC_SN_rate_units = 1.0 / (units.time * units.length ** 3)
+    r_process_rate_units = 1.0 / (units.time * units.length ** 3)
+
+    dt = (data["t2"] - data["t1"]) * 1e5
 
     # a, Redshift, SFR
     scale_factor = data["a"]
-    CC_SN_rate = (data["CC SN rate"] * CC_SN_rate_units).to(CC_SN_rate_output_units)
+    NSM_rate = (data["NSM"] /dt * r_process_rate_units).to(r_process_rate_output_units)
+    CEJSN_rate = (data["CEJSN"]/dt * r_process_rate_units).to(r_process_rate_output_units)
+    collapsar_rate = (data["collapsar"]/dt * r_process_rate_units).to(r_process_rate_output_units)
 
     # High z-order as we always want these to be on top of the observations
     simulation_lines.append(
-        ax.plot(scale_factor, CC_SN_rate.value * multiplicative_factor, zorder=10000)[0]
+        ax.plot(scale_factor, NSM_rate.value * multiplicative_factor, zorder=10000)[0]
     )
     simulation_labels.append(name)
 
-
-observation_lines = []
-observation_labels = []
-
-path_to_obs_data = f"{arguments.config.config_directory}/{arguments.config.observational_data_directory}"
-observational_data = load_observations(
-    sorted(glob.glob(f"{path_to_obs_data}/data/CosmicCCSNRate/*.hdf5"))
-)
-
-for obs_data in observational_data:
-    observation_lines.append(
-        ax.errorbar(
-            obs_data.x.value,
-            obs_data.y.value * multiplicative_factor,
-            yerr=obs_data.y_scatter.value * multiplicative_factor,
-            label=obs_data.citation,
-            linestyle="none",
-            marker="o",
-            elinewidth=0.5,
-            markeredgecolor="none",
-            markersize=2,
-            zorder=-10,
-        )
-    )
-    observation_labels.append(f"{obs_data.citation}")
 
 redshift_ticks = np.array([0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0, 100.0])
 redshift_labels = [
@@ -116,19 +95,14 @@ a_ticks = 1.0 / (redshift_ticks + 1.0)
 ax.set_xticks(a_ticks)
 ax.set_xticklabels(redshift_labels)
 
-observation_legend = ax.legend(
-    observation_lines, observation_labels, markerfirst=True, loc="center right", fontsize="xx-small"
-)
-
 simulation_legend = ax.legend(
     simulation_lines, simulation_labels, markerfirst=False, loc="upper right"
 )
 
-ax.add_artist(observation_legend)
-
 # Create second X-axis (to plot cosmic time alongside redshift)
 ax2 = ax.twiny()
 ax2.set_xscale("log")
+ax.set_yscale("log")
 
 # Cosmic-time ticks (in Gyr) along the second X-axis
 t_ticks = np.array([0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, cosmology.age(1.0e-5).value])
@@ -148,15 +122,14 @@ ax2.set_xticklabels(["$%2.1f$" % t_tick for t_tick in t_ticks])
 ax.tick_params(axis="x", which="minor", bottom=False)
 ax2.tick_params(axis="x", which="minor", top=False)
 
-ax.set_ylim(0.0, 26.0)
+ax.set_ylim(1e-5, 1e-1)
 ax.set_xlim(1.02, 0.07)
 ax2.set_xlim(1.02, 0.07)
 
 ax.set_xlabel("Redshift $z$")
 ax.set_ylabel(
-    f"CC SN rate [$10^{{-{log_multiplicative_factor}}}$ yr$^{{-1}}$ cMpc$^{{-3}}$]"
+    f"NS-NS merger rate [$10^{{-{log_multiplicative_factor}}}$ yr$^{{-1}}$ cMpc$^{{-3}}$]"
 )
 ax2.set_xlabel("Cosmic time [Gyr]")
 
-fig.savefig(f"{output_path}/CC_SN_rate_history.png")
-
+fig.savefig(f"{output_path}/log_NSM_rate_history.png")

--- a/colibre/scripts/cosmic_log_NSM_rate.py
+++ b/colibre/scripts/cosmic_log_NSM_rate.py
@@ -60,14 +60,17 @@ for idx, (snapshot_filename, r_process_filename, name) in enumerate(
 
     units = snapshot.units
     r_process_rate_units = 1.0 / (units.time * units.length ** 3)
+    
+    volume = snapshot.metadata.boxsize[0] * snapshot.metadata.boxsize[1]* snapshot.metadata.boxsize[2]
+    volume.convert_to_units("Mpc**3")
 
-    dt = (data["t2"] - data["t1"]) * 1e5
+    dt = (data["t2"] - data["t1"]) 
 
     # a, Redshift, SFR
     scale_factor = data["a"]
-    NSM_rate = (data["NSM"] /dt * r_process_rate_units).to(r_process_rate_output_units)
-    CEJSN_rate = (data["CEJSN"]/dt * r_process_rate_units).to(r_process_rate_output_units)
-    collapsar_rate = (data["collapsar"]/dt * r_process_rate_units).to(r_process_rate_output_units)
+    NSM_rate = (data["NSM"]/volume.value /dt * r_process_rate_units).to(r_process_rate_output_units)
+    CEJSN_rate = (data["CEJSN"]/volume.value/dt * r_process_rate_units).to(r_process_rate_output_units)
+    collapsar_rate = (data["collapsar"]/volume.value/dt * r_process_rate_units).to(r_process_rate_output_units)
 
     # High z-order as we always want these to be on top of the observations
     simulation_lines.append(

--- a/colibre/scripts/cosmic_log_SNIa_rate_CSFH_based.py
+++ b/colibre/scripts/cosmic_log_SNIa_rate_CSFH_based.py
@@ -1,0 +1,307 @@
+"""
+Plots the star formation history. Modified version of the script in the
+github.com/swiftsim/swiftsimio-examples repository.
+"""
+import unyt
+
+import matplotlib.pyplot as plt
+import numpy as np
+import glob
+
+from swiftsimio import load
+
+from load_sfh_data import read_obs_data
+
+from velociraptor.observations import load_observations
+
+from astropy.cosmology import z_at_value
+from astropy.units import Gyr
+
+sfr_output_units = unyt.msun / (unyt.year * unyt.Mpc ** 3)
+log_multiplicative_factor = 4
+multiplicative_factor = 10 ** log_multiplicative_factor
+SNIa_output_units = 1. / (unyt.year * unyt.Mpc ** 3)
+
+from swiftpipeline.argumentparser import ScriptArgumentParser
+
+def power_law_beta_one_DTD(t, t_delay, tH):
+    mask = t > 0.04
+    value = np.zeros(len(t)) / unyt.Gyr 
+    value_new = 1./(np.log(tH) - np.log(t_delay)) / t[mask]
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new 
+    return value
+
+def power_law_DTD(t, t_delay, tH, beta):
+    mask = t > 0.04
+    value = np.zeros(len(t)) / unyt.Gyr 
+    value_new = (1.-beta)/(tH**(1-beta) - (t_delay)**(1-beta)) / t[mask]**beta
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new 
+    return value
+
+
+def exponential_law_DTD(t, t_decay, t_delay):
+    mask = t > 0.04
+    value = np.zeros(len(t)) / unyt.Gyr
+    value_new = np.exp(-(t[mask]-t_delay)/t_decay)/t_decay
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new 
+    return value
+
+def Gaussian_law_DTD(t, t_delay, tmean, tsigma):
+    mask = t > 0.04
+    value = np.zeros(len(t)) / unyt.Gyr 
+    norm = 1./(tsigma* np.sqrt(2*np.pi))
+    delta_t = t[mask] - tmean
+    value_new = norm * np.exp(-0.5 * delta_t**2 / tsigma**2)
+    value_new.convert_to_units("Gyr**-1")
+    value[mask] = value_new 
+    return value
+
+def broken_power_law_DTD(t, slope_short_time, slope_long_time, break_time_Gyr, delay_time, normalization_timescale):
+    mask1 = (t > 0.04) & (t < break_time_Gyr)
+    mask2 = (t>= break_time_Gyr)
+    value = np.zeros(len(t)) / unyt.Gyr 
+    norm1 = (1- slope_short_time) * (1 - slope_long_time)
+    norm2a = (slope_short_time - slope_long_time) * break_time_Gyr 
+    norm2b = (1 - slope_short_time) * normalization_timescale**(1-slope_long_time) * break_time_Gyr**slope_long_time 
+    norm2c = (1 - slope_long_time) * normalization_timescale**(1-slope_short_time) * break_time_Gyr**slope_short_time 
+    norm2 = norm2a + norm2b + norm2c
+    norm = norm1 / norm2
+    value[mask1] = norm * (t[mask1]/break_time_Gyr)**(-slope_short_time)
+    value[mask2] = norm * (t[mask2]/break_time_Gyr)**(-slope_long_time)
+    return value
+
+
+arguments = ScriptArgumentParser(
+    description="Creates a star formation history plot, with added observational data."
+)
+
+snapshot_filenames = [
+    f"{directory}/{snapshot}"
+    for directory, snapshot in zip(arguments.directory_list, arguments.snapshot_list)
+]
+
+sfr_filenames = [f"{directory}/SFR.txt" for directory in arguments.directory_list]
+
+names = arguments.name_list
+output_path = arguments.output_directory
+
+plt.style.use(arguments.stylesheet_location)
+
+simulation_lines = []
+simulation_labels = []
+
+fig, ax = plt.subplots()
+
+ax.set_xscale("log")
+ax.set_yscale("log")
+
+
+for idx, (snapshot_filename, sfr_filename, name) in enumerate(
+    zip(snapshot_filenames, sfr_filenames, names)
+):
+    data = np.genfromtxt(sfr_filename).T
+
+    snapshot = load(snapshot_filename)
+
+    # find out which DTD model we are currently using in the code
+    normalization_timescale = snapshot.metadata.parameters.get("SNIaDTD:normalization_timescale_Gyr", None)
+    if normalization_timescale == None:
+        have_normalization_timescale = False
+    else:
+        normalization_timescale = float(normalization_timescale) * unyt.Gyr
+        have_normalization_timescale = True
+
+    exponential_decay = snapshot.metadata.parameters.get("SNIaDTD:SNIa_timescale_Gyr", None)
+    if exponential_decay == None:
+        have_exponential_decay = False
+    else:
+        have_exponential_decay = True 
+        exponential_decay = float(exponential_decay) * unyt.Gyr
+
+    Gaussian_SNIa_efficiency = snapshot.metadata.parameters.get("SNIaDTD:SNIa_efficiency_gauss_p_Msun", None)
+    if Gaussian_SNIa_efficiency == None:
+        have_Gaussian = False
+    else:
+        have_Gaussian = True
+        Gaussian_SNIa_efficiency = float(Gaussian_SNIa_efficiency) / unyt.Msun
+
+    power_law_slope = snapshot.metadata.parameters.get("SNIaDTD:power_law_slope", None) 
+    if power_law_slope == None:
+        have_slope = False 
+    else:
+        have_slope = True 
+        power_law_slope = float(power_law_slope)
+
+    power_law_slope_short_time = snapshot.metadata.parameters.get("SNIaDTD:power_law_slope_short_time", None)
+    if power_law_slope_short_time == None:
+        have_broken_slope = False
+    else:
+        have_broken_slope = True
+        power_law_slope_short_time = float(power_law_slope_short_time)
+
+    if have_Gaussian:
+        used_DTD = "Gaussian"
+    elif have_broken_slope:
+        used_DTD = "broken-power-law"
+    elif have_slope and have_normalization_timescale:
+        used_DTD = "power-law"
+    elif have_normalization_timescale:
+        used_DTD = "power-law-beta-one"
+    else:
+        used_DTD = "exponential"
+
+    delay_time = float(snapshot.metadata.parameters.get("SNIaDTD:SNIa_delay_time_Gyr", False) ) * unyt.Gyr
+
+    if used_DTD == "power-law" or used_DTD == "exponential" or used_DTD == "power-law-beta-one":
+        SNIa_efficiency = float(snapshot.metadata.parameters.get("SNIaDTD:SNIa_efficiency_p_Msun", False) ) / unyt.Msun
+    elif used_DTD == "Gaussian":
+        Gaussian_SNIa_efficiency = float(snapshot.metadata.parameters.get("SNIaDTD:SNIa_efficiency_gauss_p_Msun", False)) / unyt.Msun
+        Gaussian_const_SNIa_efficiency = float(snapshot.metadata.parameters.get("SNIaDTD:SNIa_efficiency_const_p_Msun", False)) / unyt.Msun
+        Gaussian_characteristic_time = float(snapshot.metadata.parameters.get("SNIaDTD:characteristic_time_Gyr", False)) * unyt.Gyr
+        Gaussian_std_time = float(snapshot.metadata.parameters.get("SNIaDTD:STD_characteristic_time_Gyr", False)) * unyt.Gyr
+    elif used_DTD == "broken-power-law":
+        SNIa_efficiency = float(snapshot.metadata.parameters.get("SNIaDTD:SNIa_efficiency_p_Msun", False) ) / unyt.Msun
+        power_law_slope_long_time = float(snapshot.metadata.parameters.get("SNIaDTD:power_law_slope_long_time", False))
+        break_time_Gyr = float(snapshot.metadata.parameters.get("SNIaDTD:break_time_Gyr", False) ) * unyt.Gyr
+        
+    # Read cosmology from the first run in the list
+    if idx == 0:
+        cosmology = snapshot.metadata.cosmology
+
+    units = snapshot.units
+    boxsize = snapshot.metadata.boxsize
+    box_volume = boxsize[0] * boxsize[1] * boxsize[2]
+
+    sfr_units = snapshot.gas.star_formation_rates.units
+
+    # a, Redshift, SFR
+    scale_factor = data[2]
+    redshift = data[3]
+    star_formation_rate = (data[7] * sfr_units / box_volume).to(sfr_output_units)
+    times = data[1] * units.time 
+    dM = data[4] * units.mass
+    
+    # Calculate the times we plot
+    times_desired = np.linspace(0.05,13.8,500) * unyt.Gyr
+    scale_factors_use = np.interp(times_desired, times, scale_factor)
+
+    SNIa_rate = np.zeros(len(times_desired))
+
+    for i in range(1,len(times_desired)):
+        time_consider = times[times < times_desired[i]]
+        time_since_formation = times_desired[i] - time_consider
+        dM_consider = dM[times < times_desired[i]]
+        #SNIa_rate_individual = 1.6e-3 * exponential_law_DTD(time_since_formation, 2.0, 0.04) * dM_consider
+        #SNIa_rate_individual = 1.6e-3 * power_law_beta_one_DTD(time_since_formation, 0.04, 13.6) * dM_consider
+        if used_DTD == "power-law":
+            SNIa_rate_individual = SNIa_efficiency * power_law_DTD(time_since_formation, delay_time, normalization_timescale,power_law_slope) * dM_consider
+        elif used_DTD == "power-law-beta-one":
+            SNIa_rate_individual = SNIa_efficiency * power_law_beta_one_DTD(time_since_formation, delay_time, normalization_timescale) * dM_consider
+        elif used_DTD == "exponential":
+            SNIa_rate_individual = SNIa_efficiency * exponential_law_DTD(time_since_formation, exponential_decay, delay_time) * dM_consider
+        elif used_DTD == "Gaussian":
+            SNIa_rate_individual = Gaussian_SNIa_efficiency * Gaussian_law_DTD(time_since_formation, delay_time, Gaussian_characteristic_time, Gaussian_std_time) * dM_consider
+        elif used_DTD == "broken-power-law":
+            SNIa_rate_individual = SNIa_efficiency * broken_power_law_DTD(time_since_formation, power_law_slope_short_time, power_law_slope_long_time, break_time_Gyr, delay_time, normalization_timescale) * dM_consider
+
+        SNIa_rate_sum = np.sum(SNIa_rate_individual)
+        SNIa_rate[i] = SNIa_rate_sum
+
+    SNIa_rate = (SNIa_rate / box_volume / unyt.Gyr).to(SNIa_output_units)
+
+    # High z-order as we always want these to be on top of the observations
+    simulation_lines.append(
+        ax.plot(scale_factors_use, SNIa_rate.value * multiplicative_factor, zorder=10000)[0]
+    )
+    simulation_labels.append(name)
+
+observation_lines = []
+observation_labels = []
+
+path_to_obs_data = f"{arguments.config.config_directory}/{arguments.config.observational_data_directory}"
+observational_data = load_observations(
+    sorted(glob.glob(f"{path_to_obs_data}/data/CosmicSNIaRate/*.hdf5"))
+)
+
+for obs_data in observational_data:
+    observation_lines.append(
+        ax.errorbar(
+            obs_data.x.value,
+            obs_data.y.value * multiplicative_factor,
+            yerr=obs_data.y_scatter.value * multiplicative_factor,
+            label=obs_data.citation,
+            linestyle="none",
+            marker="o",
+            elinewidth=0.5,
+            markeredgecolor="none",
+            markersize=2,
+            zorder=-10,
+            capsize=1.0,
+        )
+    )
+    observation_labels.append(f"{obs_data.citation}")
+
+
+redshift_ticks = np.array([0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0, 100.0])
+redshift_labels = [
+    "$0$",
+    "$0.2$",
+    "$0.5$",
+    "$1$",
+    "$2$",
+    "$3$",
+    "$5$",
+    "$10$",
+    "$20$",
+    "$50$",
+    "$100$",
+]
+a_ticks = 1.0 / (redshift_ticks + 1.0)
+
+ax.set_xticks(a_ticks)
+ax.set_xticklabels(redshift_labels)
+
+observation_legend = ax.legend(
+    observation_lines, observation_labels, markerfirst=True, loc=4, fontsize=4, ncol=2
+)
+
+simulation_legend = ax.legend(
+    simulation_lines, simulation_labels, markerfirst=False, loc="upper right"
+)
+
+ax.add_artist(observation_legend)
+
+# Create second X-axis (to plot cosmic time alongside redshift)
+ax2 = ax.twiny()
+ax2.set_xscale("log")
+
+# Cosmic-time ticks (in Gyr) along the second X-axis
+t_ticks = np.array([0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, cosmology.age(1.0e-5).value])
+
+# To place the new ticks onto the X-axis we need to know the corresponding scale factors
+a_ticks_2axis = [
+    1.0 / (1.0 + z_at_value(cosmology.age, t_tick * Gyr)) for t_tick in t_ticks
+]
+
+# Attach the ticks to the second X-axis
+ax2.set_xticks(a_ticks_2axis)
+
+# Format the ticks' labels
+ax2.set_xticklabels(["$%2.1f$" % t_tick for t_tick in t_ticks])
+
+# Final adjustments
+ax.tick_params(axis="x", which="minor", bottom=False)
+ax2.tick_params(axis="x", which="minor", top=False)
+
+ax.set_ylim(3e-2, 2.0)
+ax.set_xlim(1.02, 0.07)
+ax2.set_xlim(1.02, 0.07)
+
+ax.set_xlabel("Redshift $z$")
+ax.set_ylabel(f"SNIa rate [$10^{{-{log_multiplicative_factor}}}$ yr$^{{-1}}$ cMpc$^{{-3}}$]")
+ax2.set_xlabel("Cosmic time [Gyr]")
+
+fig.savefig(f"{output_path}/log_SNIa_rate_history_based_on_CSFH.png")

--- a/colibre/scripts/cosmic_log_collapsar_rate.py
+++ b/colibre/scripts/cosmic_log_collapsar_rate.py
@@ -61,13 +61,16 @@ for idx, (snapshot_filename, r_process_filename, name) in enumerate(
     units = snapshot.units
     r_process_rate_units = 1.0 / (units.time * units.length ** 3)
 
-    dt = (data["t2"] - data["t1"]) * 1e5
+    volume = snapshot.metadata.boxsize[0] * snapshot.metadata.boxsize[1]* snapshot.metadata.boxsize[2]
+    volume.convert_to_units("Mpc**3")
+
+    dt = (data["t2"] - data["t1"]) 
 
     # a, Redshift, SFR
     scale_factor = data["a"]
-    NSM_rate = (data["NSM"] /dt * r_process_rate_units).to(r_process_rate_output_units)
-    CEJSN_rate = (data["CEJSN"]/dt * r_process_rate_units).to(r_process_rate_output_units)
-    collapsar_rate = (data["collapsar"]/dt * r_process_rate_units).to(r_process_rate_output_units)
+    NSM_rate = (data["NSM"]/volume.value /dt * r_process_rate_units).to(r_process_rate_output_units)
+    CEJSN_rate = (data["CEJSN"]/volume.value/dt * r_process_rate_units).to(r_process_rate_output_units)
+    collapsar_rate = (data["collapsar"]/volume.value/dt * r_process_rate_units).to(r_process_rate_output_units)
 
     # High z-order as we always want these to be on top of the observations
     simulation_lines.append(

--- a/colibre/scripts/cosmic_log_collapsar_rate.py
+++ b/colibre/scripts/cosmic_log_collapsar_rate.py
@@ -74,7 +74,7 @@ for idx, (snapshot_filename, r_process_filename, name) in enumerate(
 
     # High z-order as we always want these to be on top of the observations
     simulation_lines.append(
-        ax.plot(scale_factor, collapsar_rate.value * multiplicative_factor, zorder=10000, linestyle="-.")[0]
+        ax.plot(scale_factor, collapsar_rate.value * multiplicative_factor, zorder=10000)[0]
     )
     simulation_labels.append(name)
 

--- a/colibre/scripts/cosmic_log_collapsar_rate.py
+++ b/colibre/scripts/cosmic_log_collapsar_rate.py
@@ -1,5 +1,5 @@
 """
-Plots the cosmic CCSN rate history.
+Plots the cosmic r_process rate history.
 """
 import unyt
 
@@ -17,7 +17,7 @@ from astropy.units import Gyr
 from swiftpipeline.argumentparser import ScriptArgumentParser
 
 arguments = ScriptArgumentParser(
-    description="Creates a CC SN rate history plot, with added observational data."
+    description="Creates a r-process rate history plot, with added observational data."
 )
 
 snapshot_filenames = [
@@ -25,7 +25,7 @@ snapshot_filenames = [
     for directory, snapshot in zip(arguments.directory_list, arguments.snapshot_list)
 ]
 
-CCSN_filenames = [f"{directory}/SNII.txt" for directory in arguments.directory_list]
+r_process_filenames = [f"{directory}/r_processes.txt" for directory in arguments.directory_list]
 
 names = arguments.name_list
 output_path = arguments.output_directory
@@ -41,15 +41,15 @@ ax.semilogx()
 
 log_multiplicative_factor = 4
 multiplicative_factor = 10 ** log_multiplicative_factor
-CC_SN_rate_output_units = 1.0 / (unyt.yr * unyt.Mpc ** 3)
+r_process_rate_output_units = 1.0 / (unyt.yr * unyt.Mpc ** 3)
 
-for idx, (snapshot_filename, CCSN_filename, name) in enumerate(
-    zip(snapshot_filenames, CCSN_filenames, names)
+for idx, (snapshot_filename, r_process_filename, name) in enumerate(
+    zip(snapshot_filenames, r_process_filenames, names)
 ):
     data = np.loadtxt(
-        CCSN_filename,
-        usecols=(4, 6, 11),
-        dtype=[("a", np.float32), ("z", np.float32), ("CC SN rate", np.float32)],
+        r_process_filename,
+        usecols=(2,3, 4, 6, 14, 15, 16),
+        dtype=[("t2", np.float32), ("t1", np.float32), ("a", np.float32), ("z", np.float32), ("NSM", np.float32), ("CEJSN", np.float32), ("collapsar", np.float32)],
     )
 
     snapshot = load(snapshot_filename)
@@ -59,43 +59,22 @@ for idx, (snapshot_filename, CCSN_filename, name) in enumerate(
         cosmology = snapshot.metadata.cosmology
 
     units = snapshot.units
-    CC_SN_rate_units = 1.0 / (units.time * units.length ** 3)
+    r_process_rate_units = 1.0 / (units.time * units.length ** 3)
+
+    dt = (data["t2"] - data["t1"]) * 1e5
 
     # a, Redshift, SFR
     scale_factor = data["a"]
-    CC_SN_rate = (data["CC SN rate"] * CC_SN_rate_units).to(CC_SN_rate_output_units)
+    NSM_rate = (data["NSM"] /dt * r_process_rate_units).to(r_process_rate_output_units)
+    CEJSN_rate = (data["CEJSN"]/dt * r_process_rate_units).to(r_process_rate_output_units)
+    collapsar_rate = (data["collapsar"]/dt * r_process_rate_units).to(r_process_rate_output_units)
 
     # High z-order as we always want these to be on top of the observations
     simulation_lines.append(
-        ax.plot(scale_factor, CC_SN_rate.value * multiplicative_factor, zorder=10000)[0]
+        ax.plot(scale_factor, collapsar_rate.value * multiplicative_factor, zorder=10000, linestyle="-.")[0]
     )
     simulation_labels.append(name)
 
-
-observation_lines = []
-observation_labels = []
-
-path_to_obs_data = f"{arguments.config.config_directory}/{arguments.config.observational_data_directory}"
-observational_data = load_observations(
-    sorted(glob.glob(f"{path_to_obs_data}/data/CosmicCCSNRate/*.hdf5"))
-)
-
-for obs_data in observational_data:
-    observation_lines.append(
-        ax.errorbar(
-            obs_data.x.value,
-            obs_data.y.value * multiplicative_factor,
-            yerr=obs_data.y_scatter.value * multiplicative_factor,
-            label=obs_data.citation,
-            linestyle="none",
-            marker="o",
-            elinewidth=0.5,
-            markeredgecolor="none",
-            markersize=2,
-            zorder=-10,
-        )
-    )
-    observation_labels.append(f"{obs_data.citation}")
 
 redshift_ticks = np.array([0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0, 100.0])
 redshift_labels = [
@@ -116,19 +95,14 @@ a_ticks = 1.0 / (redshift_ticks + 1.0)
 ax.set_xticks(a_ticks)
 ax.set_xticklabels(redshift_labels)
 
-observation_legend = ax.legend(
-    observation_lines, observation_labels, markerfirst=True, loc="center right", fontsize="xx-small"
-)
-
 simulation_legend = ax.legend(
     simulation_lines, simulation_labels, markerfirst=False, loc="upper right"
 )
 
-ax.add_artist(observation_legend)
-
 # Create second X-axis (to plot cosmic time alongside redshift)
 ax2 = ax.twiny()
 ax2.set_xscale("log")
+ax.set_yscale("log")
 
 # Cosmic-time ticks (in Gyr) along the second X-axis
 t_ticks = np.array([0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, cosmology.age(1.0e-5).value])
@@ -148,15 +122,14 @@ ax2.set_xticklabels(["$%2.1f$" % t_tick for t_tick in t_ticks])
 ax.tick_params(axis="x", which="minor", bottom=False)
 ax2.tick_params(axis="x", which="minor", top=False)
 
-ax.set_ylim(0.0, 26.0)
+ax.set_ylim(1e-5, 2.0)
 ax.set_xlim(1.02, 0.07)
 ax2.set_xlim(1.02, 0.07)
 
 ax.set_xlabel("Redshift $z$")
 ax.set_ylabel(
-    f"CC SN rate [$10^{{-{log_multiplicative_factor}}}$ yr$^{{-1}}$ cMpc$^{{-3}}$]"
+    f"Collapsar rate [$10^{{-{log_multiplicative_factor}}}$ yr$^{{-1}}$ cMpc$^{{-3}}$]"
 )
 ax2.set_xlabel("Cosmic time [Gyr]")
 
-fig.savefig(f"{output_path}/CC_SN_rate_history.png")
-
+fig.savefig(f"{output_path}/log_collapsar_rate_history.png")


### PR DESCRIPTION
This is an update that is mainly related to SNIa. Below I summarize the changes:
1. Update the observational data repository (depends on SWIFTSIM/velociraptor-pipeline-data#115) this MR depends on  @MatthieuSchaller 
2. Include where possible the corresponding data in the plots
3. Plot the logger file for the cosmic SNIa and CC SN rate
4. Plot the logger file for the cosmic r-processes rates (NS mergers, collapsars, CEJSN) interesting for @correac 
5. Calculate the cosmic SNIa and CC rate directly from the amount of stellar mass formed
6. I also added a plot with the cosmic ratio of SNIa and CC SN.
7. Divide the section of SNIa in more sections to keep a good overview. I now have sections for cosmic rates calculated from the stellar mass formed, cosmic rates from loggers, SNIa rates versus gas metallicity, SNIa rates versus SFR or sSFR, SNIa rates versus stellar mass. 
8. I reordered some plots such that the first plots that appear are the plots that we want to see first. 
9. I added a description of the SNIa model to the model description at the top of the webpage. 