### PR TITLE
Update comparison data in the cosmic star formation rate density plot

### DIFF
--- a/colibre/scripts/load_sfh_data.py
+++ b/colibre/scripts/load_sfh_data.py
@@ -35,6 +35,7 @@ def read_obs_data(path="observational_data"):
     output = []
 
     # SFR Observational data from Hopkins 2004
+    """
     hcorr = log10(h) - log10(0.7)  # h^-2 for SFR, h^-3 for volume
     (z, z_up, z_down, lgrho, lgrho_up, lgrho_down) = loadtxt(
         f"{path}/sfr_hopkins2004_cor.dat", unpack=True
@@ -44,16 +45,18 @@ def read_obs_data(path="observational_data"):
     obs1_rho = 10 ** lgrho
     obs1_rho_err = array([obs1_rho - 10 ** lgrho_down, 10 ** lgrho_up - obs1_rho])
 
-    # output.append(
-    #    ObservationalData(
-    #        scale_factor=obs1_a,
-    #        sfr=obs1_rho,
-    #        error=obs1_rho_err,
-    #        description="Hopkins (2004)",
-    #    )
-    # )
+     output.append(
+        ObservationalData(
+            scale_factor=obs1_a,
+            sfr=obs1_rho,
+            error=obs1_rho_err,
+            description="Hopkins (2004)",
+        )
+    )
+    """
 
     # SFR Observational data from Karim 2011
+    """
     (z, rho, err_up, err_down) = loadtxt(f"{path}/sfr_karim2011.dat", unpack=True)
     obs2_a = 1.0 / (1.0 + z)
     obs2_rho = rho * 0.6777 / 0.7
@@ -62,6 +65,7 @@ def read_obs_data(path="observational_data"):
     output.append(
         ObservationalData(obs2_a, obs2_rho, obs2_rho_err, "Karim et al. (2011) [radio]")
     )
+    """
 
     # SFR Observational data from Bouwens 2012 (not used included by Bouwens 2015)
     """
@@ -88,6 +92,7 @@ def read_obs_data(path="observational_data"):
     """
 
     # SFR Observational data from Rodighierio 2012
+    """
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_rodighiero2010.dat", unpack=True)
     rhostar = (
         (rhostar / 1.65) * 0.6777 / 0.7
@@ -101,8 +106,10 @@ def read_obs_data(path="observational_data"):
             obs4_a, obs4_rho, obs4_rho_err, "Rodighiero et al. (2010) [24 $\mu$m]"
         )
     )
+    """
 
     # SFR Observational data from Cucciati 2012
+    """
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_cucciati2011.dat", unpack=True)
     rhostar = rhostar - 2.0 * log10(0.7) + 2.0 * log10(0.6777)
     obs5_a = 1.0 / (1 + z)
@@ -116,8 +123,10 @@ def read_obs_data(path="observational_data"):
             obs5_a, obs5_rho, obs5_rho_err, "Cucciati et al. (2012) [fuv]"
         )
     )
+    """
 
     # sfr observational data from Magnelli 2013
+    """
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_magnelli2013.dat", unpack=True)
     obs6_a = 1.0 / (1 + z)
     obs6_rho = (
@@ -132,8 +141,10 @@ def read_obs_data(path="observational_data"):
     output.append(
         ObservationalData(obs6_a, obs6_rho, obs6_rho_err, "Magnelli et al. (2013) [IR]")
     )
+    """
 
     # sfr observational data from Gruppioni 2013
+    """
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_gruppioni2013.dat", unpack=True)
     obs7_a = 1.0 / (1 + z)
     obs7_rho = (
@@ -150,8 +161,10 @@ def read_obs_data(path="observational_data"):
             obs7_a, obs7_rho, obs7_rho_err, "Gruppioni et al. (2013) [IR]"
         )
     )
+    """
 
     # sfr observational data from Burgarella 2013
+    """
     z, rhostar, err = loadtxt(f"{path}/sfr_burgarella2013.dat", unpack=True)
     obs8_a = 1.0 / (1 + z)
     obs8_rho = rhostar / 1.65 * 0.6777 / 0.7  # convert to Chabrier IMF from Salpeter
@@ -162,8 +175,10 @@ def read_obs_data(path="observational_data"):
             obs8_a, obs8_rho, obs8_rho_err, "Burgarella et al. (2013) [UV + IR]"
         )
     )
+    """
 
     # sfr observational data from Schenker 2013
+    """
     z, rhostar, err_m, err_p = loadtxt(f"{path}/sfr_schenker2013.dat", unpack=True)
     obs9_a = 1.0 / (1 + z)
     obs9_rho = (
@@ -178,6 +193,7 @@ def read_obs_data(path="observational_data"):
     output.append(
         ObservationalData(obs9_a, obs9_rho, obs9_rho_err, "Schenker et al. (2013) [UV]")
     )
+    """
 
     # sfr observational data from Bouwens 2015
     z, rhostar, err_p, err_m = loadtxt(f"{path}/sfr_bouwens2015_dust.dat", unpack=True)
@@ -217,7 +233,7 @@ def read_obs_data(path="observational_data"):
         )
     )
 
-    # sfr observational data from Oesch 2015
+    # sfr observational data from Oesch 2018
     z, rhostar, err_p, err_m = loadtxt(f"{path}/sfr_oesch2018.dat", unpack=True)
     obs12_a = 1.0 / (1 + z)
     obs12_rho = (
@@ -234,6 +250,7 @@ def read_obs_data(path="observational_data"):
     )
 
     # sfr observational data from Finkelstein 2015
+    """
     z, rhostar, err_p, err_m = loadtxt(
         f"{path}/sfr_finkelstein2015_dust.dat", unpack=True
     )
@@ -252,8 +269,10 @@ def read_obs_data(path="observational_data"):
             obs13_a, obs13_rho, obs13_rho_err, "Finkelstein et al. (2015) [UV, dust]"
         )
     )
+    """
 
     # sfr observational data from Finkelstein 2015
+    """
     z, rhostar, err_p, err_m = loadtxt(
         f"{path}/sfr_finkelstein2015_no_dustcorr.dat", unpack=True
     )
@@ -272,6 +291,7 @@ def read_obs_data(path="observational_data"):
             obs14_a, obs14_rho, obs14_rho_err, "Finkelstein et al. (2015) [UV, no dust]"
         )
     )
+    """
 
     ##################################################################################
 

--- a/colibre/scripts/star_formation_history.py
+++ b/colibre/scripts/star_formation_history.py
@@ -145,7 +145,7 @@ extra_data_sample = load_observations(
 )
 
 for extra_data, color, wavrange in zip(
-    extra_data_sample, ["maroon", "goldenrod", "slategrey"], ["radio", "IR", "radio"]
+    extra_data_sample, ["maroon", "goldenrod", "slategrey"], ["radio", "FIR", "radio"]
 ):
     observation_lines.append(
         ax.errorbar(


### PR DESCRIPTION
This follows Joop's request on slack to

- change the label for Gruppioni+ 20 from "IR" to "FIR"
- omit all data from before 2016 except Bouwens+ 15

The updated plot will look as follows

![star_formation_history](https://user-images.githubusercontent.com/20153933/232350911-83eff090-3e6a-459f-bd3b-5f535c33a828.png)
