### PR TITLE
Add min smoothing length vs. redshift plot and update min smoothing length histrogram plot

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -223,7 +223,7 @@ scripts:
     section: Histograms
     title: Gas Particle Minimal Smoothing Lengths
   - filename: scripts/gas_minimal_smoothing_length_redshift.py
-    caption: Gas Particle Comoving Minimal Smoothing Lengths versus Redshifts at which these minimal smoothing lengths were reached. The black dashed curve indicates the minimum allowed smoothing length at a given redshift.
+    caption: Gas Particle Comoving Minimal Smoothing Lengths versus Redshifts at which these minimal smoothing lengths were reached. The black dashed and black dotted curves indicate, respectively, the minimum allowed smoothing length and gravitational softening length at a given redshift.
     output_file: gas_hmin_redshift.png
     section: Histograms
     title: Gas Particle Minimal Smoothing Lengths vs. Redshift

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -218,7 +218,7 @@ scripts:
     section: Histograms
     title: Gas Particle Smoothing Lengths
   - filename: scripts/gas_minimal_smoothing_lengths.py
-    caption: Gas Particle Comoving Minimal Smoothing Lengths reached during the simulation, split by redshifts at which these minimal smoothing lengths were reached and normalised by the minimum allowed gravitational softening length (at the corresponding redshift). The minimal allowed ratio between smoothing length and gravitational softening length is indicated by the vertical dashed line.
+    caption: Gas Particle Comoving Minimal Smoothing Lengths reached during the simulation, split by redshifts at which these minimal smoothing lengths were reached and normalised by the gravitational softening length (at the corresponding redshift). The minimal allowed ratio between smoothing length and gravitational softening length is indicated by the vertical dashed line.
     output_file: gas_minimal_smoothing_lengths.png
     section: Histograms
     title: Gas Particle Minimal Smoothing Lengths

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -218,10 +218,15 @@ scripts:
     section: Histograms
     title: Gas Particle Smoothing Lengths
   - filename: scripts/gas_minimal_smoothing_lengths.py
-    caption: Gas Particle Comoving Minimal Smoothing Lengths reached during the simulation, split by redshifts at which these minimal smoothing lengths were reached. The lowest minimal smoothing length that is allowed to be reached in the simulation is indicated by the vertical dashed line.
+    caption: Gas Particle Comoving Minimal Smoothing Lengths reached during the simulation, split by redshifts at which these minimal smoothing lengths were reached and normalised by the minimum allowed gravitational softening length (at the corresponding redshift). The minimal allowed ratio between smoothing length and gravitational softening length is indicated by the vertical dashed line.
     output_file: gas_minimal_smoothing_lengths.png
     section: Histograms
     title: Gas Particle Minimal Smoothing Lengths
+  - filename: scripts/gas_minimal_smoothing_length_redshift.py
+    caption: Gas Particle Comoving Minimal Smoothing Lengths versus Redshifts at which these minimal smoothing lengths were reached. The black dashed curve indicates the minimum allowed smoothing length at a given redshift.
+    output_file: gas_hmin_redshift.png
+    section: Histograms
+    title: Gas Particle Minimal Smoothing Lengths vs. Redshift
   - filename: scripts/number_of_agn_thermal_injections.py
     caption: The cumulative number of black holes (summed from right to left) with a given total number of thermal energy injections (less than or equal to the number of particles heated) the black hole has had throughout the simulation.
     output_file: num_agn_thermal_injections.png

--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -218,7 +218,7 @@ scripts:
     section: Histograms
     title: Gas Particle Smoothing Lengths
   - filename: scripts/gas_minimal_smoothing_lengths.py
-    caption: Gas Particle Comoving Minimal Smoothing Lengths reached during the simulation, split by redshifts at which these minimal smoothing lengths were reached and normalised by the gravitational softening length (at the corresponding redshift). The minimal allowed ratio between smoothing length and gravitational softening length is indicated by the vertical dashed line.
+    caption: Gas Particle Comoving Minimal Smoothing Lengths reached during the simulation, split by redshifts at which these minimal smoothing lengths were reached and normalised by the gravitational softening length (at the corresponding redshift). The minimal allowed ratio between smoothing length and gravitational softening length is indicated by the vertical dashed line. The normalisation by the softening includes the factor of 3 to convert from the Plummer-equivalent softening length, which is specified in the parameter file. The normalisation also accounts for the factor of $\gamma_{\rm kernel} \approx 2$, which relates the smoothing length to the extent of an SPH kernel.
     output_file: gas_minimal_smoothing_lengths.png
     section: Histograms
     title: Gas Particle Minimal Smoothing Lengths

--- a/colibre/scripts/gas_minimal_smoothing_length_redshift.py
+++ b/colibre/scripts/gas_minimal_smoothing_length_redshift.py
@@ -1,0 +1,203 @@
+"""
+Plots the gas minimal smoothing length versus redshift at which the minimal smoothing length was reached.
+Uses the swiftsimio library.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from swiftsimio import load
+from unyt import unyt_quantity
+from matplotlib.colors import LogNorm
+
+# Set the limits of the figure.
+hmin_bounds = [1e-5, 1e3]  # in ckpc
+redshift_bounds = [-1.5, 12]  # dimensionless
+bins = 128
+
+
+def get_data(filename):
+    """
+    Grabs the data (gas-particle minimal smoothing lengths and redshifts at which they have been reached).
+    """
+
+    data = load(filename)
+
+    # Gas particles' minimal comoving smoothing lengths
+    hmin_gas = data.gas.minimal_smoothing_lengths.to_comoving().to("kpc").value
+
+    hmin_scale_factors = data.gas.minimal_smoothing_length_scale_factors
+    hmin_redshifts = 1 / hmin_scale_factors.value - 1
+
+    # Minimal smoothing length in units of gravitational softening
+    h_min_ratio = unyt_quantity(
+        float(data.metadata.parameters.get("SPH:h_min_ratio")), units="dimensionless"
+    )
+
+    # Comoving softening length (Plummer equivalent)
+    eps_b_comov = unyt_quantity(
+        float(
+            data.metadata.gravity_scheme.get(
+                "Comoving baryon softening length (Plummer equivalent)  [internal units]",
+                0.0,
+            )
+        ),
+        units=data.metadata.units.length,
+    ).to("kpc")
+
+    # Maximal physical softening length (Plummer equivalent)
+    eps_b_phys_max = unyt_quantity(
+        float(
+            data.metadata.gravity_scheme.get(
+                "Maximal physical baryon softening length (Plummer equivalent) [internal units]",
+                0.0,
+            )
+        ),
+        units=data.metadata.units.length,
+    ).to("kpc")
+
+    # Get gamma = Kernel size / Kernel smoothing length
+    gamma = data.metadata.hydro_scheme.get("Kernel gamma")
+
+    # ρ(|r|) = W (|r|, 3.0 * eps_Plummer )
+    softening_plummer_equivalent = 3.0
+
+    hmin_comoving = (
+        softening_plummer_equivalent * h_min_ratio.value * eps_b_comov / gamma
+    )
+    hmin_phys_max = (
+        softening_plummer_equivalent * h_min_ratio.value * eps_b_phys_max / gamma
+    )
+
+    return hmin_gas, hmin_redshifts, hmin_comoving, hmin_phys_max
+
+
+def make_hist(filename, hmin_bounds, redshift_bounds, bins):
+    """
+    Makes the histogram for filename with bounds as lower, higher
+    for the bins and "bins" the number of bins along each dimension.
+
+    Also returns the edges for pcolormesh to use.
+    """
+
+    hmin_bins = np.logspace(np.log10(hmin_bounds[0]), np.log10(hmin_bounds[1]), bins)
+    redshift_bins = np.linspace(redshift_bounds[0], redshift_bounds[1], bins)
+
+    hmin_gas, hmin_redshifts, hmin_comoving, hmin_phys_max = get_data(filename)
+
+    H, hmin_edges, redshift_edges = np.histogram2d(
+        hmin_gas, hmin_redshifts, bins=[hmin_bins, redshift_bins]
+    )
+
+    return H.T, hmin_edges, redshift_edges, hmin_comoving, hmin_phys_max
+
+
+def setup_axes(number_of_simulations: int):
+    """
+    Creates the figure and axis object. Creates a grid of a x b subplots
+    that add up to at least number_of_simulations.
+    """
+
+    sqrt_number_of_simulations = np.sqrt(number_of_simulations)
+    horizontal_number = int(np.ceil(sqrt_number_of_simulations))
+    # Ensure >= number_of_simulations plots in a grid
+    vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
+
+    fig, ax = plt.subplots(
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+    )
+
+    ax = np.array([ax]) if number_of_simulations == 1 else ax
+
+    if horizontal_number * vertical_number > number_of_simulations:
+        for axis in ax.flat[number_of_simulations:]:
+            axis.axis("off")
+
+    # Set all valid on bottom row to have the horizontal axis label.
+    for axis in np.atleast_2d(ax)[:][-1]:
+        axis.set_xlabel("$h_{\\rm min}$ [ckpc]")
+
+    for axis in np.atleast_2d(ax).T[:][0]:
+        axis.set_ylabel("Redshift $z$ ($h_{\\rm min}$)")
+
+    ax.flat[0].set_xscale("log")
+    ax.flat[0].invert_yaxis()
+
+    return fig, ax
+
+
+def make_single_image(
+    filenames,
+    names,
+    number_of_simulations,
+    hmin_bounds,
+    redshift_bounds,
+    bins,
+    output_path,
+):
+    """
+    Makes a single plot of gas minimal smoothing length vs. redshift
+    """
+
+    fig, ax = setup_axes(number_of_simulations=number_of_simulations)
+
+    hists = []
+
+    for filename in filenames:
+        hist, hmin_gas, z, hmin_comoving, hmin_phys_max = make_hist(
+            filename, hmin_bounds, redshift_bounds, bins
+        )
+        hists.append(hist)
+
+    vmax = np.max([np.max(hist) for hist in hists])
+
+    for hist, name, axis in zip(hists, names, ax.flat):
+        mappable = axis.pcolormesh(hmin_gas, z, hist, norm=LogNorm(vmin=1, vmax=vmax))
+
+        redshifts = np.linspace(0, redshift_bounds[1], 64)
+        hmin_constraint = np.minimum(hmin_comoving, hmin_phys_max * (1.0 + redshifts))
+        axis.plot(hmin_constraint, redshifts, zorder=10000, color="k", dashes=(3, 3))
+
+        axis.text(
+            0.025,
+            0.975,
+            name,
+            ha="left",
+            va="top",
+            transform=axis.transAxes,
+            fontsize=5,
+            in_layout=False,
+        )
+
+    fig.colorbar(mappable, ax=ax.ravel().tolist(), label="Number of gas particles")
+
+    fig.savefig(f"{output_path}/gas_hmin_redshift.png")
+
+    return
+
+
+if __name__ == "__main__":
+    from swiftpipeline.argumentparser import ScriptArgumentParser
+
+    arguments = ScriptArgumentParser(
+        description="Gas minimal smoothing length vs. redshift phase plot."
+    )
+
+    snapshot_filenames = [
+        f"{directory}/{snapshot}"
+        for directory, snapshot in zip(
+            arguments.directory_list, arguments.snapshot_list
+        )
+    ]
+
+    plt.style.use(arguments.stylesheet_location)
+
+    make_single_image(
+        filenames=snapshot_filenames,
+        names=arguments.name_list,
+        number_of_simulations=arguments.number_of_inputs,
+        hmin_bounds=hmin_bounds,
+        redshift_bounds=redshift_bounds,
+        bins=bins,
+        output_path=arguments.output_directory,
+    )

--- a/colibre/scripts/gas_minimal_smoothing_lengths.py
+++ b/colibre/scripts/gas_minimal_smoothing_lengths.py
@@ -1,23 +1,24 @@
 """
-Makes a histogram of the gas minimal smoothing lengths split by redshifts. Uses the swiftsimio library.
+Makes a histogram of the gas minimal smoothing lengths divided by minimum allowed gravitational softening and
+split by redshifts. Uses the swiftsimio library.
 """
 
 import matplotlib.pyplot as plt
 import numpy as np
 
 from swiftsimio import load
-from unyt import unyt_quantity, dimensionless, Mpc
+from unyt import unyt_quantity
 
-h_bounds = [1e-3, 5e2]  # comoving kpc
+h_bounds = [1e-5, 5e2]  # dimensionless
 number_of_bins = 256
 hmin_bins = np.logspace(np.log10(h_bounds[0]), np.log10(h_bounds[1]), number_of_bins)
 log_hmin_bin_width = np.log10(hmin_bins[1]) - np.log10(hmin_bins[0])
-hmin_centers = 0.5 * (hmin_bins[1:] + hmin_bins[:-1])
+hmin_centers = 10.0 ** (0.5 * (np.log10(hmin_bins[1:]) + np.log10(hmin_bins[:-1])))
 
 
 def get_data(filename):
     """
-    Grabs the data (gas-particle minimal smoothing lengths in comoving kpc).
+    Grabs the data (gas-particle minimal smoothing lengths and redshifts at which they have been reached).
     """
 
     data = load(filename)
@@ -30,7 +31,7 @@ def get_data(filename):
 
     # Minimal smoothing length in units of gravitational softening
     h_min_ratio = unyt_quantity(
-        float(data.metadata.parameters.get("SPH:h_min_ratio")), units=dimensionless
+        float(data.metadata.parameters.get("SPH:h_min_ratio")), units="dimensionless"
     )
 
     # Comoving softening length (Plummer equivalent)
@@ -58,26 +59,24 @@ def get_data(filename):
     # Get gamma = Kernel size / Kernel smoothing length
     gamma = data.metadata.hydro_scheme.get("Kernel gamma")
 
-    # Redshift of the snapshot
-    z = data.metadata.redshift
-
     # ρ(|r|) = W (|r|, 3.0 * eps_Plummer )
     softening_plummer_equivalent = 3.0
 
-    # Compute the minimal comoving smoothing length in ckpc
-    h_min = (
-        softening_plummer_equivalent
-        * h_min_ratio.value
-        * min(eps_b_comov, eps_b_phys_max * (1.0 + z))
-        / gamma
+    # Compute the minimum allowed gravitational softening
+    grav_softening_limit = softening_plummer_equivalent * np.minimum(
+        eps_b_comov, eps_b_phys_max * (1.0 + hmin_redshifts)
     )
 
-    return hmin_gas, hmin_redshifts, h_min
+    hmin_gas_over_softening = hmin_gas * gamma / grav_softening_limit
+
+    return hmin_gas_over_softening, hmin_redshifts, h_min_ratio.value
 
 
-def make_single_image(filenames, names, h_bounds, number_of_simulations, output_path):
+def make_single_image(filenames, names, output_path):
     """
-    Makes a single histogram of the gas particle minimal smoothing lengths.
+    Makes a single histogram of the gas particle minimal smoothing lengths (plotted in units of minimum allowed
+    gravitational softening length at the redshift at which a given gas particle's minimal smoothing length was
+    reached.)
     """
 
     # Begin plotting
@@ -93,34 +92,40 @@ def make_single_image(filenames, names, h_bounds, number_of_simulations, output_
         )
 
     for color, (filename, name) in enumerate(zip(filenames, names)):
-        hmin_gas, hmin_redshifts, h_min = get_data(filename)
+        hmin_gas_over_min_softening, hmin_redshifts, hmin_to_softening_ratio = get_data(
+            filename
+        )
 
         # Segment minimal smoothing lengths into redshift bins
-        hmin_gas_by_redshift = {
-            "$z < 1$": hmin_gas[hmin_redshifts < 1],
-            "$1 < z < 3$": hmin_gas[
+        hmin_gas_over_min_softening_by_redshift = {
+            "$z < 1$": hmin_gas_over_min_softening[hmin_redshifts < 1],
+            "$1 < z < 3$": hmin_gas_over_min_softening[
                 np.logical_and(hmin_redshifts > 1, hmin_redshifts < 3)
             ],
-            "$z > 3$": hmin_gas[hmin_redshifts > 3],
+            "$z > 3$": hmin_gas_over_min_softening[hmin_redshifts > 3],
         }
 
         # Total number of stars formed
         Num_of_gas_total = len(hmin_redshifts)
 
         for redshift, ax in ax_dict.items():
-            data = hmin_gas_by_redshift[redshift]
+            data = hmin_gas_over_min_softening_by_redshift[redshift]
 
             H, _ = np.histogram(data, bins=hmin_bins)
             y_points = H / log_hmin_bin_width / Num_of_gas_total
 
             ax.plot(hmin_centers, y_points, label=name, color=f"C{color}")
 
-            # Add vertical line showing lowest possible hmin
-            ax.axvline(x=h_min, color=f"C{color}", ls="--", lw=0.2)
+            # Add vertical line showing lowest possible hmin to softening ratio
+            ax.axvline(x=hmin_to_softening_ratio, color=f"C{color}", ls="--", lw=0.2)
 
     axes[0].legend(loc="upper right", markerfirst=False)
-    axes[2].set_xlabel("Gas Particle Smoothing length $h_{\\rm min}$ [ckpc]")
-    axes[1].set_ylabel("$N_{\\rm bin}$ / d$\\log h_{\\rm min}$ / $N_{\\rm total}$")
+    axes[2].set_xlabel(
+        "Minimal Smoothing length over softening $h_{\\rm min}/\\varepsilon_{\\rm soft,min}$"
+    )
+    axes[1].set_ylabel(
+        "$N_{\\rm bin}$ / d$\\log (h_{\\rm min}/\\varepsilon_{\\rm soft,min}$) / $N_{\\rm total}$"
+    )
 
     fig.savefig(f"{output_path}/gas_minimal_smoothing_lengths.png")
 
@@ -131,7 +136,7 @@ if __name__ == "__main__":
     from swiftpipeline.argumentparser import ScriptArgumentParser
 
     arguments = ScriptArgumentParser(
-        description="Gas-particle minimal smoothing-length histogram split by redshifts."
+        description="Gas-particle minimal smoothing-length histogram, in units of softening and split by redshifts."
     )
 
     snapshot_filenames = [
@@ -146,7 +151,5 @@ if __name__ == "__main__":
     make_single_image(
         filenames=snapshot_filenames,
         names=arguments.name_list,
-        h_bounds=h_bounds,
-        number_of_simulations=arguments.number_of_inputs,
         output_path=arguments.output_directory,
     )

--- a/colibre/scripts/gas_minimal_smoothing_lengths.py
+++ b/colibre/scripts/gas_minimal_smoothing_lengths.py
@@ -1,5 +1,5 @@
 """
-Makes a histogram of the gas minimal smoothing lengths divided by minimum allowed gravitational softening and
+Makes a histogram of the gas minimal smoothing lengths normalized by gravitational softening and
 split by redshifts. Uses the swiftsimio library.
 """
 
@@ -74,9 +74,8 @@ def get_data(filename):
 
 def make_single_image(filenames, names, output_path):
     """
-    Makes a single histogram of the gas particle minimal smoothing lengths (plotted in units of minimum allowed
-    gravitational softening length at the redshift at which a given gas particle's minimal smoothing length was
-    reached.)
+    Makes a single histogram of the gas particle minimal smoothing lengths (plotted in units of gravitational softening
+    length at the redshift at which a given gas particle's minimal smoothing length was reached.)
     """
 
     # Begin plotting
@@ -116,12 +115,12 @@ def make_single_image(filenames, names, output_path):
 
             ax.plot(hmin_centers, y_points, label=name, color=f"C{color}")
 
-            # Add vertical line showing lowest possible hmin to softening ratio
+            # Add vertical line showing the lowest possible hmin to softening ratio
             ax.axvline(x=hmin_to_softening_ratio, color=f"C{color}", ls="--", lw=0.2)
 
     axes[0].legend(loc="upper right", markerfirst=False)
     axes[2].set_xlabel(
-        "Minimal Smoothing length over softening $h_{\\rm min}/\\varepsilon_{\\rm soft,min}$"
+        "Minimal Smoothing length over softening $h_{\\rm min}/\\varepsilon_{\\rm soft}$"
     )
     axes[1].set_ylabel(
         "$N_{\\rm bin}$ / d$\\log (h_{\\rm min}/\\varepsilon_{\\rm soft,min}$) / $N_{\\rm total}$"

--- a/colibre/scripts/gas_minimal_smoothing_lengths.py
+++ b/colibre/scripts/gas_minimal_smoothing_lengths.py
@@ -123,7 +123,7 @@ def make_single_image(filenames, names, output_path):
         "Minimal Smoothing length over softening $h_{\\rm min}/\\varepsilon_{\\rm soft}$"
     )
     axes[1].set_ylabel(
-        "$N_{\\rm bin}$ / d$\\log (h_{\\rm min}/\\varepsilon_{\\rm soft,min}$) / $N_{\\rm total}$"
+        "$N_{\\rm bin}$ / d$\\log (h_{\\rm min}/\\varepsilon_{\\rm soft}$) / $N_{\\rm total}$"
     )
 
     fig.savefig(f"{output_path}/gas_minimal_smoothing_lengths.png")


### PR DESCRIPTION
Two changes in this update

- Update the gas-particle minimal smoothing-length histogram by normalizing `hmin_gas` by gravitational softening at the corresponding redshift. I.e. before the update, `hmin_gas` would be plotted but now `hmin_gas / \varepsilon_soft` is plotted.

- Add a plot showing gas-particle minimal smoothing-length vs. redshift at which it as reached, plotted as a 2D histogram.

Here are the examples of the updated plot and the new plot
![gas_minimal_smoothing_lengths](https://github.com/SWIFTSIM/pipeline-configs/assets/20153933/f888545a-7629-43f0-ba71-832de0bdf25f)

![gas_hmin_redshift](https://github.com/SWIFTSIM/pipeline-configs/assets/20153933/080f4999-8c8d-4b34-9845-e2b0efafa7c8)


