### PR TITLE
Update  comparison data in gas metallicity and HI mass function plots

### DIFF
--- a/colibre/auto_plotter/gas_mass_functions.yml
+++ b/colibre/auto_plotter/gas_mass_functions.yml
@@ -17,8 +17,8 @@ gas_HI_mass_function:
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyHIMassFunction/Zwaan2003.hdf5
-    - filename: GalaxyHIMassFunction/Haynes2011.hdf5
     - filename: GalaxyHIMassFunction/Jones2018.hdf5
+    - filename: GalaxyHIMassFunction/Ponomareva2023.hdf5
 
 adaptive_gas_HI_mass_function:
   type: "adaptivemassfunction"
@@ -39,8 +39,8 @@ adaptive_gas_HI_mass_function:
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyHIMassFunction/Zwaan2003.hdf5
-    - filename: GalaxyHIMassFunction/Haynes2011.hdf5
     - filename: GalaxyHIMassFunction/Jones2018.hdf5
+    - filename: GalaxyHIMassFunction/Ponomareva2023.hdf5
 
 gas_H2_mass_function:
   type: "massfunction"

--- a/colibre/auto_plotter/metallicity.yml
+++ b/colibre/auto_plotter/metallicity.yml
@@ -37,6 +37,8 @@ stellar_mass_gas_sf_metallicity_fromz_lom_30:
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
     - filename: GalaxyStellarMassGasMetallicity/FIREbox.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Strom2022_OH.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Curti2020.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Lewis2023.hdf5
 
 stellar_mass_gas_sf_metallicity_fromz_lom_50:
   type: "scatter"
@@ -77,6 +79,8 @@ stellar_mass_gas_sf_metallicity_fromz_lom_50:
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
     - filename: GalaxyStellarMassGasMetallicity/FIREbox.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Strom2022_OH.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Curti2020.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Lewis2023.hdf5
 
 stellar_mass_gas_sf_metallicity_lom_30:
   type: "scatter"
@@ -117,6 +121,8 @@ stellar_mass_gas_sf_metallicity_lom_30:
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
     - filename: GalaxyStellarMassGasMetallicity/FIREbox.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Strom2022_OH.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Curti2020.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Lewis2023.hdf5
 
 stellar_mass_gas_sf_metallicity_lom_50:
   type: "scatter"
@@ -157,6 +163,8 @@ stellar_mass_gas_sf_metallicity_lom_50:
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
     - filename: GalaxyStellarMassGasMetallicity/FIREbox.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Strom2022_OH.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Curti2020.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Lewis2023.hdf5
 
 stellar_mass_gas_sf_metallicity_total_lom_30:
   type: "scatter"
@@ -197,6 +205,8 @@ stellar_mass_gas_sf_metallicity_total_lom_30:
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
     - filename: GalaxyStellarMassGasMetallicity/FIREbox.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Strom2022_OH.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Curti2020.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Lewis2023.hdf5
 
 stellar_mass_gas_sf_metallicity_total_lom_50:
   type: "scatter"
@@ -237,6 +247,8 @@ stellar_mass_gas_sf_metallicity_total_lom_50:
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
     - filename: GalaxyStellarMassGasMetallicity/FIREbox.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Strom2022_OH.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Curti2020.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Lewis2023.hdf5
 
 stellar_mass_gas_sf_metallicity_mol_lowfloor_30:
   type: "scatter"
@@ -277,6 +289,8 @@ stellar_mass_gas_sf_metallicity_mol_lowfloor_30:
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
     - filename: GalaxyStellarMassGasMetallicity/FIREbox.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Strom2022_OH.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Curti2020.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Lewis2023.hdf5
 
 stellar_mass_gas_sf_metallicity_mol_lowfloor_50:
   type: "scatter"
@@ -317,6 +331,8 @@ stellar_mass_gas_sf_metallicity_mol_lowfloor_50:
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
     - filename: GalaxyStellarMassGasMetallicity/FIREbox.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Strom2022_OH.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Curti2020.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Lewis2023.hdf5
 
 stellar_mass_gas_sf_metallicity_mol_hifloor_30:
   type: "scatter"
@@ -357,6 +373,8 @@ stellar_mass_gas_sf_metallicity_mol_hifloor_30:
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
     - filename: GalaxyStellarMassGasMetallicity/FIREbox.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Strom2022_OH.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Curti2020.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Lewis2023.hdf5
 
 stellar_mass_gas_sf_metallicity_mol_hifloor_50:
   type: "scatter"
@@ -397,6 +415,8 @@ stellar_mass_gas_sf_metallicity_mol_hifloor_50:
     - filename: GalaxyStellarMassGasMetallicity/Fraser-McKelvie_2021.hdf5
     - filename: GalaxyStellarMassGasMetallicity/FIREbox.hdf5
     - filename: GalaxyStellarMassGasMetallicity/Strom2022_OH.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Curti2020.hdf5
+    - filename: GalaxyStellarMassGasMetallicity/Lewis2023.hdf5
 
 stellar_mass_gas_sf_metallicity_lom_allgals_30:
   type: "scatter"


### PR DESCRIPTION
This PR updates comparison data for gas metallicities and HI mass function.

The data from Haynes+2011 is removed because it is superseded by Jones+2018.