### PR TITLE
Updating metallicity.yml, removing [O/Fe] vs Mstellar plot

### DIFF
--- a/colibre/auto_plotter/metallicity.yml
+++ b/colibre/auto_plotter/metallicity.yml
@@ -765,7 +765,7 @@ stellar_mass_star_mg_over_fe_50:
   x:
     quantity: "apertures.mass_star_50_kpc"
     units: solar_mass
-    start: 1e7
+    start: 1e6
     end: 1e12
   median:
     plot: true
@@ -773,7 +773,7 @@ stellar_mass_star_mg_over_fe_50:
     adaptive: true
     number_of_bins: 20
     start:
-      value: 1e7
+      value: 1e6
       units: solar_mass
     end:
       value: 1e12
@@ -781,7 +781,7 @@ stellar_mass_star_mg_over_fe_50:
   metadata:
     title: 'Stellar mass - [Mg/Fe]$_*$ relation (50 kpc aperture)'
     section: Stellar Metallicity
-    caption: '[Mg/Fe] versus stellar mass, both computed in 50-kpc apertures. The values of [Mg/Fe] are obtained by computing the (log10 of) ratio between the total Magnesium mass in stars and total Iron mass in stars, and then normalising it by the corresponding solar abundances. The solar abundances are taken from Asplund et al. (2009). All haloes are plotted, including subhaloes.'
+    caption: '[Mg/Fe] versus stellar mass, both computed in 50-kpc apertures. The values of [Mg/Fe] are obtained by computing the (log10 of) ratio between the total Magnesium mass in stars and total Iron mass in stars, and then normalising it by the corresponding solar abundances. The solar abundances are taken from Asplund et al. (2009). All haloes are plotted, including subhaloes. Romero-Gomez+ dataset of ATLAS-3D galaxies has been corrected from Grevesse & Sauval (1998) to Aspund+ solar abundances. However Romero-Gomez dataset of dwarf galaxies, that corresponds to a compilation of [alpha/Fe] values from the dwarf spherical galaxies in the Local Group (Table B2 of Romero-Gomez et al. 2023), has not been corrected to Asplund+ solar abundances, this is pending and should be done for each individual data point. Gallazzi+ dataset should be corrected from Grevesse + (1991) to Asplund+ solar abundances. However a different [Fe/H] value is adopted (7.48 as opposed to 7.67) because we think that that value was used in the study, but confirmation from Gallazzi et al. is still pending on this.'
   observational_data:
     - filename: GalaxyStellarMassAlphatoIron/Gallazzi2021_Data_MgFe.hdf5
     - filename: GalaxyStellarMassAlphatoIron/RomeroGomez2023_ATLAS3D_Data_MgFe.hdf5

--- a/colibre/auto_plotter/metallicity.yml
+++ b/colibre/auto_plotter/metallicity.yml
@@ -784,35 +784,5 @@ stellar_mass_star_mg_over_fe_50:
     caption: '[Mg/Fe] versus stellar mass, both computed in 50-kpc apertures. The values of [Mg/Fe] are obtained by computing the (log10 of) ratio between the total Magnesium mass in stars and total Iron mass in stars, and then normalising it by the corresponding solar abundances. The solar abundances are taken from Asplund et al. (2009). All haloes are plotted, including subhaloes.'
   observational_data:
     - filename: GalaxyStellarMassAlphatoIron/Gallazzi2021_Data_MgFe.hdf5
-
-stellar_mass_star_o_over_fe_50:
-  type: "scatter"
-  legend_loc: "lower left"
-  y:
-    quantity: "derived_quantities.star_oxygen_over_iron_50_kpc"
-    units: "dimensionless"
-    start: -0.2
-    end: 0.7
-    log: false
-  x:
-    quantity: "apertures.mass_star_50_kpc"
-    units: solar_mass
-    start: 1e7
-    end: 1e12
-  median:
-    plot: true
-    log: true
-    adaptive: true
-    number_of_bins: 20
-    start:
-      value: 1e7
-      units: solar_mass
-    end:
-      value: 1e12
-      units: solar_mass
-  metadata:
-    title: 'Stellar mass - [O/Fe]$_*$ relation (50 kpc aperture)'
-    section: Stellar Metallicity
-    caption: '[O/Fe] versus stellar mass, both computed in 50-kpc apertures. The values of [O/Fe] are obtained by computing the (log10 of) ratio between the total Oxygen mass in stars and total Iron mass in stars, and then normalising it by the corresponding solar abundances. The solar abundances are taken from Asplund et al. (2009). All haloes are plotted, including subhaloes.'
-  observational_data:
-    - filename: GalaxyStellarMassAlphatoIron/Gallazzi2021_Data_OFe.hdf5
+    - filename: GalaxyStellarMassAlphatoIron/RomeroGomez2023_ATLAS3D_Data_MgFe.hdf5
+    - filename: GalaxyStellarMassAlphatoIron/RomeroGomez2023_SphDwarfsLG_Data_MgFe.hdf5


### PR DESCRIPTION
Hello! Ignore the previous pull request. I think the tip of my remote repo was not right, which gave raise to the additional (unwanted) modification. Find the correct changes in this PR, where I am modifying the following file colibre/auto_plotter/metallicity.yml. I am adding the Romero-Gomez+ dataset that is already in the observational data repository. I am also deleting the [O/Fe] vs Stellar Mass plot, since the observational data to compare was not suite for it.
