### PR TITLE
Adding arrow in stellar abundance plots

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -344,7 +344,7 @@ scripts:
     section: Feedback kick velocities
     title: Maximal SNII kick velocity
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [C/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [C/H]Sun = 8.43. The median [C/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the GALAH survey (Buder et al. 2021). Contours use a log scale with 0.04 bin size and a minimum star count of 10. All recommended flags are applied to GALAH data to select stars (SN, FE/H and X/Fe quality flags).'
+    caption: '[Fe/H] vs [C/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [C/H]Sun = 8.43. The median [C/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the GALAH survey (Buder et al. 2021). Contours use a log scale with 0.04 bin size and a minimum star count of 10. All recommended flags are applied to GALAH data to select stars (SN, FE/H and X/Fe quality flags). The arrows at [Fe/H]=-4 indicate the median value of [C/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_CFe_GALAH.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [C/Fe]'
@@ -353,7 +353,7 @@ scripts:
       yvar: C_Fe
       dataset: GALAH
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [C/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [C/H]Sun = 8.43. The median [C/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size.'
+    caption: '[Fe/H] vs [C/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [C/H]Sun = 8.43. The median [C/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size. The arrows at [Fe/H]=-4 indicate the median value of [C/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_CFe_APOGEE.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [C/Fe]'
@@ -362,7 +362,7 @@ scripts:
       yvar: C_Fe
       dataset: APOGEE
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [C/O] using Asplund et al. (2009) values for [O/H]Sun = 8.69 and [C/H]Sun = 8.43. The median [C/O] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size.'
+    caption: '[Fe/H] vs [C/O] using Asplund et al. (2009) values for [O/H]Sun = 8.69 and [C/H]Sun = 8.43. The median [C/O] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size. The arrows at [Fe/H]=-4 indicate the median value of [C/O] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_CO_APOGEE.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [C/O]'
@@ -371,7 +371,7 @@ scripts:
       yvar: C_O
       dataset: APOGEE
   - filename: scripts/stellar_abundances.py
-    caption: '[O/H] vs [C/O] using Asplund et al. (2009) values for [O/H]Sun = 8.69 and [C/H]Sun = 8.43. The median [C/O] vs median [O/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size.'
+    caption: '[O/H] vs [C/O] using Asplund et al. (2009) values for [O/H]Sun = 8.69 and [C/H]Sun = 8.43. The median [C/O] vs median [O/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size. The arrows at [O/H]=-4 indicate the median value of [C/O] of gas with [O/H]<-4.'
     output_file: stellar_abundances_OH_CO_APOGEE.png
     section: Stellar Metal Abundances
     title: '[O/H] vs [C/O]'
@@ -380,7 +380,7 @@ scripts:
       yvar: C_O
       dataset: APOGEE
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [N/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [N/H]Sun = 7.83. The median [N/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size.'
+    caption: '[Fe/H] vs [N/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [N/H]Sun = 7.83. The median [N/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size. The arrows at [Fe/H]=-4 indicate the median value of [N/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_NFe_APOGEE.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [N/Fe]'
@@ -389,7 +389,7 @@ scripts:
       yvar: N_Fe
       dataset: APOGEE
   - filename: scripts/stellar_abundances.py
-    caption: '[O/H] vs [N/O] using Asplund et al. (2009) values for [O/H]Sun = 8.69 and [N/H]Sun = 7.83. The median [N/O] vs median [O/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size.'
+    caption: '[O/H] vs [N/O] using Asplund et al. (2009) values for [O/H]Sun = 8.69 and [N/H]Sun = 7.83. The median [N/O] vs median [O/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size. The arrows at [O/H]=-4 indicate the median value of [N/O] of gas with [O/H]<-4.'
     output_file: stellar_abundances_OH_NO_APOGEE.png
     section: Stellar Metal Abundances
     title: '[O/H] vs [N/O]'
@@ -398,7 +398,7 @@ scripts:
       yvar: N_O
       dataset: APOGEE
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [N/O] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5, [N/H]Sun = 7.83 and [O/H]Sun = 8.69. The median [N/O] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size.'
+    caption: '[Fe/H] vs [N/O] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5, [N/H]Sun = 7.83 and [O/H]Sun = 8.69. The median [N/O] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size. The arrows at [Fe/H]=-4 indicate the median value of [N/O] of gas with [O/H]<-4.'
     output_file: stellar_abundances_FeH_NO_APOGEE.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [N/O]'
@@ -407,7 +407,7 @@ scripts:
       yvar: N_O
       dataset: APOGEE
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [O/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [O/H]Sun = 8.69. The median [O/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the GALAH survey (Buder et al. 2021). Contours use a log scale with 0.04 bin size and a minimum star count of 10. All recommended flags are applied to GALAH data to select stars (SN, FE/H and X/Fe quality flags).'
+    caption: '[Fe/H] vs [O/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [O/H]Sun = 8.69. The median [O/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the GALAH survey (Buder et al. 2021). Contours use a log scale with 0.04 bin size and a minimum star count of 10. All recommended flags are applied to GALAH data to select stars (SN, FE/H and X/Fe quality flags). The arrows at [Fe/H]=-4 indicate the median value of [O/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_OFe_GALAH.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [O/Fe]'
@@ -416,7 +416,7 @@ scripts:
       yvar: O_Fe
       dataset: GALAH
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [O/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [O/H]Sun = 8.69. The median [O/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size.'
+    caption: '[Fe/H] vs [O/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [O/H]Sun = 8.69. The median [O/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size. The arrows at [Fe/H]=-4 indicate the median value of [O/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_OFe_APOGEE.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [O/Fe]'
@@ -425,7 +425,7 @@ scripts:
       yvar: O_Fe
       dataset: APOGEE
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [O/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [O/H]Sun = 8.69. The median [O/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the works of Mishenina+99, Israelian+98, Cayrel+04, Bai+04, Zhang+05, Koch+08. Most of these works assume Grevesser & Anders (1989) values for solar metallicity, their were corrected  to Asplund+09. Additional data includes Fornax (Letarte+07), Carina (Kock+05), Sculptor (Geisler+05) and  Sagittarious (Sbordone+07).'
+    caption: '[Fe/H] vs [O/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [O/H]Sun = 8.69. The median [O/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the works of Mishenina+99, Israelian+98, Cayrel+04, Bai+04, Zhang+05, Koch+08. Most of these works assume Grevesser & Anders (1989) values for solar metallicity, their were corrected  to Asplund+09. Additional data includes Fornax (Letarte+07), Carina (Kock+05), Sculptor (Geisler+05) and  Sagittarious (Sbordone+07). The arrows at [Fe/H]=-4 indicate the median value of [O/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_OFe.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [O/Fe]'
@@ -433,7 +433,7 @@ scripts:
       xvar: Fe_H
       yvar: O_Fe
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [Ne/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Ne/H]Sun = 7.93. The median [Ne/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles.'
+    caption: '[Fe/H] vs [Ne/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Ne/H]Sun = 7.93. The median [Ne/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The arrows at [Fe/H]=-4 indicate the median value of [Ne/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_NeFe.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [Ne/Fe]'
@@ -441,7 +441,7 @@ scripts:
       xvar: Fe_H
       yvar: Ne_Fe
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [Mg/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6. The median [Mg/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the GALAH survey (Buder et al. 2021). Contours use a log scale with 0.04 bin size and a minimum star count of 10. All recommended flags are applied to GALAH data to select stars (SN, FE/H and X/Fe quality flags).'
+    caption: '[Fe/H] vs [Mg/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6. The median [Mg/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the GALAH survey (Buder et al. 2021). Contours use a log scale with 0.04 bin size and a minimum star count of 10. All recommended flags are applied to GALAH data to select stars (SN, FE/H and X/Fe quality flags). The arrows at [Fe/H]=-4 indicate the median value of [Mg/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_MgFe_GALAH.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [Mg/Fe]'
@@ -450,7 +450,7 @@ scripts:
       yvar: Mg_Fe
       dataset: GALAH
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [Mg/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6. The median [Mg/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size.'
+    caption: '[Fe/H] vs [Mg/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6. The median [Mg/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size. The arrows at [Fe/H]=-4 indicate the median value of [Mg/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_MgFe_APOGEE.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [Mg/Fe]'
@@ -459,7 +459,7 @@ scripts:
       yvar: Mg_Fe
       dataset: APOGEE
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [Mg/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6. The median [Mg/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW, Carina, Fornax, Sculptor and Sagittarious corresponds to a data compilation presented by Tolstoy, Hill & Tosi (2009) and extracted by Rob Crain. Note solar metallicity of Grevesser & Anders (1989) was corrected to Asplund+09.'
+    caption: '[Fe/H] vs [Mg/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6. The median [Mg/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW, Carina, Fornax, Sculptor and Sagittarious corresponds to a data compilation presented by Tolstoy, Hill & Tosi (2009) and extracted by Rob Crain. Note solar metallicity of Grevesser & Anders (1989) was corrected to Asplund+09. The arrows at [Fe/H]=-4 indicate the median value of [Mg/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_MgFe.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [Mg/Fe]'
@@ -467,7 +467,7 @@ scripts:
       xvar: Fe_H
       yvar: Mg_Fe
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [Si/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Si/H]Sun = 7.51. The median [Si/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the GALAH survey (Buder et al. 2021). Contours use a log scale with 0.04 bin size and a minimum star count of 10. All recommended flags are applied to GALAH data to select stars (SN, FE/H and X/Fe quality flags).'
+    caption: '[Fe/H] vs [Si/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Si/H]Sun = 7.51. The median [Si/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the GALAH survey (Buder et al. 2021). Contours use a log scale with 0.04 bin size and a minimum star count of 10. All recommended flags are applied to GALAH data to select stars (SN, FE/H and X/Fe quality flags). The arrows at [Fe/H]=-4 indicate the median value of [Si/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_SiFe_GALAH.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [Si/Fe]'
@@ -476,7 +476,7 @@ scripts:
       yvar: Si_Fe
       dataset: GALAH
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [Sr/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Sr/H]Sun = 2.87. The median [Sr/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles.'
+    caption: '[Fe/H] vs [Sr/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Sr/H]Sun = 2.87. The median [Sr/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The arrows at [Fe/H]=-4 indicate the median value of [Sr/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_SrFe.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [Sr/Fe]'
@@ -484,7 +484,7 @@ scripts:
       xvar: Fe_H
       yvar: Sr_Fe
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [Ba/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Ba/H]Sun = 2.18. The median [Ba/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the GALAH survey (Buder et al. 2021). Contours use a log scale with 0.04 bin size and a minimum star count of 10. All recommended flags are applied to GALAH data to select stars (SN, FE/H and X/Fe quality flags).'
+    caption: '[Fe/H] vs [Ba/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Ba/H]Sun = 2.18. The median [Ba/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the GALAH survey (Buder et al. 2021). Contours use a log scale with 0.04 bin size and a minimum star count of 10. All recommended flags are applied to GALAH data to select stars (SN, FE/H and X/Fe quality flags). The arrows at [Fe/H]=-4 indicate the median value of [Ba/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_BaFe_GALAH.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [Ba/Fe]'
@@ -493,7 +493,7 @@ scripts:
       yvar: Ba_Fe
       dataset: GALAH
   - filename: scripts/stellar_abundances.py
-    caption: '[Fe/H] vs [Eu/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Eu/H]Sun = 0.52. The median [Eu/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the GALAH survey (Buder et al. 2021). Contours use a log scale with 0.04 bin size and a minimum star count of 10. All recommended flags are applied to GALAH data to select stars (SN, FE/H and X/Fe quality flags).'
+    caption: '[Fe/H] vs [Eu/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [Eu/H]Sun = 0.52. The median [Eu/Fe] vs median [Fe/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the GALAH survey (Buder et al. 2021). Contours use a log scale with 0.04 bin size and a minimum star count of 10. All recommended flags are applied to GALAH data to select stars (SN, FE/H and X/Fe quality flags). The arrows at [Fe/H]=-4 indicate the median value of [Eu/Fe] of gas with [Fe/H]<-4.'
     output_file: stellar_abundances_FeH_EuFe_GALAH.png
     section: Stellar Metal Abundances
     title: '[Fe/H] vs [Eu/Fe]'
@@ -502,7 +502,7 @@ scripts:
       yvar: Eu_Fe
       dataset: GALAH
   - filename: scripts/stellar_abundances.py
-    caption: '[O/H] vs [O/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [O/H]Sun = 8.69. The median [O/Fe] vs median [O/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size.'
+    caption: '[O/H] vs [O/Fe] using Asplund et al. (2009) values for [Fe/H]Sun = 7.5 and [O/H]Sun = 8.69. The median [O/Fe] vs median [O/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size. The arrows at [O/H]=-4 indicate the median value of [O/Fe] of gas with [O/H]<-4.'
     output_file: stellar_abundances_OH_OFe_APOGEE.png
     section: Stellar Metal Abundances
     title: '[O/H] vs [O/Fe]'
@@ -511,7 +511,7 @@ scripts:
       yvar: O_Fe
       dataset: APOGEE
   - filename: scripts/stellar_abundances.py
-    caption: '[O/H] vs [Mg/Fe] using Asplund et al. (2009) values for [O/H]Sun = 8.69 and [Mg/H]Sun = 7.6. The median [Mg/Fe] vs median [O/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size.'
+    caption: '[O/H] vs [Mg/Fe] using Asplund et al. (2009) values for [O/H]Sun = 8.69 and [Mg/H]Sun = 7.6. The median [Mg/Fe] vs median [O/H] is indicated by the solid curve(s). The scatter points show abundances of individual stellar particles. The observational data for MW compiles the data from the APOGEE survey (Holtzman et al. 2018) and AstroNN added-value catalog (Leung, H.W. & Bovy, Jo 2019b). We create 6 stellar distributions by selecting stars from APOGEE based on galactocentric radial & azimuthal cuts, and combine them in order to derive a joint stellar abundance distribution that gives less weight to stars in the solar vicinity. The resulting contours use a log scale with 0.2 bin size. The arrows at [O/H]=-4 indicate the median value of [Mg/Fe] of gas with [O/H]<-4.'
     output_file: stellar_abundances_OH_MgFe_APOGEE.png
     section: Stellar Metal Abundances
     title: '[O/H] vs [Mg/Fe]'

--- a/colibre/scripts/stellar_abundances.py
+++ b/colibre/scripts/stellar_abundances.py
@@ -276,7 +276,16 @@ for isnap, (snapshot_filename, name) in enumerate(zip(snapshot_filenames, names)
     if yvar != "Fe_SNIa_fraction":
         mask = xval < -4
         ym = np.median(yval[mask])
-        ax.arrow(-3.6, ym, -0.2, 0, head_width=0.05, head_length=0.1, color=colour, zorder=1000)
+        ax.arrow(
+            -3.6,
+            ym,
+            -0.2,
+            0,
+            head_width=0.05,
+            head_length=0.1,
+            color=colour,
+            zorder=1000,
+        )
 
 path_to_obs_data = f"{arguments.config.config_directory}/{arguments.config.observational_data_directory}"
 if dataset == "APOGEE":

--- a/colibre/scripts/stellar_abundances.py
+++ b/colibre/scripts/stellar_abundances.py
@@ -129,82 +129,69 @@ def read_data(data, xvar, yvar):
 
     if xvar == "O_H":
         O_H = np.log10(oxygen / hydrogen) - O_H_Sun
-        O_H[oxygen == 0] = -4  # set lower limit
-        O_H[O_H < -4] = -4  # set lower limit
+        O_H[oxygen == 0] = -10  # set lower limit
         xval = O_H
     elif xvar == "Fe_H":
         Fe_H = np.log10(iron / hydrogen) - Fe_H_Sun
-        Fe_H[iron == 0] = -4  # set lower limit
-        Fe_H[Fe_H < -4] = -4  # set lower limit
+        Fe_H[iron == 0] = -10  # set lower limit
         xval = Fe_H
     else:
         raise AttributeError(f"Unknown x variable: {xvar}!")
 
     if yvar == "C_Fe":
         C_Fe = np.log10(carbon / iron) - C_Fe_Sun
-        C_Fe[iron == 0] = -2  # set lower limit
-        C_Fe[carbon == 0] = -2  # set lower limit
-        C_Fe[C_Fe < -2] = -2  # set lower limit
+        C_Fe[iron == 0] = -10  # set lower limit
+        C_Fe[carbon == 0] = -10  # set lower limit
         yval = C_Fe
     elif yvar == "N_Fe":
         N_Fe = np.log10(nitrogen / iron) - N_Fe_Sun
-        N_Fe[iron == 0] = -2  # set lower limit
-        N_Fe[nitrogen == 0] = -2  # set lower limit
-        N_Fe[N_Fe < -2] = -2  # set lower limit
+        N_Fe[iron == 0] = -10  # set lower limit
+        N_Fe[nitrogen == 0] = -10  # set lower limit
         yval = N_Fe
     elif yvar == "N_O":
         N_O = np.log10(nitrogen / oxygen) - N_O_Sun
-        N_O[oxygen == 0] = -2  # set lower limit
-        N_O[nitrogen == 0] = -2  # set lower limit
-        N_O[N_O < -2] = -2  # set lower limit
+        N_O[oxygen == 0] = -10  # set lower limit
+        N_O[nitrogen == 0] = -10  # set lower limit
         yval = N_O
     elif yvar == "C_O":
         C_O = np.log10(carbon / oxygen) - C_O_Sun
-        C_O[oxygen == 0] = -2  # set lower limit
-        C_O[carbon == 0] = -2  # set lower limit
-        C_O[C_O < -2] = -2  # set lower limit
+        C_O[oxygen == 0] = -10  # set lower limit
+        C_O[carbon == 0] = -10  # set lower limit
         yval = C_O
     elif yvar == "O_Fe":
         O_Fe = np.log10(oxygen / iron) - O_Fe_Sun
-        O_Fe[iron == 0] = -2  # set lower limit
-        O_Fe[oxygen == 0] = -2  # set lower limit
-        O_Fe[O_Fe < -2] = -2  # set lower limit
+        O_Fe[iron == 0] = -10  # set lower limit
+        O_Fe[oxygen == 0] = -10  # set lower limit
         yval = O_Fe
     elif yvar == "Mg_Fe":
         Mg_Fe = np.log10(magnesium / iron) - Mg_Fe_Sun
-        Mg_Fe[iron == 0] = -2  # set lower limit
-        Mg_Fe[magnesium == 0] = -2  # set lower limit
-        Mg_Fe[Mg_Fe < -2] = -2  # set lower limit
+        Mg_Fe[iron == 0] = -10  # set lower limit
+        Mg_Fe[magnesium == 0] = -10  # set lower limit
         yval = Mg_Fe
     elif yvar == "Si_Fe":
         Si_Fe = np.log10(silicon / iron) - Si_Fe_Sun
-        Si_Fe[iron == 0] = -2  # set lower limit
-        Si_Fe[silicon == 0] = -2  # set lower limit
-        Si_Fe[Si_Fe < -2] = -2  # set lower limit
+        Si_Fe[iron == 0] = -10  # set lower limit
+        Si_Fe[silicon == 0] = -10  # set lower limit
         yval = Si_Fe
     elif yvar == "Ne_Fe":
         Ne_Fe = np.log10(neon / iron) - Ne_Fe_Sun
-        Ne_Fe[iron == 0] = -2  # set lower limit
-        Ne_Fe[neon == 0] = -2  # set lower limit
-        Ne_Fe[Ne_Fe < -2] = -2  # set lower limit
+        Ne_Fe[iron == 0] = -10  # set lower limit
+        Ne_Fe[neon == 0] = -10  # set lower limit
         yval = Ne_Fe
     elif yvar == "Eu_Fe":
         Eu_Fe = np.log10(europium / iron) - Eu_Fe_Sun
-        Eu_Fe[iron == 0] = -2  # set lower limit
-        Eu_Fe[europium == 0] = -2  # set lower limit
-        Eu_Fe[Eu_Fe < -2] = -2  # set lower limit
+        Eu_Fe[iron == 0] = -10  # set lower limit
+        Eu_Fe[europium == 0] = -10  # set lower limit
         yval = Eu_Fe
     elif yvar == "Ba_Fe":
         Ba_Fe = np.log10(barium / iron) - Ba_Fe_Sun
-        Ba_Fe[iron == 0] = -2  # set lower limit
-        Ba_Fe[barium == 0] = -2  # set lower limit
-        Ba_Fe[Ba_Fe < -2] = -2  # set lower limit
+        Ba_Fe[iron == 0] = -10  # set lower limit
+        Ba_Fe[barium == 0] = -10  # set lower limit
         yval = Ba_Fe
     elif yvar == "Sr_Fe":
         Sr_Fe = np.log10(strontium / iron) - Sr_Fe_Sun
-        Sr_Fe[iron == 0] = -2  # set lower limit
-        Sr_Fe[strontium == 0] = -2  # set lower limit
-        Sr_Fe[Sr_Fe < -2] = -2  # set lower limit
+        Sr_Fe[iron == 0] = -10  # set lower limit
+        Sr_Fe[strontium == 0] = -10  # set lower limit
         yval = Sr_Fe
     elif yvar == "Fe_SNIa_fraction":
         Fe_snia_fraction = unyt_array(np.zeros_like(iron), "dimensionless")
@@ -284,6 +271,12 @@ for isnap, (snapshot_filename, name) in enumerate(zip(snapshot_filenames, names)
         )[0]
     )
     simulation_labels.append(f"{name} ($z={redshift:.1f}$)")
+
+    # Let's add lower symbol indicating the median for [Fe/H]<-4:
+    if yvar != "Fe_SNIa_fraction":
+        mask = xval < -4
+        ym = np.median(yval[mask])
+        ax.arrow(-3.6, ym, -0.2, 0, head_width=0.05, head_length=0.1, color=colour, zorder=1000)
 
 path_to_obs_data = f"{arguments.config.config_directory}/{arguments.config.observational_data_directory}"
 if dataset == "APOGEE":


### PR DESCRIPTION
In this PR we are adding an arrow in the stellar abundance plots to show lower median values [X/Fe] that are not shown in the figure ([Fe/H]<-4). Note that we are also decreasing the lower limit value to -10 in case iron (or other elements) are zero, and we are removing the lower limits of [X/Fe]<-2 that were overwriting some values.

See this figure as example:

![stellar_abundances_FeH_MgFe_APOGEE](https://github.com/SWIFTSIM/pipeline-configs/assets/35491033/b061530e-16ea-48ed-97d7-eac6b827015a)
