### PR TITLE
Add two new plots with dust depletion relations using a stellar-mass cut

### DIFF
--- a/colibre/auto_plotter/depletion_relations.yml
+++ b/colibre/auto_plotter/depletion_relations.yml
@@ -1,46 +1,6 @@
 oxygen_abundance_v_neutral_dust_to_gas:
   type: "scatter"
   legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_50_kpc"
-  x:
-    quantity: "derived_quantities.gas_o_abundance_avglog_low_50_kpc"
-    units: "dimensionless"
-    start: 6.8
-    end: 9.7
-    log: false
-  y:
-    quantity: "derived_quantities.neutral_dust_to_gas_ratio_50_kpc"
-    units: "dimensionless"
-    start: 1e-7
-    end: 0.05
-  median:
-    plot: true
-    log: false
-    adaptive: true
-    number_of_bins: 15
-    start:
-      value: 7
-      units: "dimensionless"
-    end:
-      value: 10
-      units: "dimensionless"
-    lower:
-      value: 0
-      units: "dimensionless"
-    upper:
-      value: 1
-      units: "dimensionless"
-  metadata:
-    title:  Oxygen abundance vs dust-to-gas ratio in Neutral Gas (50 kpc aperture)
-    caption: Dust-to-gas mass ratio as a function of oxygen number density abundance in Neutral gas.
-    section: Dust Depletion Relations
-    show_on_webpage: true
-  observational_data:
-    - filename: GalaxyMetallicityDusttoGasRatio/Konstantopoulou2023.hdf5
-
-oxygen_abundance_v_neutral_dust_to_gas:
-  type: "scatter"
-  legend_loc: "lower right"
   selection_mask: "derived_quantities.is_active_30_kpc"
   x:
     quantity: "derived_quantities.gas_o_abundance_avglog_low_30_kpc"
@@ -72,7 +32,47 @@ oxygen_abundance_v_neutral_dust_to_gas:
       units: "dimensionless"
   metadata:
     title:  Oxygen abundance vs dust-to-gas ratio in Neutral Gas (30 kpc aperture)
-    caption: Dust-to-gas mass ratio as a function of oxygen number density abundance in Neutral gas.
+    caption: Dust-to-gas mass ratio as a function of oxygen number density abundance in Neutral gas. Only active galaxies are selected.
+    section: Dust Depletion Relations
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyMetallicityDusttoGasRatio/Konstantopoulou2023.hdf5
+
+oxygen_abundance_v_neutral_dust_to_gas_mstar_gtr_1e9:
+  type: "scatter"
+  legend_loc: "lower right"
+  selection_mask: "derived_quantities.stellar_mass_is_bigger_than_1e9_msun_active_30_kpc"
+  x:
+    quantity: "derived_quantities.gas_o_abundance_avglog_low_30_kpc"
+    units: "dimensionless"
+    start: 6.8
+    end: 9.7
+    log: false
+  y:
+    quantity: "derived_quantities.neutral_dust_to_gas_ratio_30_kpc"
+    units: "dimensionless"
+    start: 1e-7
+    end: 0.05
+  median:
+    plot: true
+    log: false
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 7
+      units: "dimensionless"
+    end:
+      value: 10
+      units: "dimensionless"
+    lower:
+      value: 0
+      units: "dimensionless"
+    upper:
+      value: 1
+      units: "dimensionless"
+  metadata:
+    title:  Oxygen abundance vs dust-to-gas ratio in Neutral Gas (30 kpc aperture)
+    caption: Dust-to-gas mass ratio as a function of oxygen number density abundance in Neutral gas. Only galaxies that are active and have $M_* > 10^9 \, \rm M_\odot$ are selected. 
     section: Dust Depletion Relations
     show_on_webpage: true
   observational_data:
@@ -112,52 +112,11 @@ oxygen_abundance_fromz_v_neutral_dust_to_gas:
       units: "dimensionless"
   metadata:
     title:  Oxygen abundance (from Z) vs dust-to-gas ratio in Neutral Gas (30 kpc aperture)
-    caption: Dust-to-gas mass ratio as a function of metallicity represented as an oxygen number density abundance for compatibility with observations.
+    caption: Dust-to-gas mass ratio as a function of metallicity represented as an oxygen number density abundance for compatibility with observations. Only active galaxies are selected.
     section: Dust Depletion Relations
     show_on_webpage: true
   observational_data:
     - filename: GalaxyMetallicityDusttoGasRatio/Konstantopoulou2023.hdf5
-
-
-oxygen_abundance_v_neutral_dust_to_gas:
-  type: "scatter"
-  legend_loc: "lower right"
-  selection_mask: "derived_quantities.is_active_30_kpc"
-  x:
-    quantity: "derived_quantities.gas_o_abundance_avglog_low_30_kpc"
-    units: "dimensionless"
-    start: 6.8
-    end: 9.7
-    log: false
-  y:
-    quantity: "derived_quantities.neutral_dust_to_gas_ratio_30_kpc"
-    units: "dimensionless"
-    start: 1e-7
-    end: 0.05
-  median:
-    plot: true
-    log: false
-    adaptive: true
-    number_of_bins: 15
-    start:
-      value: 7
-      units: "dimensionless"
-    end:
-      value: 10
-      units: "dimensionless"
-    lower:
-      value: 0
-      units: "dimensionless"
-    upper:
-      value: 1
-      units: "dimensionless"
-  metadata:
-    title:  Oxygen abundance vs dust-to-gas ratio in Neutral Gas (30 kpc aperture)
-    caption: Dust-to-gas mass ratio as a function of oxygen number density abundance in Neutral gas.
-    section: Dust Depletion Relations
-    show_on_webpage: true
-  observational_data:
-    - filename: GalaxyMetallicityDusttoGasRatio/Konstantopoulou2023.hdf5  
 
 oxygen_abundance_v_neutral_dust_to_metal:
   type: "scatter"
@@ -194,14 +153,56 @@ oxygen_abundance_v_neutral_dust_to_metal:
       units: "dimensionless"
   metadata:
     title:  Oxygen abundance vs dust-to-metal ratio in Neutral Gas (30 kpc aperture)
-    caption: Dust-to-metal mass ratio as a function of oxygen number density abundance in Neutral gas.
+    caption: Dust-to-metal mass ratio as a function of oxygen number density abundance in Neutral gas. Only active galaxies are selected.
     section: Dust Depletion Relations
     show_on_webpage: true
   observational_data:
     - filename: GalaxyMetallicityDusttoMetalRatio/Peroux2020.hdf5
     - filename: GalaxyMetallicityDusttoMetalRatio/Konstantopoulou2023.hdf5  
 
-oxygen_abundance_Fromz_v_neutral_dust_to_metal:
+oxygen_abundance_v_neutral_dust_to_metal_mstar_gtr_1e9:
+  type: "scatter"
+  legend_loc: "lower right"
+  selection_mask: "derived_quantities.stellar_mass_is_bigger_than_1e9_msun_active_30_kpc"
+  x:
+    quantity: "derived_quantities.gas_o_abundance_avglog_low_30_kpc"
+    units: "dimensionless"
+    start: 6.8
+    end: 9.7
+    log: false
+  y:
+    quantity: "derived_quantities.cold_dense_dust_to_metal_ratio_30_kpc"
+    units: "dimensionless"
+    start: 1e-3
+    end: 5
+    log: true
+  median:
+    plot: true
+    log: false
+    adaptive: true
+    number_of_bins: 15
+    start:
+      value: 7
+      units: "dimensionless"
+    end:
+      value: 10
+      units: "dimensionless"
+    lower:
+      value: 0
+      units: "dimensionless"
+    upper:
+      value: 1
+      units: "dimensionless"
+  metadata:
+    title:  Oxygen abundance vs dust-to-metal ratio in Neutral Gas (30 kpc aperture)
+    caption: Dust-to-metal mass ratio as a function of oxygen number density abundance in Neutral gas. Only galaxies that are active and have $M_* > 10^9 \, \rm M_\odot$ are selected.
+    section: Dust Depletion Relations
+    show_on_webpage: true
+  observational_data:
+    - filename: GalaxyMetallicityDusttoMetalRatio/Peroux2020.hdf5
+    - filename: GalaxyMetallicityDusttoMetalRatio/Konstantopoulou2023.hdf5  
+
+oxygen_abundance_fromz_v_neutral_dust_to_metal:
   type: "scatter"
   legend_loc: "lower right"
   selection_mask: "derived_quantities.is_active_30_kpc"
@@ -236,7 +237,7 @@ oxygen_abundance_Fromz_v_neutral_dust_to_metal:
       units: "dimensionless"
   metadata:
     title:  Oxygen abundance (from Z) vs dust-to-metal ratio in Neutral Gas (30 kpc aperture)
-    caption: Dust-to-metal mass ratio as a function of metallicity, converted into an oxygen number density abundance for compatability with observations.
+    caption: Dust-to-metal mass ratio as a function of metallicity, converted into an oxygen number density abundance for compatability with observations. Only active galaxies are selected.
     section: Dust Depletion Relations
     show_on_webpage: true
   observational_data:

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -92,6 +92,16 @@ def register_specific_star_formation_rates(self, catalogue, aperture_sizes):
         )
         is_active.name = "Active Fraction"
 
+        # Mask for active galaxies above 10^9 Msun
+        is_bigger_than_1e9_active = unyt.unyt_array(
+            (
+                (stellar_mass > (1e9 * unyt.Msun).to(stellar_mass.units))
+                & (ssfr > (1.01 * marginal_ssfr).to(ssfr.units))
+            ).astype(float),
+            units="dimensionless",
+        )
+        is_bigger_than_1e9_active.name = "Stellar mass larger than 10^9 Msun and active"
+
         # Mask for galaxies above 10^10 Msun
         is_bigger_than_1e10 = unyt.unyt_array(
             (stellar_mass > unyt.unyt_quantity(1e10, units="Msun")).astype(float),
@@ -99,7 +109,7 @@ def register_specific_star_formation_rates(self, catalogue, aperture_sizes):
         )
         is_bigger_than_1e10.name = "Stellar mass larger than 10^10 Msun"
 
-        # Mask for galaxies above 10^10 Msun
+        # Mask for active galaxies above 10^10 Msun
         is_bigger_than_1e10_active = unyt.unyt_array(
             (
                 (stellar_mass > (1e10 * unyt.Msun).to(stellar_mass.units))
@@ -118,7 +128,7 @@ def register_specific_star_formation_rates(self, catalogue, aperture_sizes):
         )
         is_bigger_than_5e10.name = "Stellar mass larger than 5 $\\times$ 10^10 Msun"
 
-        # Mask for galaxies above 5 * 10^10 Msun
+        # Mask for active galaxies above 5 * 10^10 Msun
         is_bigger_than_5e10_active = unyt.unyt_array(
             (
                 (stellar_mass > (5e10 * unyt.Msun).to(stellar_mass.units))
@@ -149,6 +159,11 @@ def register_specific_star_formation_rates(self, catalogue, aperture_sizes):
             self,
             f"stellar_mass_is_bigger_than_1e10_msun_{aperture_size}_kpc",
             is_bigger_than_1e10,
+        )
+        setattr(
+            self,
+            f"stellar_mass_is_bigger_than_1e9_msun_active_{aperture_size}_kpc",
+            is_bigger_than_1e9_active,
         )
         setattr(
             self,


### PR DESCRIPTION
- Add a stellar-mass mask (Mstar > 1e9 Msun) for active galaxies in `registraction.py`
- Add two new plots with dust depletion relations based on the new mask. The simulation data shown in these plots corresponds to galaxies that are not only active but also have Mstar > 1e9 Msun

An example of the dust section with the new plots can be found here: https://swift.dur.ac.uk/COLIBREPlots/chaikin/comparisons/YEAR2023/z0.0_L12N376_vary_dust_clumping/index.html#983660477724058836

An example of the older version of the same section (without the two new plots) can be found here: https://swift.dur.ac.uk/COLIBREPlots/chaikin/comparisons/YEAR2023/z0.0_L12N376_increase_BH_seed_mass/index.html#2422449837951610890

Note that in this PR, I also slightly cleaned  up the `depletion_relations.yml` file, removing the code that is of no use.