### PR TITLE
Set aspect ratio for density-temperature plots

### DIFF
--- a/colibre/scripts/bh_masses.py
+++ b/colibre/scripts/bh_masses.py
@@ -51,8 +51,14 @@ def setup_axes(mass_bounds, number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/birth_density_metallicity.py
+++ b/colibre/scripts/birth_density_metallicity.py
@@ -74,8 +74,14 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/birth_density_redshift.py
+++ b/colibre/scripts/birth_density_redshift.py
@@ -60,8 +60,14 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/birth_density_temperature.py
+++ b/colibre/scripts/birth_density_temperature.py
@@ -62,8 +62,14 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/birth_metallicity_redshift.py
+++ b/colibre/scripts/birth_metallicity_redshift.py
@@ -72,8 +72,14 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_internal_energy.py
+++ b/colibre/scripts/density_internal_energy.py
@@ -61,8 +61,10 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        figsize=(fig_w, fig_h)
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_internal_energy.py
+++ b/colibre/scripts/density_internal_energy.py
@@ -61,10 +61,14 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
-    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
-        figsize=(fig_w, fig_h)
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_pressure.py
+++ b/colibre/scripts/density_pressure.py
@@ -63,10 +63,14 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
-    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
-        figsize=(fig_w, fig_h)
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_pressure.py
+++ b/colibre/scripts/density_pressure.py
@@ -63,8 +63,10 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        figsize=(fig_w, fig_h)
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_species_depletions.py
+++ b/colibre/scripts/density_species_depletions.py
@@ -195,8 +195,14 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_species_diffuse.py
+++ b/colibre/scripts/density_species_diffuse.py
@@ -197,8 +197,14 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_species_interp.py
+++ b/colibre/scripts/density_species_interp.py
@@ -198,8 +198,14 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature.py
+++ b/colibre/scripts/density_temperature.py
@@ -63,10 +63,14 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
-    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
-        figsize=(fig_w, fig_h)
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature.py
+++ b/colibre/scripts/density_temperature.py
@@ -63,8 +63,10 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        figsize=(fig_w, fig_h)
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_dust.py
+++ b/colibre/scripts/density_temperature_dust.py
@@ -83,8 +83,10 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        figsize=(fig_w, fig_h)
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_dust.py
+++ b/colibre/scripts/density_temperature_dust.py
@@ -83,10 +83,14 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
-    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
-        figsize=(fig_w, fig_h)
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_dust2metal.py
+++ b/colibre/scripts/density_temperature_dust2metal.py
@@ -90,8 +90,10 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        figsize=(fig_w, fig_h)
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_dust2metal.py
+++ b/colibre/scripts/density_temperature_dust2metal.py
@@ -90,10 +90,14 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
-    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
-        figsize=(fig_w, fig_h)
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_dust_to_metals.py
+++ b/colibre/scripts/density_temperature_dust_to_metals.py
@@ -92,10 +92,14 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
-    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
-        figsize=(fig_w, fig_h)
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_dust_to_metals.py
+++ b/colibre/scripts/density_temperature_dust_to_metals.py
@@ -92,8 +92,10 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        figsize=(fig_w, fig_h)
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_metals.py
+++ b/colibre/scripts/density_temperature_metals.py
@@ -75,10 +75,14 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
-    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
-        figsize=(fig_w, fig_h)
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_metals.py
+++ b/colibre/scripts/density_temperature_metals.py
@@ -75,8 +75,10 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        figsize=(fig_w, fig_h)
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_sf_fraction.py
+++ b/colibre/scripts/density_temperature_sf_fraction.py
@@ -88,10 +88,14 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
-    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
-        figsize=(fig_w, fig_h)
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_sf_fraction.py
+++ b/colibre/scripts/density_temperature_sf_fraction.py
@@ -88,8 +88,10 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number/horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        figsize=(fig_w, fig_h)
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/density_temperature_species.py
+++ b/colibre/scripts/density_temperature_species.py
@@ -91,8 +91,14 @@ def setup_axes(number_of_simulations: int, prop_type="hydro"):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/gas_minimal_smoothing_length_redshift.py
+++ b/colibre/scripts/gas_minimal_smoothing_length_redshift.py
@@ -120,8 +120,14 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/max_temperature_redshift.py
+++ b/colibre/scripts/max_temperature_redshift.py
@@ -65,8 +65,14 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/median_temperature_density.py
+++ b/colibre/scripts/median_temperature_density.py
@@ -47,8 +47,10 @@ if __name__ == "__main__":
             nlabel % number_of_simulations > 0
         )
 
+    fig_w, fig_h = pl.figaspect(vertical_number/horizontal_number)
     fig, ax = pl.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
+        figsize=(fig_w, fig_h)
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/median_temperature_density.py
+++ b/colibre/scripts/median_temperature_density.py
@@ -47,10 +47,14 @@ if __name__ == "__main__":
             nlabel % number_of_simulations > 0
         )
 
-    fig_w, fig_h = pl.figaspect(vertical_number/horizontal_number)
+    fig_w, fig_h = pl.figaspect(vertical_number / horizontal_number)
     fig, ax = pl.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True,
-        figsize=(fig_w, fig_h)
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax

--- a/colibre/scripts/particle_updates_step_cost.py
+++ b/colibre/scripts/particle_updates_step_cost.py
@@ -71,8 +71,14 @@ def setup_axes(number_of_simulations: int):
     # Ensure >= number_of_simulations plots in a grid
     vertical_number = int(np.ceil(number_of_simulations / horizontal_number))
 
+    fig_w, fig_h = plt.figaspect(vertical_number / horizontal_number)
     fig, ax = plt.subplots(
-        vertical_number, horizontal_number, squeeze=True, sharex=True, sharey=True
+        vertical_number,
+        horizontal_number,
+        squeeze=True,
+        sharex=True,
+        sharey=True,
+        figsize=(fig_w, fig_h),
     )
 
     ax = np.array([ax]) if number_of_simulations == 1 else ax


### PR DESCRIPTION
Update the plot aspect ratio so that more ticks will be shown on the x axis. We still end up with only one tick when comparing 7 simulations, but that never really happens anyway. Examples of different numbers of simulations are below.

![density_temperature](https://github.com/SWIFTSIM/pipeline-configs/assets/36136863/d39832e1-5763-4e06-9657-0ba5631da39a)
![density_temperature](https://github.com/SWIFTSIM/pipeline-configs/assets/36136863/1e12e151-c263-4578-84cf-5f9eb6a6576c)
![density_temperature](https://github.com/SWIFTSIM/pipeline-configs/assets/36136863/4254aaaf-6ccc-4f43-a76e-eafe18bc6f60)
![density_temperature](https://github.com/SWIFTSIM/pipeline-configs/assets/36136863/e52b43e5-c6f5-457c-8794-56e7d3e7f91e)

![density_temperature](https://github.com/SWIFTSIM/pipeline-configs/assets/36136863/f8c1660a-8982-4202-88f5-e7842eba615a)
