### PR TITLE
Display AGN variable dT model's parameters on webpage

### DIFF
--- a/colibre/description.html
+++ b/colibre/description.html
@@ -381,6 +381,38 @@
 
 <h4>AGN feedback</h4>
 {% if data.metadata.parameters.get("COLIBREAGN:AGN_delta_T_K", False) %}
+    {% if data.metadata.parameters.get("COLIBREAGN:AGN_delta_T_floor_K", False) %}
+    <p>Parameters of the variable AGN \(\Delta T\) model</p>
+    <table>
+        <tr>
+            <th>\(\Delta T_{\rm min}\) </th>
+            <th>\(\Delta T_{\rm max}\)</th>
+            <th>\(\Delta T_{\rm pivot}\)</th>
+            <th>\(M_{\rm BH,pivot}\)</th>
+            <th>\(\rm Slope\)</th>
+        </tr>
+        <tr>
+            <td>{{ data.metadata.parameters | get_if_present_float("COLIBREAGN:AGN_delta_T_floor_K", "K") }}</td>
+            <td>{{ data.metadata.parameters | get_if_present_float("COLIBREAGN:AGN_delta_T_K", "K") }}</td>
+            <td>{{ data.metadata.parameters | get_if_present_float("COLIBREAGN:AGN_delta_T_K", "K") }}</td>
+            <td>{{ data.metadata.parameters | get_if_present_float("COLIBREAGN:delta_T_Mass_Msun", "Msun") }}</td>
+            <td>1.0</td>
+        </tr>
+    </table>
+    {% else %}
+    <p>Parameters of the constant AGN \(\Delta T\) model</p>
+    <table>
+    <tr>
+        <th>Parameter</th>
+        <th>Value</th>
+    </tr>
+    <tr>
+        <td>\(\Delta T\)</td>
+        <td>{{ data.metadata.parameters | get_if_present_float("COLIBREAGN:AGN_delta_T_K", "K") }}</td>
+    </tr>
+    </table>
+    {% endif %}
+<p>Other AGN parameters</p>
 <table>
     <tr>
         <th>Parameter</th>
@@ -393,10 +425,6 @@
     <tr>
         <td>Use Deterministic Feedback</td>
         <td>{{ data.metadata.parameters | get_if_present_int("COLIBREAGN:AGN_use_deterministic_feedback") }}</td>
-    </tr>
-    <tr>
-        <td>\(\Delta T\)</td>
-        <td>{{ data.metadata.parameters | get_if_present_float("COLIBREAGN:AGN_delta_T_K", "K") }}</td>
     </tr>
     <tr>
         <td>Coupling efficiency</td>


### PR DESCRIPTION
![Screenshot from 2024-04-02 12-21-43](https://github.com/SWIFTSIM/pipeline-configs/assets/20153933/79b76982-1796-4655-bbed-0b9f47e1b286)


Note that 

- The general expression is `dT_AGN = dT_AGN_pivot * (M_BH / M_BH_pivot) ** slope` with a constraint  `dT_AGN_min  < dT_AGN  < dT_AGN_max`
- in the code, we always use the slope of 1
- in the code, the pivot and maximum temperatures are described by the same parameter. This is because the pivot point is arbitrary, so we don't really need an extra parameter to specify it; instead, we can just use either `dT_AGN_min` or `dT_AGN_max`.

The reason why I decided to display some extra information than in fact used internally in the code (5 params instead of 3), is to make the webpage more clear and less ambiguous