### PR TITLE
Two new plots with the information on the SN energy fractions

### DIFF
--- a/colibre/config.yml
+++ b/colibre/config.yml
@@ -103,10 +103,20 @@ scripts:
     section: Stellar Birth Properties
     output_file: birth_pressure_distribution.png
   - filename: scripts/snii_energy_fraction_distribution.py
-    caption: Distributions of SNII energy fractions, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median SNII energy fraction in three different redshift intervals. The dotted vertical line shows the average SNII energy fraction computed over all star particles in the simulation.
-    title: SNII Energy Fraction
-    section: Stellar Birth Properties
+    caption: Distribution of SNII energy fractions, split by redshift. The y-axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median SNII energy fraction in three different redshift intervals. The dotted vertical line shows the average SNII energy fraction computed over all star particles in the simulation.
+    title: SNII Energy Fraction Distribution
+    section: SN Feedback Energy Fractions
     output_file: snii_energy_fraction_distribution.png
+  - filename: scripts/snii_energy_fraction_birth_pressure.py
+    caption: The relation between the SNII energy fraction and stellar birth pressure. The dashed vertical lines indicate the pivot birth pressure used in the simulation.
+    title: SNII Energy Fraction vs. Stellar Birth Pressure
+    section: SN Feedback Energy Fractions
+    output_file: snii_energy_fraction_birth_pressure.png
+  - filename: scripts/snii_energy_fraction_stellar_mass.py
+    caption: The SNII energy fraction evaluated at the galaxy median stellar birth pressure vs. galaxy stellar mass. The solid lines indicate the median values in stellar mass bins, while the shaded regions indicate the 16-84 percentile scatter.
+    title: SNII Energy Fraction vs. Galaxy Stellar Mass
+    section: SN Feedback Energy Fractions
+    output_file: snii_energy_fraction_stellar_mass.png
   - filename: scripts/birth_temperature_distribution.py
     caption: Distributions of stellar birth temperatures, split by redshift. The y axis shows the number of stars per bin divided by the bin width and by the total number of stars. The dashed vertical lines show the median stellar birth-temperatures.
     title: Stellar Birth Temperatures

--- a/colibre/scripts/snii_energy_fraction_birth_pressure.py
+++ b/colibre/scripts/snii_energy_fraction_birth_pressure.py
@@ -1,15 +1,17 @@
 """
-Plots the SNII energy fraction distribution.
+Plots the SNII energy fraction vs. stellar birth pressure.
 """
 
 import matplotlib.pyplot as plt
 import numpy as np
 import unyt
 
-from unyt import mh
-
 from swiftsimio import load
 from swiftpipeline.argumentparser import ScriptArgumentParser
+
+# Set x-axis limits
+pressure_bounds = [1e1, 1e9]
+log_pressure_bounds = np.log10(pressure_bounds)
 
 
 def energy_fraction(
@@ -46,7 +48,7 @@ def get_snapshot_param_float(snapshot, param_name: str) -> float:
 
 
 arguments = ScriptArgumentParser(
-    description="Creates an SNII energy fraction distribution plot, split by redshift"
+    description="Creates a plot of SNII energy fraction vs. birth pressure"
 )
 
 
@@ -61,32 +63,19 @@ output_path = arguments.output_directory
 plt.style.use(arguments.stylesheet_location)
 
 data = [load(snapshot_filename) for snapshot_filename in snapshot_filenames]
+
 number_of_bins = 128
-
-energy_fraction_bins = unyt.unyt_array(
-    np.linspace(0, 5.0, number_of_bins), units="dimensionless"
+birth_pressures = unyt.unyt_array(
+    np.logspace(*log_pressure_bounds, number_of_bins), "K/cm**3"
 )
-energy_fraction_bin_width = (
-    energy_fraction_bins[1].value - energy_fraction_bins[0].value
-)
-energy_fraction_centers = 0.5 * (energy_fraction_bins[1:] + energy_fraction_bins[:-1])
-
 
 # Begin plotting
-fig, axes = plt.subplots(3, 1, sharex=True, sharey=True)
-axes = axes.flat
-
-ax_dict = {"$z < 1$": axes[0], "$1 < z < 3$": axes[1], "$z > 3$": axes[2]}
-
-for label, ax in ax_dict.items():
-    ax.text(0.025, 1.0 - 0.025 * 3, label, transform=ax.transAxes, ha="left", va="top")
-
+fig, ax = plt.subplots(1, 1)
 for color, (snapshot, name) in enumerate(zip(data, names)):
 
-    birth_densities = snapshot.stars.birth_densities.to("g/cm**3") / mh.to("g")
-    birth_temperatures = snapshot.stars.birth_temperatures.to("K")
-    birth_pressures = (birth_densities * birth_temperatures).to("K/cm**3")
-    birth_redshifts = 1 / snapshot.stars.birth_scale_factors.value - 1
+    # Default value that will be plotted outside the plot's domain
+    # if the true value is not found in the snapshot's metadata
+    pivot_pressure = 1e-10
 
     try:
         # Extract feedback parameters from snapshot metadata
@@ -118,48 +107,23 @@ for color, (snapshot, name) in enumerate(zip(data, names)):
             -np.ones_like(birth_pressures.value), "dimensionless"
         )
 
-    # Segment birth pressures into redshift bins
-    energy_fraction_by_redshift = {
-        "$z < 1$": energy_fractions[birth_redshifts < 1],
-        "$1 < z < 3$": energy_fractions[
-            np.logical_and(birth_redshifts > 1, birth_redshifts < 3)
-        ],
-        "$z > 3$": energy_fractions[birth_redshifts > 3],
-    }
+    z = snapshot.metadata.z
+    ax.plot(
+        birth_pressures.value,
+        energy_fractions,
+        label=f"{name} ($z={z:.1f})$",
+        color=f"C{color}",
+    )
 
-    # Total number of stars formed
-    Num_of_stars_total = len(birth_redshifts)
+    # Add the pivot pressure line
+    ax.axvline(
+        pivot_pressure, color=f"C{color}", linestyle="dashed", zorder=-10, alpha=0.5
+    )
 
-    # Average energy fraction (computed among all star particles)
-    average_energy_fraction = np.mean(energy_fractions)
+ax.set_xlim(*pressure_bounds)
+ax.set_xscale("log")
+ax.legend(loc="upper left", markerfirst=False)
+ax.set_ylabel("SNII Energy Fraction $f_{\\rm E}$")
+ax.set_xlabel("Stellar Birth Pressure $P_B/k$ [K cm$^{-3}$]")
 
-    for redshift, ax in ax_dict.items():
-        data = energy_fraction_by_redshift[redshift]
-
-        H, _ = np.histogram(data, bins=energy_fraction_bins)
-        y_points = H / energy_fraction_bin_width / Num_of_stars_total
-
-        ax.plot(energy_fraction_centers, y_points, label=name, color=f"C{color}")
-
-        # Add the median snii energy fraction
-        ax.axvline(
-            np.median(data),
-            color=f"C{color}",
-            linestyle="dashed",
-            zorder=-10,
-            alpha=0.5,
-        )
-
-        ax.axvline(
-            average_energy_fraction,
-            color=f"C{color}",
-            linestyle="dotted",
-            zorder=-10,
-            alpha=0.5,
-        )
-
-axes[0].legend(loc="upper right", markerfirst=False)
-axes[2].set_xlabel("SNII Energy Fraction $f_{\\rm E}$")
-axes[1].set_ylabel("$N_{\\rm bin}$ / d$f_{\\rm E}$ / $N_{\\rm total}$")
-
-fig.savefig(f"{arguments.output_directory}/snii_energy_fraction_distribution.png")
+fig.savefig(f"{arguments.output_directory}/snii_energy_fraction_birth_pressure.png")

--- a/colibre/scripts/snii_energy_fraction_stellar_mass.py
+++ b/colibre/scripts/snii_energy_fraction_stellar_mass.py
@@ -1,0 +1,159 @@
+"""
+Plots the SNII energy fraction at galaxy median stellar
+birth pressure vs. galaxy stellar mass.
+"""
+
+
+import matplotlib.pyplot as plt
+import numpy as np
+import unyt
+
+from swiftpipeline.argumentparser import ScriptArgumentParser
+from velociraptor import load as load_catalogue
+from swiftsimio import load as load_snapshot
+from scipy import stats
+
+# Set x-axis limits
+mass_bounds = [1e5, 1e13]  # Msun
+log_mass_bounds = np.log10(mass_bounds)  # Msun
+
+
+def energy_fraction(
+    pressure: unyt.unyt_array,
+    fmin: float,
+    fmax: float,
+    sigma: float,
+    pivot_pressure: float,
+) -> unyt.unyt_array:
+    """
+    Computes the energy fraction in SNII feedback vs. stellar birth pressure.
+
+    Parameters:
+    pressure (unyt.unyt_array): The stellar birth pressure.
+    fmin (float): The minimum energy fraction.
+    fmax (float): The maximum energy fraction.
+    sigma (float): The dispersion parameter.
+    pivot_pressure (float): The pivot pressure.
+
+    Returns:
+    unyt.unyt_array: The computed energy fraction as a dimensionless unyt array.
+    """
+
+    slope = -1.0 / np.log(10) / sigma
+    f_E = fmin + (fmax - fmin) / (1.0 + (pressure.value / pivot_pressure) ** slope)
+    return unyt.unyt_array(f_E, "dimensionless")
+
+
+def get_snapshot_param_float(snapshot, param_name: str) -> float:
+    try:
+        return float(snapshot.metadata.parameters[param_name].decode("utf-8"))
+    except KeyError:
+        raise KeyError(f"Parameter {param_name} not found in snapshot metadata.")
+
+
+arguments = ScriptArgumentParser(
+    description="the SNII energy fraction at galaxy median stellar birth pressure vs. galaxy stellar mass."
+)
+
+snapshot_filenames = [
+    f"{directory}/{snapshot}"
+    for directory, snapshot in zip(arguments.directory_list, arguments.snapshot_list)
+]
+catalogue_filenames = [
+    f"{directory}/{catalogue}"
+    for directory, catalogue in zip(arguments.directory_list, arguments.catalogue_list)
+]
+
+plt.style.use(arguments.stylesheet_location)
+
+aperture_size = 50  # kpc
+
+number_of_bins = 41
+stellar_mass_bins = np.linspace(*log_mass_bounds, number_of_bins)
+stellar_mass_centers = 0.5 * (stellar_mass_bins[1:] + stellar_mass_bins[:-1])
+
+# Creating plot
+fig, ax = plt.subplots()
+ax.set_xlabel(f"ExclusiveSphere {aperture_size}kpc StellarMass $\\rm [M_\odot]$")
+ax.set_ylabel("SNII Energy Fraction $f_{\\rm E}$ at Median Birth Pressure")
+ax.set_xscale("log")
+
+for color, (snp_filename, cat_filename, name) in enumerate(
+    zip(snapshot_filenames, catalogue_filenames, arguments.name_list)
+):
+    catalogue = load_catalogue(cat_filename)
+    snapshot = load_snapshot(snp_filename)
+    z = snapshot.metadata.z
+
+    star_mass = catalogue.get_quantity(f"apertures.mass_star_{aperture_size}_kpc")
+    mask = star_mass > mass_bounds[0] * star_mass.units
+    star_mass = star_mass[mask]
+    birth_pressures = catalogue.get_quantity(
+        f"fofsubhaloproperties.medianstellarbirthpressure"
+    ).to("K/cm**3")[mask]
+
+    try:
+        # Extract feedback parameters from snapshot metadata
+        fmin = get_snapshot_param_float(
+            snapshot, "COLIBREFeedback:SNII_energy_fraction_min"
+        )
+        fmax = get_snapshot_param_float(
+            snapshot, "COLIBREFeedback:SNII_energy_fraction_max"
+        )
+        sigma = get_snapshot_param_float(
+            snapshot, "COLIBREFeedback:SNII_energy_fraction_sigma_P"
+        )
+        pivot_pressure = get_snapshot_param_float(
+            snapshot, "COLIBREFeedback:SNII_energy_fraction_P_0_K_p_cm3"
+        )
+
+        # Compute energy fractions
+        energy_fractions = energy_fraction(
+            pressure=birth_pressures,
+            fmin=fmin,
+            fmax=fmax,
+            pivot_pressure=pivot_pressure,
+            sigma=sigma,
+        )
+    except KeyError as e:
+        print(e)
+        # Default to -1 if any parameter is missing
+        energy_fractions = unyt.unyt_array(
+            -np.ones_like(birth_pressures.value), "dimensionless"
+        )
+
+    # Compute binned statistics
+    log_star_mass = np.log10(star_mass)
+    bin_stats = [
+        stats.binned_statistic(
+            log_star_mass, energy_fractions, bins=stellar_mass_bins, statistic=stat
+        )
+        for stat in [
+            "median",
+            lambda x: np.percentile(x, 16),
+            lambda x: np.percentile(x, 84),
+        ]
+    ]
+    energy_fractions_median, energy_fractions_lower, energy_fractions_upper = (
+        stat[0] for stat in bin_stats
+    )
+
+    ax.plot(
+        10 ** stellar_mass_centers,
+        energy_fractions_median,
+        label=f"{name} ($z={z:.1f})$",
+        color=f"C{color}",
+    )
+    ax.fill_between(
+        10 ** stellar_mass_centers,
+        energy_fractions_upper,
+        energy_fractions_lower,
+        color=f"C{color}",
+        alpha=0.3,
+        zorder=-10,
+    )
+
+ax.legend()
+ax.set_xlim(*mass_bounds)
+
+fig.savefig(f"{arguments.output_directory}/snii_energy_fraction_stellar_mass.png")


### PR DESCRIPTION
- Add a plot that shows the relation between the SN energy fraction and stellar birth pressure
- Add a plot that shows the relation between the SN energy fraction and galaxy stellar mass
- Rewrite the code in the script that computes the distribution of SN energy fractions, to make it more readable and maintainable

**Example:**

![Screenshot from 2024-06-03 16-29-37](https://github.com/SWIFTSIM/pipeline-configs/assets/20153933/9e332028-5604-4913-83df-d7c892723258)

The two plots on the right are the new plots.