### PR TITLE
Add separate plots for centrals and satellites

### DIFF
--- a/colibre/auto_plotter/mass_functions.yml
+++ b/colibre/auto_plotter/mass_functions.yml
@@ -157,6 +157,54 @@ stellar_mass_function_50:
     - filename: GalaxyStellarMassFunction/Navarro-Carrera2023.hdf5
     - filename: GalaxyStellarMassFunction/Weibel2024.hdf5
 
+stellar_mass_function_centrals_50:
+  type: "massfunction"
+  legend_loc: "lower left"
+  number_of_bins: 30
+  select_structure_type: 10
+  comment: "Centrals only"
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 1e0
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture, centrals only)
+    caption: 50 kpc aperture GSMF, showing central galaxies only, with a fixed bin-width of 0.2 dex.
+    section: Stellar Mass Function
+  observational_data:
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+    - filename: GalaxyStellarMassFunction/Driver2022.hdf5
+    - filename: GalaxyStellarMassFunction/Navarro-Carrera2023.hdf5
+
+stellar_mass_function_satellites_50:
+  type: "massfunction"
+  legend_loc: "lower left"
+  number_of_bins: 30
+  exclude_structure_type: 10
+  comment: "Satellites only"
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: Solar_Mass
+    start: 1e6
+    end: 1e12
+  y:
+    units: 1/Mpc**3
+    start: 1e-6
+    end: 1e0
+  metadata:
+    title: Stellar Mass Function (50 kpc aperture, satellites only)
+    caption: 50 kpc aperture GSMF, showing satellite galaxies only, with a fixed bin-width of 0.2 dex.
+    section: Stellar Mass Function
+  observational_data:
+    - filename: GalaxyStellarMassFunction/Leja_2020.hdf5
+    - filename: GalaxyStellarMassFunction/Driver2022.hdf5
+    - filename: GalaxyStellarMassFunction/Navarro-Carrera2023.hdf5
+      
 stellar_mass_function_50_calibration:
   type: "massfunction"
   legend_loc: "lower left"

--- a/colibre/auto_plotter/star_formation_rates.yml
+++ b/colibre/auto_plotter/star_formation_rates.yml
@@ -163,6 +163,68 @@ stellar_mass_specific_sfr_all_30:
     - filename: GalaxyStellarMassSpecificStarFormationRate/FIREbox_AllGalaxies.hdf5
     - filename: GalaxyStellarMassSpecificStarFormationRate/Leja2022.hdf5
 
+stellar_mass_specific_sfr_centrals_50:
+  type: "scatter"
+  legend_loc: "lower left"
+  select_structure_type: 10
+  comment: "Centrals only"
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: solar_mass
+    start: 1e6
+    end: 1e12
+  y:
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
+    units: 1 / gigayear
+    start: 0.5e-3
+    end: 3e0
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+  metadata:
+    title: Specific Star Formation Rate - Stellar Mass (50 kpc aperture, centrals only)
+    caption: Only central galaxies are included in the median line.
+    section: Star Formation Rates
+
+stellar_mass_specific_sfr_satellites_50:
+  type: "scatter"
+  legend_loc: "lower left"
+  exclude_structure_type: 10
+  comment: "Satellites only"
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: solar_mass
+    start: 1e6
+    end: 1e12
+  y:
+    quantity: "derived_quantities.specific_sfr_gas_50_kpc"
+    units: 1 / gigayear
+    start: 0.5e-3
+    end: 3e0
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+  metadata:
+    title: Specific Star Formation Rate - Stellar Mass (50 kpc aperture, satellites only)
+    caption: Only satellite galaxies are included in the median line.
+    section: Star Formation Rates
+
 stellar_mass_specific_sfr_active_50:
   type: "scatter"
   selection_mask: "derived_quantities.is_active_50_kpc"
@@ -567,6 +629,41 @@ stellar_mass_passive_fraction_centrals_50:
     - filename: GalaxyStellarMassPassiveFraction/Moustakas2013.hdf5
     - filename: GalaxyStellarMassPassiveFraction/Behroozi2019_centrals.hdf5
     - filename: GalaxyStellarMassPassiveFraction/FIREbox.hdf5
+
+stellar_mass_passive_fraction_satellites_50:
+  type: "scatter"
+  exclude_structure_type: 10
+  comment: "Satellites only"
+  legend_loc: "lower left"
+  redshift_loc: "upper center"
+  min_num_points_highlight: 0
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: solar_mass
+    start: 1e6
+    end: 1e12
+  y:
+    quantity: "derived_quantities.is_passive_50_kpc"
+    units: "dimensionless"
+    log: false
+    start: 0
+    end: 1
+  mean:
+    plot: true
+    log: true
+    scatter: "none"
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+  metadata:
+    title: Passive Fraction - Stellar Mass (50 kpc aperture, satellites)
+    caption: A galaxy is determined as being passive if it has a sSFR below 0.01 / Gyr. This figure shows only satellite galaxies.
+    section: Star Formation Rates
 
 star_formation_rate_function_50:
   type: "massfunction"


### PR DESCRIPTION
[Request from Joop](https://leiden-observatory.slack.com/archives/G035RUR984V/p1716973767531199) 
A plot of the central passive fraction was already in the pipeline

![Screenshot from 2024-06-07 15-39-25](https://github.com/SWIFTSIM/pipeline-configs/assets/36136863/03c9f8ff-47b2-442d-a348-9d3de96e5ba9)
![Screenshot from 2024-06-07 15-39-43](https://github.com/SWIFTSIM/pipeline-configs/assets/36136863/b30f06f2-3065-4e91-8a8c-1d35ddfaacd6)
![Screenshot from 2024-06-07 15-46-45](https://github.com/SWIFTSIM/pipeline-configs/assets/36136863/2790c0ed-8301-4788-b2f0-2cf63a696cf8)
