### PR TITLE
Add Mg/H plots

### DIFF
--- a/colibre/auto_plotter/metallicity.yml
+++ b/colibre/auto_plotter/metallicity.yml
@@ -1105,6 +1105,48 @@ stellar_mass_star_fe_over_h_lom_50:
     - filename: GalaxyStellarMassStellarMetallicity/Yates2021_Data.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Chartab2023.hdf5
 
+stellar_mass_star_mg_over_h_lom_50:
+  type: "scatter"
+  legend_loc: "upper left"
+  comment: "LoM"
+  y:
+    quantity: "derived_quantities.star_mg_abundance_avglin_50_kpc"
+    units: "dimensionless"
+    start: 1e-2
+    end: 1e1
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: solar_mass
+    start: 1e6
+    end: 1e12
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+    lower:
+      value: 1.e-10
+      units: "dimensionless"
+  metadata:
+    title: 'Stellar mass - (Mg/H)$_*$ relation (50 kpc aperture)'
+    section: Stellar Metallicity
+    caption: 'Computed as the mass-weighted average of (Mg/H)$_*$, and normalised by solar values. All haloes are plotted, including subhaloes.'
+  observational_data:
+    - filename: GalaxyStellarMassStellarMetallicity/Zahid2017_Data.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Kudritzki2016_Data.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Gallazzi2005_Data.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Fraser-McKelvie_2021.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/FIREbox.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Strom2022_FeH.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Yates2021_Data.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Chartab2023.hdf5
 
 stellar_mass_star_fe_snia_over_h_lom_50:
   type: "scatter"
@@ -1191,6 +1233,47 @@ stellar_mass_star_fe_over_h_mol_lofloor_50:
     - filename: GalaxyStellarMassStellarMetallicity/Strom2022_FeH.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Chartab2023.hdf5
 
+stellar_mass_star_mg_over_h_mol_lofloor_50:
+  type: "scatter"
+  legend_loc: "upper left"
+  comment: "MoL w. [F/H]=-4 floor"
+  y:
+    quantity: "derived_quantities.star_mg_abundance_avglog_low_50_kpc"
+    units: "dimensionless"
+    start: 1e-2
+    end: 1e1
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: solar_mass
+    start: 1e6
+    end: 1e12
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+    lower:
+      value: 1.e-10
+      units: "dimensionless"
+  metadata:
+    title: 'Stellar mass - [Mg/H]$_*$ relation (mean-of-log, 50 kpc aperture)'
+    section: Stellar Metallicity
+    caption: 'Computed as the mass-weighted average of log(Mg/H)$_*$, with a floor value set to [Mg/H]=-4. All haloes are plotted, including subhaloes.'
+  observational_data:
+    - filename: GalaxyStellarMassStellarMetallicity/Zahid2017_Data.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Kudritzki2016_Data.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Gallazzi2005_Data.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Fraser-McKelvie_2021.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/FIREbox.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Chartab2023.hdf5
+
 
 stellar_mass_star_fe_over_h_mol_hifloor_50:
   type: "scatter"
@@ -1234,6 +1317,46 @@ stellar_mass_star_fe_over_h_mol_hifloor_50:
     - filename: GalaxyStellarMassStellarMetallicity/Strom2022_FeH.hdf5
     - filename: GalaxyStellarMassStellarMetallicity/Chartab2023.hdf5
 
+stellar_mass_star_mg_over_h_mol_hifloor_50:
+  type: "scatter"
+  legend_loc: "upper left"
+  comment: "MoL w. [F/H]=-3 floor"
+  y:
+    quantity: "derived_quantities.star_mg_abundance_avglog_high_50_kpc"
+    units: "dimensionless"
+    start: 1e-2
+    end: 1e1
+  x:
+    quantity: "apertures.mass_star_50_kpc"
+    units: solar_mass
+    start: 1e6
+    end: 1e12
+  median:
+    plot: true
+    log: true
+    adaptive: true
+    number_of_bins: 30
+    start:
+      value: 1e6
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+    lower:
+      value: 1.e-10
+      units: "dimensionless"
+  metadata:
+    title: 'Stellar mass - [Mg/H]$_*$ relation (mean-of-log, 50 kpc aperture)'
+    section: Stellar Metallicity
+    caption: 'Computed as the mass-weighted average of log(Mg/H)$_*$, with a floor value set to [Mg/H]=-3. All haloes are plotted, including subhaloes.'
+  observational_data:
+    - filename: GalaxyStellarMassStellarMetallicity/Zahid2017_Data.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Kudritzki2016_Data.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Gallazzi2005_Data.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Kirby2013_Data.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Fraser-McKelvie_2021.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/FIREbox.hdf5
+    - filename: GalaxyStellarMassStellarMetallicity/Chartab2023.hdf5
 
 stellar_mass_star_mg_over_fe_50:
   type: "scatter"

--- a/colibre/scripts/bh_merger_mass_fractions.py
+++ b/colibre/scripts/bh_merger_mass_fractions.py
@@ -39,7 +39,7 @@ def make_single_image(
 
     fig, ax = plt.subplots()
 
-    ax.set_xlabel("Black Hole Subgrid Masses $M_{\\rm sub}$ [M$_\odot$]")
+    ax.set_xlabel(r"Black Hole Subgrid Masses $M_{\rm sub}$ [M$_\odot$]")
     ax.set_ylabel(r"Fraction of Mass Grown Through Mergers")
     ax.set_xscale("log")
 


### PR DESCRIPTION
Depends on https://github.com/SWIFTSIM/SOAP/pull/109

Since old SOAP catalogues will be missing the Mg/H properties, we default to zeros in that case