### PR TITLE
Hot gas fraction

### DIFF
--- a/colibre/auto_plotter/baryon_fractions.yml
+++ b/colibre/auto_plotter/baryon_fractions.yml
@@ -72,6 +72,45 @@ gas_fraction_500_no_bias:
     - filename: HaloMassGasFractions/Eckert2016.hdf5
     - filename: HaloMassGasFractions/Lovisari2015.hdf5
 
+hot_gas_fraction_500_no_bias:
+  type: "scatter"
+  select_structure_type: 1
+  comment: "Centrals only"
+  legend_loc: "upper left"
+  x:
+    quantity: "spherical_overdensities.mass_500_rhocrit"
+    units: Solar_Mass
+    start: 1e10
+    end: 1e15
+  y:
+    quantity: "derived_quantities.hot_gas_fraction_true_R500"
+    units:  "dimensionless"
+    log: false
+    start: 0.
+    end: 1.2
+  median:
+    plot: true
+    log: true
+    min_num_points_highlight: 0
+    adaptive: true
+    number_of_bins: 25
+    start:
+      value: 1e10
+      units: Solar_Mass
+    end:
+      value: 1e15
+      units: Solar_Mass
+  metadata:
+    title: "Halo hot gas fractions within $R_{500}$ (no hydrostatic bias)"
+    caption: Fraction of halo mass within $R_{500}$ in hot ($T>10^5$K) gas, normalised by the cosmic mean. These are 'true' values, i.e. no cut or observational correction was applied. The observational data does not include any correction for hydrostatic bias.
+    section: Baryon Fractions
+  observational_data:
+    - filename: HaloMassGasFractions/Lin2012.hdf5
+    - filename: HaloMassGasFractions/Sun2009.hdf5
+    - filename: HaloMassGasFractions/Vikhlinin2006.hdf5
+    - filename: HaloMassGasFractions/Eckert2016.hdf5
+    - filename: HaloMassGasFractions/Lovisari2015.hdf5
+
 gas_fraction_500_with_bias:
   type: "scatter"
   select_structure_type: 1

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -1864,6 +1864,7 @@ def register_gas_fraction(self, catalogue):
 
     M_500 = catalogue.get_quantity("spherical_overdensities.mass_500_rhocrit")
     M_500_gas = catalogue.get_quantity("spherical_overdensities.mass_gas_500_rhocrit")
+    M_500_hot_gas = catalogue.get_SOAP_quantity("so.500_crit.hotgasmass")
     M_500_star = catalogue.get_quantity("spherical_overdensities.mass_star_500_rhocrit")
     M_500_baryon = M_500_gas + M_500_star
 
@@ -1881,6 +1882,13 @@ def register_gas_fraction(self, catalogue):
     name = "$f_{\\rm gas, 500, true} / (\\Omega_{\\rm b} / \\Omega_{\\rm m})$"
     f_gas_500.name = name
 
+    f_hot_gas_500 = unyt.unyt_array(np.zeros(M_500.shape), units=unyt.dimensionless)
+    f_hot_gas_500[M_500 > 0.0] = (M_500_hot_gas[M_500 > 0.0] / M_500[M_500 > 0.0]) / (
+        Omega_b / Omega_m
+    )
+    name = "$f_{\\rm hot gas, 500, true} / (\\Omega_{\\rm b} / \\Omega_{\\rm m})$"
+    f_hot_gas_500.name = name
+
     f_star_500 = unyt.unyt_array(np.zeros(M_500.shape), units=unyt.dimensionless)
     f_star_500[M_500 > 0.0] = (M_500_star[M_500 > 0.0] / M_500[M_500 > 0.0]) / (
         Omega_b / Omega_m
@@ -1890,6 +1898,7 @@ def register_gas_fraction(self, catalogue):
 
     setattr(self, "baryon_fraction_true_R500", f_b_500)
     setattr(self, "gas_fraction_true_R500", f_gas_500)
+    setattr(self, "hot_gas_fraction_true_R500", f_hot_gas_500)
     setattr(self, "star_fraction_true_R500", f_star_500)
 
     return

--- a/colibre/registration.py
+++ b/colibre/registration.py
@@ -1886,7 +1886,7 @@ def register_gas_fraction(self, catalogue):
     f_hot_gas_500[M_500 > 0.0] = (M_500_hot_gas[M_500 > 0.0] / M_500[M_500 > 0.0]) / (
         Omega_b / Omega_m
     )
-    name = "$f_{\\rm hot gas, 500, true} / (\\Omega_{\\rm b} / \\Omega_{\\rm m})$"
+    name = "$f_{\\rm hot \\, gas, 500, true} / (\\Omega_{\\rm b} / \\Omega_{\\rm m})$"
     f_hot_gas_500.name = name
 
     f_star_500 = unyt.unyt_array(np.zeros(M_500.shape), units=unyt.dimensionless)


### PR DESCRIPTION
Add fraction of hot gas in R500. The following images are from the L0100 Thermal. First shows the current gas fraction, second shows hot gas fraction.
![gas_fraction_500_no_bias](https://github.com/user-attachments/assets/0764217c-3bac-4598-b525-787c74b14eaf)
![hot_gas_fraction_500_no_bias](https://github.com/user-attachments/assets/1722eb04-e1d1-4db2-a025-40614e8cb72b)
