### PR TITLE
Update HI mass function data

### DIFF
--- a/colibre/auto_plotter/gas_mass_functions.yml
+++ b/colibre/auto_plotter/gas_mass_functions.yml
@@ -17,8 +17,8 @@ gas_HI_mass_function:
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyHIMassFunction/Zwaan2005.hdf5
-    - filename: GalaxyHIMassFunction/Jones2018.hdf5
     - filename: GalaxyHIMassFunction/Xi2022.hdf5
+    - filename: GalaxyHIMassFunction/Guo2023.hdf5
     - filename: GalaxyHIMassFunction/Ponomareva2023.hdf5
     - filename: GalaxyHIMassFunction/Ma2024_north.hdf5
     - filename: GalaxyHIMassFunction/Ma2024_south.hdf5
@@ -42,8 +42,8 @@ adaptive_gas_HI_mass_function:
     section: Gas Mass Function
   observational_data:
     - filename: GalaxyHIMassFunction/Zwaan2005.hdf5
-    - filename: GalaxyHIMassFunction/Jones2018.hdf5
     - filename: GalaxyHIMassFunction/Xi2022.hdf5
+    - filename: GalaxyHIMassFunction/Guo2023.hdf5
     - filename: GalaxyHIMassFunction/Ponomareva2023.hdf5
     - filename: GalaxyHIMassFunction/Ma2024_north.hdf5
     - filename: GalaxyHIMassFunction/Ma2024_south.hdf5

--- a/colibre/auto_plotter/gas_mass_functions.yml
+++ b/colibre/auto_plotter/gas_mass_functions.yml
@@ -16,9 +16,12 @@ gas_HI_mass_function:
     caption: HIMF, showing all galaxies with a fixed bin-width of 0.2 dex (HI masses 50 kpc).
     section: Gas Mass Function
   observational_data:
-    - filename: GalaxyHIMassFunction/Zwaan2003.hdf5
+    - filename: GalaxyHIMassFunction/Zwaan2005.hdf5
     - filename: GalaxyHIMassFunction/Jones2018.hdf5
+    - filename: GalaxyHIMassFunction/Xi2022.hdf5
     - filename: GalaxyHIMassFunction/Ponomareva2023.hdf5
+    - filename: GalaxyHIMassFunction/Ma2024_north.hdf5
+    - filename: GalaxyHIMassFunction/Ma2024_south.hdf5
 
 adaptive_gas_HI_mass_function:
   type: "adaptivemassfunction"
@@ -38,9 +41,12 @@ adaptive_gas_HI_mass_function:
     caption: HIMF, showing all galaxies with an adaptive bin-width (HI masses 50 kpc).
     section: Gas Mass Function
   observational_data:
-    - filename: GalaxyHIMassFunction/Zwaan2003.hdf5
+    - filename: GalaxyHIMassFunction/Zwaan2005.hdf5
     - filename: GalaxyHIMassFunction/Jones2018.hdf5
+    - filename: GalaxyHIMassFunction/Xi2022.hdf5
     - filename: GalaxyHIMassFunction/Ponomareva2023.hdf5
+    - filename: GalaxyHIMassFunction/Ma2024_north.hdf5
+    - filename: GalaxyHIMassFunction/Ma2024_south.hdf5
 
 gas_H2_mass_function:
   type: "massfunction"

--- a/colibre/auto_plotter/gas_mass_functions.yml
+++ b/colibre/auto_plotter/gas_mass_functions.yml
@@ -22,6 +22,7 @@ gas_HI_mass_function:
     - filename: GalaxyHIMassFunction/Ponomareva2023.hdf5
     - filename: GalaxyHIMassFunction/Ma2024_north.hdf5
     - filename: GalaxyHIMassFunction/Ma2024_south.hdf5
+    - filename: GalaxyHIMassFunction/Chowdhury2024.hdf5
 
 adaptive_gas_HI_mass_function:
   type: "adaptivemassfunction"
@@ -47,6 +48,7 @@ adaptive_gas_HI_mass_function:
     - filename: GalaxyHIMassFunction/Ponomareva2023.hdf5
     - filename: GalaxyHIMassFunction/Ma2024_north.hdf5
     - filename: GalaxyHIMassFunction/Ma2024_south.hdf5
+    - filename: GalaxyHIMassFunction/Chowdhury2024.hdf5
 
 gas_H2_mass_function:
   type: "massfunction"


### PR DESCRIPTION
Add some new HI mass function data. Also update the points we use from HIPASS & ALFALFA

We need to update the submodule once https://github.com/SWIFTSIM/pipeline-configs/pull/new/HI_mass_function is merged

@EvgeniiChaikin do you know why the data from https://github.com/SWIFTSIM/velociraptor-comparison-data/pull/197 was never added to the pipeline? Should we add it as part of this?