### PR TITLE
Add dust data from Jolly+24, Berta+25

### DIFF
--- a/colibre/auto_plotter/dust_mass_function.yml
+++ b/colibre/auto_plotter/dust_mass_function.yml
@@ -20,6 +20,7 @@ dust_mass_function:
     - filename: GalaxyDustMassFunction/Pozzi2020_z001p800.hdf5
     - filename: GalaxyDustMassFunction/Beeston2018_z000p000.hdf5
     - filename: GalaxyDustMassFunction/Traina2024.hdf5
+    - filename: GalaxyDustMassFunction/Berta2025.hdf5
 
 adaptive_dust_mass_function:
   type: "adaptivemassfunction"
@@ -43,6 +44,7 @@ adaptive_dust_mass_function:
     - filename: GalaxyDustMassFunction/Pozzi2020_z001p800.hdf5
     - filename: GalaxyDustMassFunction/Beeston2018_z000p000.hdf5
     - filename: GalaxyDustMassFunction/Traina2024.hdf5
+    - filename: GalaxyDustMassFunction/Berta2025.hdf5
 
 dust_mass_function_molecular:
   type: "massfunction"
@@ -66,6 +68,7 @@ dust_mass_function_molecular:
     - filename: GalaxyDustMassFunction/Pozzi2020_z001p800.hdf5
     - filename: GalaxyDustMassFunction/Beeston2018_z000p000.hdf5
     - filename: GalaxyDustMassFunction/Traina2024.hdf5
+    - filename: GalaxyDustMassFunction/Berta2025.hdf5
 
 dust_mass_function_neutral:
   type: "massfunction"
@@ -89,6 +92,7 @@ dust_mass_function_neutral:
     - filename: GalaxyDustMassFunction/Pozzi2020_z001p800.hdf5
     - filename: GalaxyDustMassFunction/Beeston2018_z000p000.hdf5
     - filename: GalaxyDustMassFunction/Traina2024.hdf5
+    - filename: GalaxyDustMassFunction/Berta2025.hdf5
 
 dust_mass_function_cold_dense:
   type: "massfunction"
@@ -112,4 +116,5 @@ dust_mass_function_cold_dense:
     - filename: GalaxyDustMassFunction/Pozzi2020_z001p800.hdf5
     - filename: GalaxyDustMassFunction/Beeston2018_z000p000.hdf5
     - filename: GalaxyDustMassFunction/Traina2024.hdf5
+    - filename: GalaxyDustMassFunction/Berta2025.hdf5
 

--- a/colibre/auto_plotter/dust_mass_relations.yml
+++ b/colibre/auto_plotter/dust_mass_relations.yml
@@ -37,6 +37,7 @@ stellar_mass_v_dust_mass:
     - filename: GalaxyStellarMassDustMass/DaCunha2015_z005p000.hdf5
     - filename: GalaxyStellarMassDustMass/DaCunha2015_z006p000.hdf5
     - filename: GalaxyStellarMassDustMass/Sommovigo2022.hdf5
+    - filename: GalaxyStellarMassDustMass/Jolly2024.hdf5
 
 star_formation_rate_v_dust_mass:
   type: "scatter"
@@ -46,7 +47,7 @@ star_formation_rate_v_dust_mass:
     quantity: "apertures.sfr_gas_50_kpc"
     units: Solar_Mass / year
     start: 1e-3
-    end: 1e2
+    end: 3e2
     log: true
   y:
     quantity: "derived_quantities.total_dust_masses_50_kpc"
@@ -72,6 +73,7 @@ star_formation_rate_v_dust_mass:
     show_on_webpage: true
   observational_data:
     - filename: GalaxyStarFormationRateDustMass/Bianchi2018_Data_noerr.hdf5
+    - filename: GalaxyStarFormationRateDustMass/Jolly2024.hdf5
 
 neutral_mass_v_dust_mass:
   type: "scatter"


### PR DESCRIPTION
Editing config to include data in https://github.com/SWIFTSIM/velociraptor-comparison-data/pull/205 and https://github.com/SWIFTSIM/velociraptor-comparison-data/pull/208

I have extended the x axis of the SFR plots since we have more extreme objects in the big boxes.

TODO
- [x] Update submodule link after merging observational data PR